### PR TITLE
alpha12 tag preparation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,8 +26,8 @@ jobs:
       - run:
           name: Clone and build OpenSSL(3) 
           command: |
-             git clone --depth 1 --branch master git://git.openssl.org/openssl.git openssl &&
-             cd openssl && ./config --prefix=$(echo $(pwd)/../.local) && make -j 4 && make install_dev && cd ..
+             git clone --branch master git://git.openssl.org/openssl.git openssl &&
+             cd openssl && git checkout openssl-3.0.0-alpha12 && ./config --prefix=$(echo $(pwd)/../.local) && make -j 4 && make install_dev && cd ..
       - run:
           name: Build OQS-OpenSSL provider
           command: |

--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ Example for building and installing OpenSSL 3.0 in `.local`:
 OpenSSL (3.0) is not yet released in a production version. For [limitations
 see here](https://wiki.openssl.org/index.php/OpenSSL_3.0#STATUS_of_current_development).
 
+*Note*: Building has last been validated with OpenSSL tag `openssl-3.0.0-alpha12`
+even though the goal of this project is to always build and work with the latest
+OpenSSL `master` branch code.
+
 ### liboqs
 
 Example for building and installing liboqs in `.local`:

--- a/oqsprov/oqs_sig.c
+++ b/oqsprov/oqs_sig.c
@@ -493,7 +493,7 @@ static const OSSL_PARAM known_gettable_ctx_params[] = {
     OSSL_PARAM_END
 };
 
-static const OSSL_PARAM *oqs_sig_gettable_ctx_params(ossl_unused void *vpoqs_sigctx, ossl_unused void *vctx)
+static const OSSL_PARAM *oqs_sig_gettable_ctx_params(ossl_unused void *vpoqs_sigctx)
 {
     OQS_SIG_PRINTF("OQS SIG provider: gettable_ctx_params called\n");
     return known_gettable_ctx_params;
@@ -537,8 +537,7 @@ static const OSSL_PARAM known_settable_ctx_params[] = {
     OSSL_PARAM_END
 };
 
-static const OSSL_PARAM *oqs_sig_settable_ctx_params(ossl_unused void *vpsm2ctx,
-                                                     ossl_unused void *provctx)
+static const OSSL_PARAM *oqs_sig_settable_ctx_params(ossl_unused void *vpsm2ctx)
 {
     /*
      * TODO(3.0): Should this function return a different set of settable ctx


### PR DESCRIPTION
Revert API adaptation to be in sync with `openssl-3.0.0-alpha12`