### PR TITLE
McEliece linkage

### DIFF
--- a/oqsprov/CMakeLists.txt
+++ b/oqsprov/CMakeLists.txt
@@ -11,4 +11,4 @@ set_target_properties(oqsprovider
 )
 target_link_libraries(oqsprovider ${liboqs_LIBRARY} ${OPENSSL_CRYPTO_LIBRARY})
 # To link weird mceliece avx code:
-target_link_options(oqs PRIVATE -Wl,-Bsymbolic)
+target_link_options(oqsprovider PRIVATE -Wl,-Bsymbolic)

--- a/oqsprov/CMakeLists.txt
+++ b/oqsprov/CMakeLists.txt
@@ -10,3 +10,5 @@ set_target_properties(oqsprovider
   PROPERTIES PREFIX "" OUTPUT_NAME "oqsprovider"
 )
 target_link_libraries(oqsprovider ${liboqs_LIBRARY} ${OPENSSL_CRYPTO_LIBRARY})
+# To link weird mceliece avx code:
+target_link_options(oqs PRIVATE -Wl,-Bsymbolic)


### PR DESCRIPTION
"Hack" unless https://github.com/open-quantum-safe/liboqs/discussions/930 provides an alternative solution.
Properly enables https://github.com/open-quantum-safe/oqs-demos/pull/73