### PR TITLE
Hybrid KEM support

### DIFF
--- a/oqsprov/CMakeLists.txt
+++ b/oqsprov/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(PROVIDER_SOURCE_FILES
   oqsprov.c oqsprov_groups.c oqsprov_keys.c
-  oqs_kmgmt.c oqs_sig.c oqs_kem.c
+  oqs_kmgmt.c oqs_sig.c oqs_kem.c oqs_hyb_kem.c
 )
 set(PROVIDER_HEADER_FILES
   oqsx.h

--- a/oqsprov/oqs_hyb_kem.c
+++ b/oqsprov/oqs_hyb_kem.c
@@ -1,0 +1,296 @@
+// SPDX-License-Identifier: Apache-2.0 AND MIT
+
+/*
+ * OQS OpenSSL 3 provider
+ *
+ * Code strongly inspired by OpenSSL rsa kem.
+ *
+ * Hybrid KEM
+ *
+ * Message/ciphertext encoding follows https://tools.ietf.org/html/draft-ietf-tls-hybrid-design-01
+ */
+
+#include <openssl/crypto.h>
+#include <openssl/evp.h>
+#include <openssl/ec.h>
+#include <openssl/core_dispatch.h>
+#include <openssl/core_names.h>
+#include <openssl/params.h>
+#include <openssl/err.h>
+#include "oqsx.h"
+#include <string.h>
+
+#ifdef NDEBUG
+#define OQS_HYBKEM_PRINTF(a) printf(a)
+#define OQS_HYBKEM_PRINTF2(a, b) printf(a, b)
+#define OQS_HYBKEM_PRINTF3(a, b, c) printf(a, b, c)
+#else
+#define OQS_HYBKEM_PRINTF(a) if (getenv("OQSHYBKEM")) printf(a)
+#define OQS_HYBKEM_PRINTF2(a, b) if (getenv("OQSHYBKEM")) printf(a, b)
+#define OQS_HYBKEM_PRINTF3(a, b, c) if (getenv("OQSHYBKEM")) printf(a, b, c)
+#endif // NDEBUG
+
+
+static OSSL_FUNC_kem_newctx_fn oqs_hyb_kem_newctx;
+static OSSL_FUNC_kem_encapsulate_init_fn oqs_hyb_kem_encaps_init;
+static OSSL_FUNC_kem_encapsulate_fn oqs_hyb_kem_encaps;
+static OSSL_FUNC_kem_decapsulate_init_fn oqs_hyb_kem_decaps_init;
+static OSSL_FUNC_kem_decapsulate_fn oqs_hyb_kem_decaps;
+static OSSL_FUNC_kem_freectx_fn oqs_hyb_kem_freectx;
+
+/*
+ * What's passed as an actual key is defined by the KEYMGMT interface.
+ */
+typedef struct {
+    OSSL_LIB_CTX *libctx;
+    OQSX_KEY *kem;
+} PROV_OQSHYBKEM_CTX;
+
+static void get_pubkey_ptr(unsigned char *pubkey,
+                           unsigned char **pubkey_kem,
+                           size_t *pubkey_kemlen,
+                           unsigned char **pubkey_kex,
+                           size_t *pubkey_kexlen)
+{
+    DECODE_UINT32(*pubkey_kemlen, pubkey);
+    DECODE_UINT32(*pubkey_kexlen, pubkey + 4 + *pubkey_kemlen);
+
+    *pubkey_kem = pubkey + 4;
+    *pubkey_kex = pubkey + 4 + *pubkey_kemlen + 4;
+}
+
+static void get_privkey_ptr(unsigned char *privkey,
+                            unsigned char **privkey_kem,
+                            size_t *privkey_kemlen,
+                            unsigned char **privkey_kex,
+                            size_t *privkey_kexlen)
+{
+    DECODE_UINT32(*privkey_kemlen, privkey);
+    DECODE_UINT32(*privkey_kexlen, privkey + 4 + *privkey_kemlen);
+
+    *privkey_kem = privkey + 4;
+    *privkey_kex = privkey + 4 + *privkey_kemlen + 4;
+}
+
+/* Gets the pointers to two messages/ciphertexts (classical and PQC):
+   Expected format: ct1 || ct2
+   Follows format specified in https://tools.ietf.org/html/draft-stebila-tls-hybrid-design-03
+ */
+static int get_ct_ptr(const unsigned char *ct, uint16_t ctlen,
+                      unsigned char **ct1, uint16_t ct1len,
+                      unsigned char **ct2, uint16_t ct2len)
+{
+    int ret = 1;
+    int index = 0;
+
+    ON_ERR_SET_GOTO(ctlen != ct1len + ct2len, ret, 0, err);
+    ON_ERR_SET_GOTO(!ct, ret, 0, err);
+
+    *ct1 = (unsigned char *) ct + index;
+    index += ct1len;
+    *ct2 = (unsigned char *) ct + index;
+
+    err:
+    return ret;
+}
+
+static OQS_HYB_KEM *get_hyb_kem(const PROV_OQSHYBKEM_CTX *pkemctx)
+{
+    return (OQS_HYB_KEM *)pkemctx->kem->primitive.hybkem;
+}
+
+static void *oqs_hyb_kem_newctx(void *provctx)
+{
+    PROV_OQSHYBKEM_CTX *pkemctx =  OPENSSL_zalloc(sizeof(PROV_OQSHYBKEM_CTX));
+
+
+    OQS_HYBKEM_PRINTF("OQS Hybrid KEM provider called: newctx\n");
+    if (pkemctx == NULL)
+        return NULL;
+    pkemctx->libctx = PROV_OQS_LIBCTX_OF(provctx);
+    // kem will only be set in init
+
+    return pkemctx;
+}
+
+static void oqs_hyb_kem_freectx(void *vpkemctx)
+{
+    PROV_OQSHYBKEM_CTX *pkemctx = (PROV_OQSHYBKEM_CTX *)vpkemctx;
+
+    OQS_HYBKEM_PRINTF("OQS Hybrid KEM provider called: freectx\n");
+    oqsx_key_free(pkemctx->kem);
+    OPENSSL_free(pkemctx);
+}
+
+static int oqs_hyb_kem_decapsencaps_init(void *vpkemctx, void *vkem, int operation)
+{
+    PROV_OQSHYBKEM_CTX *pkemctx = (PROV_OQSHYBKEM_CTX *)vpkemctx;
+
+    OQS_HYBKEM_PRINTF3("OQS Hybrid KEM provider called: _init : New: %p; old: %p \n", vkem, pkemctx->kem);
+    if (pkemctx == NULL || vkem == NULL || !oqsx_key_up_ref(vkem))
+        return 0;
+    oqsx_key_free(pkemctx->kem);
+    pkemctx->kem = vkem;
+
+    return 1;
+}
+
+static int oqs_hyb_kem_encaps_init(void *vpkemctx, void *vkem, const OSSL_PARAM params[])
+{
+    OQS_HYBKEM_PRINTF("OQS Hybrid KEM provider called: encaps_init\n");
+    return oqs_hyb_kem_decapsencaps_init(vpkemctx, vkem, EVP_PKEY_OP_ENCAPSULATE);
+}
+
+static int oqs_hyb_kem_decaps_init(void *vpkemctx, void *vkem, const OSSL_PARAM params[])
+{
+    OQS_HYBKEM_PRINTF("OQS Hybrid KEM provider called: decaps_init\n");
+    return oqs_hyb_kem_decapsencaps_init(vpkemctx, vkem, EVP_PKEY_OP_DECAPSULATE);
+}
+
+#if 0
+static void printhex(const char* title, unsigned char* c, size_t clen) {
+    printf("%s = ", title);
+    for (int i = 0; i < clen; ++i) {
+        printf("%02x", c[i]);
+    }
+    printf("\n");
+}
+static void print_ss(const char* title, unsigned char *ss1, size_t ss1len, unsigned char *ss2, size_t ss2len)
+{
+    printf("%s ..\n", title);
+    printhex("ss1", ss1, ss1len);
+    printhex("ss2", ss2, ss2len);
+    fflush(stdout);
+}
+#endif
+
+static int oqs_hyb_kem_encaps(void *vpkemctx, unsigned char *ct, size_t *ctlen,
+                          unsigned char *secret, size_t *secretlen)
+{
+    int ret = OQS_SUCCESS, ret2 = 0;
+
+    PROV_OQSHYBKEM_CTX *pkemctx = (PROV_OQSHYBKEM_CTX *)vpkemctx;
+    unsigned char *pubkey_kem = NULL, *pubkey_kex = NULL;
+    unsigned char *ct1 = NULL, *ct2 = NULL;
+    size_t pubkey_kemlen = 0, pubkey_kexlen = 0;
+    size_t kexDeriveLen = 0, pkeylen = 0;
+    OQS_HYB_KEM *hybkem = get_hyb_kem(pkemctx);
+    EVP_PKEY_CTX *kctx = hybkem->kex;
+    EVP_PKEY_CTX *pctx, *ctx;
+    EVP_PKEY *pkey = NULL, *peerpk = NULL;
+
+    OQS_HYBKEM_PRINTF("OQS Hybrid KEM provider called: encaps\n");
+    get_pubkey_ptr(pkemctx->kem->pubkey, &pubkey_kem, &pubkey_kemlen, &pubkey_kex, &pubkey_kexlen);
+
+    kexDeriveLen = (size_t) EVP_PKEY_size(hybkem->kexParam);
+    ON_ERR_GOTO(kexDeriveLen <= 0, err);
+    OQS_HYBKEM_PRINTF2("kexDeriveLen = %zu\n", kexDeriveLen);
+
+
+    *ctlen = hybkem->kem->length_ciphertext + pubkey_kexlen;
+    *secretlen = hybkem->kem->length_shared_secret + kexDeriveLen;
+
+    if (ct == NULL || secret == NULL) {
+        OQS_HYBKEM_PRINTF3("KEM returning lengths %ld and %ld\n", *ctlen, *secretlen);
+        return 1;
+    }
+
+    peerpk = EVP_PKEY_new_raw_public_key(NID_X25519, NULL, pubkey_kex, pubkey_kexlen);
+    ON_ERR_SET_GOTO(!peerpk, ret, -1, err);
+
+    ret2 = EVP_PKEY_keygen_init(kctx);
+    ON_ERR_SET_GOTO(ret2 != 1, ret, -1, err);
+    ret2 = EVP_PKEY_keygen(kctx, &pkey);
+    ON_ERR_SET_GOTO(ret2 != 1, ret, -1, err);
+
+    ctx = EVP_PKEY_CTX_new(pkey, NULL);
+    ON_ERR_SET_GOTO(!ctx, ret, -1, err);
+
+    ret = EVP_PKEY_derive_init(ctx);
+    ON_ERR_SET_GOTO(ret <= 0, ret, -1, err);
+    ret = EVP_PKEY_derive_set_peer(ctx, peerpk);
+    ON_ERR_SET_GOTO(ret <= 0, ret, -1, err);
+
+    get_ct_ptr(ct, *ctlen, &ct1, hybkem->kem->length_ciphertext, &ct2, pubkey_kexlen);
+
+    ret = EVP_PKEY_derive(ctx, secret + hybkem->kem->length_shared_secret, &kexDeriveLen);
+    ON_ERR_SET_GOTO(ret <= 0, ret, -1, err);
+
+    ret = OQS_SUCCESS == OQS_KEM_encaps(hybkem->kem, ct1, secret, pubkey_kem);
+    ON_ERR_SET_GOTO(!ret, ret, -1, err);
+
+    // Note: this EVP API works only with x25519 and x448
+    ret = EVP_PKEY_get_raw_public_key(pkey, NULL, &pkeylen);
+    ON_ERR_SET_GOTO(ret <= 0 || pkeylen != pubkey_kexlen, ret, -1, err);
+
+    ret = EVP_PKEY_get_raw_public_key(pkey, ct2, &pkeylen);
+    ON_ERR_SET_GOTO(ret <= 0, ret, -1, err);
+
+err:
+    return ret;
+}
+
+static int oqs_hyb_kem_decaps(void *vpkemctx, unsigned char *secret, size_t *secretlen,
+                          const unsigned char *ct, size_t ctlen)
+{
+    OQS_HYBKEM_PRINTF("OQS Hybrid KEM provider called: decaps\n");
+
+    int ret = OQS_SUCCESS, ret2 = 0;
+    PROV_OQSHYBKEM_CTX *pkemctx = (PROV_OQSHYBKEM_CTX *)vpkemctx;
+    ON_ERR_GOTO(!pkemctx->kem, err);
+
+    OQS_HYB_KEM *hybkem = get_hyb_kem(pkemctx);
+    EVP_PKEY_CTX *kctx = hybkem->kex;
+    OQS_KEM *kemctx = hybkem->kem;
+    EVP_PKEY_CTX *pctx, *ctx;
+    EVP_PKEY *pkey = NULL, *peerpkey = NULL;
+    unsigned char *ct1 = NULL, *ct2 = NULL;
+    size_t pubkey_kexlen = ctlen - hybkem->kem->length_ciphertext;
+    size_t kexDeriveLen = (size_t) EVP_PKEY_size(hybkem->kexParam);
+    unsigned char *privkey_kem = NULL, *privkey_kex = NULL;
+    size_t privkey_kemlen = 0, privkey_kexlen = 0;
+
+    get_privkey_ptr(pkemctx->kem->privkey, &privkey_kem, &privkey_kemlen, &privkey_kex, &privkey_kexlen);
+
+    *secretlen = hybkem->kem->length_shared_secret + kexDeriveLen;
+    if (secret == NULL) return 1;
+
+    pkey = EVP_PKEY_new_raw_private_key(NID_X25519, NULL, privkey_kex, privkey_kexlen);
+    ON_ERR_SET_GOTO(!pkey, ret, -1, err);
+
+    get_ct_ptr(ct, ctlen, &ct1, hybkem->kem->length_ciphertext, &ct2, pubkey_kexlen);
+
+    peerpkey = EVP_PKEY_new_raw_public_key(NID_X25519, NULL, ct2, pubkey_kexlen);
+    ON_ERR_SET_GOTO(!peerpkey, ret, -1, err);
+
+
+    ctx = EVP_PKEY_CTX_new(pkey, NULL);
+    ON_ERR_SET_GOTO(!ctx, ret, -1, err);
+
+    ret = EVP_PKEY_derive_init(ctx);
+    ON_ERR_SET_GOTO(ret <= 0, ret, -1, err);
+    ret = EVP_PKEY_derive_set_peer(ctx, peerpkey);
+    ON_ERR_SET_GOTO(ret <= 0, ret, -1, err);
+
+    ret = EVP_PKEY_derive(ctx, secret + kemctx->length_shared_secret, &kexDeriveLen);
+    ON_ERR_SET_GOTO(ret <= 0, ret, -1, err);
+
+    ret = OQS_SUCCESS == OQS_KEM_decaps(kemctx, secret, ct1, privkey_kem);
+
+err:
+    return ret;
+}
+
+#define MAKE_HYB_KEM_FUNCTIONS(alg) \
+    const OSSL_DISPATCH oqs_##alg##_kem_functions[] = { \
+      { OSSL_FUNC_KEM_NEWCTX, (void (*)(void))oqs_hyb_kem_newctx }, \
+      { OSSL_FUNC_KEM_ENCAPSULATE_INIT, (void (*)(void))oqs_hyb_kem_encaps_init }, \
+      { OSSL_FUNC_KEM_ENCAPSULATE, (void (*)(void))oqs_hyb_kem_encaps }, \
+      { OSSL_FUNC_KEM_DECAPSULATE_INIT, (void (*)(void))oqs_hyb_kem_decaps_init }, \
+      { OSSL_FUNC_KEM_DECAPSULATE, (void (*)(void))oqs_hyb_kem_decaps }, \
+      { OSSL_FUNC_KEM_FREECTX, (void (*)(void))oqs_hyb_kem_freectx }, \
+      { 0, NULL } \
+  };
+
+// keep this just in case we need to become ALG-specific at some point in time
+MAKE_HYB_KEM_FUNCTIONS(hybrid)

--- a/oqsprov/oqs_kem.c
+++ b/oqsprov/oqs_kem.c
@@ -96,16 +96,16 @@ static int oqs_kem_encaps(void *vpkemctx, unsigned char *out, size_t *outlen,
 
     OQS_KEM_PRINTF("OQS KEM provider called: encaps\n");
     if (pkemctx->kem == NULL) {
-        printf("OQS Warning: OQS_KEM not initialized\n");
+        OQS_KEM_PRINTF("OQS Warning: OQS_KEM not initialized\n");
         return -1;
     }
-    *outlen = pkemctx->kem->key.k->length_ciphertext;
-    *secretlen = pkemctx->kem->key.k->length_shared_secret;
+    *outlen = pkemctx->kem->primitive.kem->length_ciphertext;
+    *secretlen = pkemctx->kem->primitive.kem->length_shared_secret;
     if (out == NULL || secret == NULL) {
        OQS_KEM_PRINTF3("KEM returning lengths %ld and %ld\n", *outlen, *secretlen);
        return 1;
     }
-    return OQS_SUCCESS == OQS_KEM_encaps(pkemctx->kem->key.k, out, secret, pkemctx->kem->pubkey);
+    return OQS_SUCCESS == OQS_KEM_encaps(pkemctx->kem->primitive.kem, out, secret, pkemctx->kem->pubkey);
 }
 
 static int oqs_kem_decaps(void *vpkemctx, unsigned char *out, size_t *outlen,
@@ -115,13 +115,13 @@ static int oqs_kem_decaps(void *vpkemctx, unsigned char *out, size_t *outlen,
 
     OQS_KEM_PRINTF("OQS KEM provider called: decaps\n");
     if (pkemctx->kem == NULL) {
-        printf("OQS Warning: OQS_KEM not initialized\n");
+        OQS_KEM_PRINTF("OQS Warning: OQS_KEM not initialized\n");
         return -1;
     }
-    *outlen = pkemctx->kem->key.k->length_shared_secret;
+    *outlen = pkemctx->kem->primitive.kem->length_shared_secret;
     if (out == NULL) return 1;
 
-    return OQS_SUCCESS == OQS_KEM_decaps(pkemctx->kem->key.k, out, in, pkemctx->kem->privkey);
+    return OQS_SUCCESS == OQS_KEM_decaps(pkemctx->kem->primitive.kem, out, in, pkemctx->kem->privkey);
 }
 
 #define MAKE_KEM_FUNCTIONS(alg) \

--- a/oqsprov/oqs_kmgmt.c
+++ b/oqsprov/oqs_kmgmt.c
@@ -948,6 +948,16 @@ static void *sntrup857_gen_init(void *provctx, int selection)
     return oqsx_gen_init(provctx, selection, OQS_KEM_alg_ntruprime_sntrup857, 1);
 }
 
+static void *p256_sikep434_new_key(void *provctx)
+{
+    return oqsx_key_new(PROV_OQS_LIBCTX_OF(provctx), OQS_KEM_alg_sike_p434, "sikep434", 2, NULL);
+}
+
+static void *p256_sikep434_gen_init(void *provctx, int selection)
+{
+    return oqsx_gen_init(provctx, selection, OQS_KEM_alg_sike_p434, 2);
+}
+
 ///// OQS_TEMPLATE_FRAGMENT_KEYMGMT_CONSTRUCTORS_END
 
 #define MAKE_KEYMGMT_FUNCTIONS(alg) \
@@ -1034,3 +1044,4 @@ MAKE_KEYMGMT_FUNCTIONS(sntrup653)
 MAKE_KEYMGMT_FUNCTIONS(sntrup761)
 MAKE_KEYMGMT_FUNCTIONS(sntrup857)
 ///// OQS_TEMPLATE_FRAGMENT_KEYMGMT_FUNCTIONS_END
+MAKE_KEYMGMT_FUNCTIONS(p256_sikep434)

--- a/oqsprov/oqs_kmgmt.c
+++ b/oqsprov/oqs_kmgmt.c
@@ -51,7 +51,7 @@ struct oqsx_gen_ctx {
     char *propq;
     char *oqs_name;
     char *tls_name;
-    int is_kem;
+    int primitive;
     int selection;
 };
 
@@ -287,7 +287,7 @@ static const OSSL_PARAM *oqsx_settable_params(void *provctx)
     return oqs_settable_params;
 }
 
-static void *oqsx_gen_init(void *provctx, int selection, char* oqs_name, int is_kem)
+static void *oqsx_gen_init(void *provctx, int selection, char* oqs_name, int primitive)
 {
     OSSL_LIB_CTX *libctx = PROV_OQS_LIBCTX_OF(provctx);
     struct oqsx_gen_ctx *gctx = NULL;
@@ -297,7 +297,7 @@ static void *oqsx_gen_init(void *provctx, int selection, char* oqs_name, int is_
     if ((gctx = OPENSSL_zalloc(sizeof(*gctx))) != NULL) {
         gctx->libctx = libctx;
         gctx->oqs_name = OPENSSL_strdup(oqs_name);
-        gctx->is_kem = is_kem;
+        gctx->primitive = primitive;
         gctx->selection = selection;
     }
     return gctx;
@@ -310,7 +310,7 @@ static void *oqsx_genkey(struct oqsx_gen_ctx *gctx)
     OQS_KM_PRINTF2("OQSKEYMGMT: gen called for %s\n", gctx->oqs_name);
     if (gctx == NULL)
         return NULL;
-    if ((key = oqsx_key_new(gctx->libctx, gctx->oqs_name, NULL, gctx->is_kem, gctx->propq)) == NULL) {
+    if ((key = oqsx_key_new(gctx->libctx, gctx->oqs_name, NULL, gctx->primitive, gctx->propq)) == NULL) {
         ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
         return NULL;
     }
@@ -946,7 +946,7 @@ static void *sntrup857_new_key(void *provctx)
 static void *sntrup857_gen_init(void *provctx, int selection)
 { 
     return oqsx_gen_init(provctx, selection, OQS_KEM_alg_ntruprime_sntrup857, 1);
-} 
+}
 
 ///// OQS_TEMPLATE_FRAGMENT_KEYMGMT_CONSTRUCTORS_END
 

--- a/oqsprov/oqs_sig.c
+++ b/oqsprov/oqs_sig.c
@@ -187,7 +187,7 @@ static void *oqs_sig_newctx(void *provctx, const char *propq)
 static int oqs_sig_setup_md(PROV_OQSSIG_CTX *ctx,
                         const char *mdname, const char *mdprops)
 {
-    OQS_SIG_PRINTF3("OQS SIG provider: setup_md called for MD %s (alg %s)\n", mdname, ctx->sig->key.s->method_name);
+    OQS_SIG_PRINTF3("OQS SIG provider: setup_md called for MD %s (alg %s)\n", mdname, ctx->sig->primitive.sig->method_name);
     if (mdprops == NULL)
         mdprops = ctx->propq;
 
@@ -207,7 +207,7 @@ static int oqs_sig_setup_md(PROV_OQSSIG_CTX *ctx,
 
         OPENSSL_free(ctx->aid);
         ctx->aid = NULL; // ensure next function allocates memory
-        ctx->aid_len = get_oqs_oid(ctx->aid, ctx->sig->key.s->method_name);
+        ctx->aid_len = get_oqs_oid(ctx->aid, ctx->sig->primitive.sig->method_name);
 
         ctx->mdctx = NULL;
         ctx->md = md;
@@ -253,7 +253,7 @@ static int oqs_sig_sign(void *vpoqs_sigctx, unsigned char *sig, size_t *siglen,
 {
     PROV_OQSSIG_CTX *poqs_sigctx = (PROV_OQSSIG_CTX *)vpoqs_sigctx;
     int ret = 0;
-    size_t oqs_sigsize = poqs_sigctx->sig->key.s->length_signature;
+    size_t oqs_sigsize = poqs_sigctx->sig->primitive.sig->length_signature;
     size_t mdsize = oqs_sig_get_md_size(poqs_sigctx);
 
     OQS_SIG_PRINTF("OQS SIG provider: sign called\n");
@@ -273,7 +273,7 @@ static int oqs_sig_sign(void *vpoqs_sigctx, unsigned char *sig, size_t *siglen,
         return 0;
     }
 
-    ret = OQS_SIG_sign(poqs_sigctx->sig->key.s, sig, siglen, tbs, tbslen, poqs_sigctx->sig->privkey);
+    ret = OQS_SIG_sign(poqs_sigctx->sig->primitive.sig, sig, siglen, tbs, tbslen, poqs_sigctx->sig->privkey);
     if (ret != OQS_SUCCESS) {
         printf("OQS sign error\n");
         return 0;
@@ -293,7 +293,7 @@ static int oqs_sig_verify(void *vpoqs_sigctx, const unsigned char *sig, size_t s
     if (mdsize != 0 && tbslen != mdsize)
         return 0;
 
-    ret = OQS_SIG_verify(poqs_sigctx->sig->key.s, tbs, tbslen, sig, siglen, poqs_sigctx->sig->pubkey);
+    ret = OQS_SIG_verify(poqs_sigctx->sig->primitive.sig, tbs, tbslen, sig, siglen, poqs_sigctx->sig->pubkey);
     if (ret != OQS_SUCCESS) {
         printf("OQS sign error\n");
         return 0;
@@ -498,7 +498,6 @@ static const OSSL_PARAM *oqs_sig_gettable_ctx_params(ossl_unused void *vpoqs_sig
     OQS_SIG_PRINTF("OQS SIG provider: gettable_ctx_params called\n");
     return known_gettable_ctx_params;
 }
-
 static int oqs_sig_set_ctx_params(void *vpoqs_sigctx, const OSSL_PARAM params[])
 {
     PROV_OQSSIG_CTX *poqs_sigctx = (PROV_OQSSIG_CTX *)vpoqs_sigctx;

--- a/oqsprov/oqsprov.c
+++ b/oqsprov/oqsprov.c
@@ -41,6 +41,7 @@ static const OSSL_PARAM oqsprovider_param_types[] = {
 };
 
 extern const OSSL_DISPATCH oqs_generic_kem_functions[];
+extern const OSSL_DISPATCH oqs_hybrid_kem_functions[];
 extern const OSSL_DISPATCH oqs_signature_functions[];
 
 ///// OQS_TEMPLATE_FRAGMENT_ALG_FUNCTIONS_START
@@ -102,6 +103,7 @@ extern const OSSL_DISPATCH oqs_sntrup653_keymgmt_functions[];
 extern const OSSL_DISPATCH oqs_sntrup761_keymgmt_functions[];
 extern const OSSL_DISPATCH oqs_sntrup857_keymgmt_functions[];
 ///// OQS_TEMPLATE_FRAGMENT_ALG_FUNCTIONS_END
+extern const OSSL_DISPATCH oqs_p256_sikep434_keymgmt_functions[];
 
 static const OSSL_ALGORITHM oqsprovider_signatures[] = {
 ///// OQS_TEMPLATE_FRAGMENT_SIG_FUNCTIONS_START
@@ -168,6 +170,7 @@ static const OSSL_ALGORITHM oqsprovider_asym_kems[] = {
     ALG("sntrup761", oqs_generic_kem_functions),
     ALG("sntrup857", oqs_generic_kem_functions),
 ///// OQS_TEMPLATE_FRAGMENT_KEM_FUNCTIONS_END
+    ALG("p256_sikep434", oqs_hybrid_kem_functions),
     { NULL, NULL, NULL }
 };
 
@@ -231,6 +234,7 @@ static const OSSL_ALGORITHM oqsprovider_keymgmt[] = {
     ALG("sntrup761", oqs_sntrup761_keymgmt_functions),
     ALG("sntrup857", oqs_sntrup857_keymgmt_functions),
 ///// OQS_TEMPLATE_FRAGMENT_KEYMGMT_FUNCTIONS_END
+    ALG("p256_sikep434", oqs_p256_sikep434_keymgmt_functions),
     { NULL, NULL, NULL }
 };
 
@@ -330,4 +334,3 @@ int OSSL_provider_init(const OSSL_CORE_HANDLE *handle,
 
     return 1;
 }
-

--- a/oqsprov/oqsprov_groups.c
+++ b/oqsprov/oqsprov_groups.c
@@ -73,6 +73,7 @@ static const OQS_GROUP_CONSTANTS oqs_group_list[] = {
    { 0x0233, 192, TLS1_3_VERSION, 0, -1, 0, 1 },
    { 0x0234, 192, TLS1_3_VERSION, 0, -1, 0, 1 },
 ///// OQS_TEMPLATE_FRAGMENT_GROUP_ASSIGNMENTS_END
+   { 0x0235, 128, TLS1_3_VERSION, 0, -1, 0, 1 },
 };
 
 #define OQS_GROUP_ENTRY(tlsname, realname, algorithm, idx) \
@@ -147,6 +148,7 @@ static const OSSL_PARAM oqs_param_group_list[][11] = {
     OQS_GROUP_ENTRY("sntrup761", "sntrup761", "sntrup761", 38),
     OQS_GROUP_ENTRY("sntrup857", "sntrup857", "sntrup857", 39),
 ///// OQS_TEMPLATE_FRAGMENT_GROUP_NAMES_END
+    OQS_GROUP_ENTRY("p256_sikep434", "p256_sikep434", "p256_sikep434", 40),
 };
 
 static int oqs_group_capability(OSSL_CALLBACK *cb, void *arg)

--- a/oqsprov/oqsprov_keys.c
+++ b/oqsprov/oqsprov_keys.c
@@ -53,6 +53,34 @@ OQSX_KEY *oqsx_key_new(OSSL_LIB_CTX *libctx, char* oqs_name, char* tls_name, int
         ret->privkeylen = ret->primitive.sig->length_secret_key;
         ret->pubkeylen = ret->primitive.sig->length_public_key;
         ret->keytype = KEY_TYPE_SIG;
+    } else if (primitive == KEY_TYPE_HYB_KEM) {
+        OQS_HYB_KEM* hybkem = OPENSSL_zalloc(sizeof(OQS_HYB_KEM));
+        size_t kex_length_public_key = 0, kex_length_private_key = 0;
+
+        ON_ERR_GOTO(!hybkem, err);
+
+        hybkem->kem = OQS_KEM_new(oqs_name);
+        ON_ERR_GOTO(!hybkem->kem, err);
+
+        hybkem->kexParam = EVP_PKEY_new();
+        ON_ERR_GOTO(!hybkem->kexParam, err);
+
+        // TODO: don't hardcode X25519
+        EVP_PKEY_set_type(hybkem->kexParam, NID_X25519);
+
+        hybkem->kex = EVP_PKEY_CTX_new(hybkem->kexParam, NULL);
+        ON_ERR_GOTO(!hybkem->kex, err);
+
+        ret2 = EVP_PKEY_get_raw_public_key(hybkem->kexParam, NULL, &kex_length_public_key);
+        ON_ERR_GOTO(ret2 <= 0 || kex_length_public_key == 0, err);
+
+        ret2 = EVP_PKEY_get_raw_private_key(hybkem->kexParam, NULL, &kex_length_private_key);
+        ON_ERR_GOTO(ret2 <= 0 || kex_length_private_key == 0, err);
+
+        ret->primitive.hybkem = hybkem;
+        ret->privkeylen = 4 + hybkem->kem->length_secret_key + 4 + kex_length_private_key;
+        ret->pubkeylen = 4 + hybkem->kem->length_public_key + 4 + kex_length_public_key;
+        ret->keytype = KEY_TYPE_HYB_KEM;
     } else goto err;
 
     ret->libctx = libctx;
@@ -98,7 +126,11 @@ void oqsx_key_free(OQSX_KEY *key)
     OPENSSL_secure_clear_free(key->pubkey, key->pubkeylen);
     if (key->keytype == KEY_TYPE_KEM)
         OQS_KEM_free(key->primitive.kem);
-    else
+    else if (key->keytype == KEY_TYPE_HYB_KEM) {
+        OQS_KEM_free(key->primitive.hybkem->kem);
+        EVP_PKEY_CTX_free(key->primitive.hybkem->kex);
+        EVP_PKEY_free(key->primitive.hybkem->kexParam);
+    } else
         OQS_SIG_free(key->primitive.sig);
     OPENSSL_free(key);
 }
@@ -128,6 +160,18 @@ int oqsx_key_allocate_keymaterial(OQSX_KEY *key)
         key->pubkey = OPENSSL_secure_zalloc(key->pubkeylen);
         ON_ERR_SET_GOTO(!key->pubkey, ret, 1, err);
     }
+#if 0
+    if (key->keytype == KEY_TYPE_HYB_KEM) {
+        if (!key->privkeyhyb) {
+            key->privkeyhyb = OPENSSL_secure_zalloc(key->privkeyhyblen);
+            ON_ERR_SET_GOTO(!key->privkeyhyb, ret, 1, err);
+        }
+        if (!key->pubkeyhyb) {
+            key->pubkeyhyb = OPENSSL_secure_zalloc(key->pubkeyhyblen);
+            ON_ERR_SET_GOTO(!key->pubkeyhyb, ret, 1, err);
+        }
+    }
+#endif
     err:
     return ret;
 }
@@ -181,6 +225,35 @@ int oqsx_key_gen(OQSX_KEY *key)
     if (key->keytype == KEY_TYPE_KEM) {
         ret = OQS_KEM_keypair(key->primitive.kem, key->pubkey, key->privkey);
         ON_ERR_GOTO(ret, err);
+    } else if (key->keytype == KEY_TYPE_HYB_KEM) {
+        OQS_HYB_KEM *hybkem = key->primitive.hybkem;
+        OQS_KEM *kem = hybkem->kem;
+        EVP_PKEY_CTX *kex = hybkem->kex;
+        EVP_PKEY *pkey = NULL;
+
+        size_t privkeykemlen = kem->length_secret_key, privkeykexlen = 0;
+        size_t pubkeykemlen = kem->length_public_key, pubkeykexlen = 0;
+
+
+        ret = OQS_KEM_keypair(hybkem->kem, key->pubkey + 4, key->privkey + 4);
+        ON_ERR_GOTO(ret, err);
+
+        ret2 = EVP_PKEY_keygen_init(kex);
+        ON_ERR_SET_GOTO(ret2 != 1, ret, 10, err);
+        ret2 = EVP_PKEY_keygen(kex, &pkey);
+        ON_ERR_SET_GOTO(ret2 != 1, ret, 11, err);
+
+        ret2 = EVP_PKEY_get_raw_public_key(pkey, key->pubkey + 4 + kem->length_public_key + 4, &pubkeykexlen);
+        ON_ERR_SET_GOTO(ret2 <= 0, ret, 44, err);
+
+        ret2 = EVP_PKEY_get_raw_private_key(pkey, key->privkey + 4 + kem->length_secret_key + 4, &privkeykexlen);
+        ON_ERR_SET_GOTO(ret2 <= 0, ret, 45, err);
+
+        ENCODE_UINT32((unsigned char *)key->pubkey, pubkeykemlen);
+        ENCODE_UINT32((unsigned char *)key->pubkey + 4 + pubkeykemlen, pubkeykexlen);
+        ENCODE_UINT32((unsigned char *)key->privkey, privkeykemlen);
+        ENCODE_UINT32((unsigned char *)key->privkey + 4 + privkeykemlen, privkeykexlen);
+
     } else if (key->keytype == KEY_TYPE_SIG) {
         ret = OQS_SIG_keypair(key->primitive.sig, key->pubkey, key->privkey);
         ON_ERR_GOTO(ret, err);

--- a/oqsprov/oqsprov_keys.c
+++ b/oqsprov/oqsprov_keys.c
@@ -12,6 +12,8 @@
 #include <openssl/err.h>
 #include <openssl/params.h>
 #include <openssl/core_names.h>
+#include <openssl/evp.h>
+#include <openssl/ec.h>
 #include <string.h>
 #include <assert.h>
 #include "oqsx.h"
@@ -33,26 +35,26 @@ void oqsx_freeprovctx(PROV_OQS_CTX *ctx) {
 
 /// Key code
 
-OQSX_KEY *oqsx_key_new(OSSL_LIB_CTX *libctx, char* oqs_name, char* tls_name, int is_kem, const char *propq)
+OQSX_KEY *oqsx_key_new(OSSL_LIB_CTX *libctx, char* oqs_name, char* tls_name, int primitive, const char *propq)
 {
     OQSX_KEY *ret = OPENSSL_zalloc(sizeof(*ret));
+    int ret2 = 0;
 
-    if (ret == NULL)
-        return NULL;
+    if (ret == NULL) goto err;
 
-    //printf("Creating new %s key (type %d)\n", oqs_name, is_kem);
-    if (is_kem) {
-        ret->key.k = OQS_KEM_new(oqs_name);
-        ret->privkeylen = ret->key.k->length_secret_key;
-        ret->pubkeylen = ret->key.k->length_public_key;
-        ret->iskem = 1;
-    }
-    else {
-        ret->key.s = OQS_SIG_new(oqs_name);
-        ret->privkeylen = ret->key.s->length_secret_key;
-        ret->pubkeylen = ret->key.s->length_public_key;
-        ret->iskem = 0;
-    }
+    printf("Creating new %s key (type %d)\n", oqs_name, primitive);
+    if (primitive == KEY_TYPE_KEM) {
+        ret->primitive.kem = OQS_KEM_new(oqs_name);
+        ret->privkeylen = ret->primitive.kem->length_secret_key;
+        ret->pubkeylen = ret->primitive.kem->length_public_key;
+        ret->keytype = KEY_TYPE_KEM;
+    } else if (primitive == KEY_TYPE_SIG) {
+        ret->primitive.sig = OQS_SIG_new(oqs_name);
+        ret->privkeylen = ret->primitive.sig->length_secret_key;
+        ret->pubkeylen = ret->primitive.sig->length_public_key;
+        ret->keytype = KEY_TYPE_SIG;
+    } else goto err;
+
     ret->libctx = libctx;
     ret->references = 1;
     ret->tls_name = OPENSSL_strdup(tls_name);
@@ -87,13 +89,17 @@ void oqsx_key_free(OQSX_KEY *key)
 #endif
     if (refcnt > 0)
         return;
+#ifndef NDEBUG
     assert(refcnt == 0);
+#endif
 
     OPENSSL_free(key->propq);
     OPENSSL_secure_clear_free(key->privkey, key->privkeylen);
     OPENSSL_secure_clear_free(key->pubkey, key->pubkeylen);
-    if (key->iskem) OQS_KEM_free(key->key.k);
-    else OQS_SIG_free(key->key.s);
+    if (key->keytype == KEY_TYPE_KEM)
+        OQS_KEM_free(key->primitive.kem);
+    else
+        OQS_SIG_free(key->primitive.sig);
     OPENSSL_free(key);
 }
 
@@ -105,24 +111,32 @@ int oqsx_key_up_ref(OQSX_KEY *key)
                                        memory_order_relaxed) + 1;
 #ifndef NDEBUG
     fprintf(stderr, "%p:%4d:OQSX_KEY\n", (void*)key, refcnt);
-#endif
     assert(refcnt > 1);
+#endif
     return (refcnt > 1);
 }
 
 int oqsx_key_allocate_keymaterial(OQSX_KEY *key)
 {
-    key->privkey = OPENSSL_secure_zalloc(key->privkeylen);
-    key->pubkey = OPENSSL_secure_zalloc(key->pubkeylen);
+    int ret = 0;
 
-    if (key->privkey == NULL || key->pubkey == NULL) return 1;
-
-    return 0;
+    if (!key->privkey) {
+        key->privkey = OPENSSL_secure_zalloc(key->privkeylen);
+        ON_ERR_SET_GOTO(!key->privkey, ret, 1, err);
+    }
+    if (!key->pubkey) {
+        key->pubkey = OPENSSL_secure_zalloc(key->pubkeylen);
+        ON_ERR_SET_GOTO(!key->pubkey, ret, 1, err);
+    }
+    err:
+    return ret;
 }
 
 int oqsx_key_fromdata(OQSX_KEY *key, const OSSL_PARAM params[], int include_private)
 {
     const OSSL_PARAM *p;
+
+    printf("oqsx_key_fromdata\n");
 
     p = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_PRIV_KEY);
     if (p != NULL) {
@@ -159,24 +173,32 @@ int oqsx_key_fromdata(OQSX_KEY *key, const OSSL_PARAM params[], int include_priv
 
 int oqsx_key_gen(OQSX_KEY *key)
 {
-    if (key->privkey == NULL || key->pubkey == NULL) oqsx_key_allocate_keymaterial(key);
+    int ret = 0, ret2 = 0;
 
-    if (key->iskem)
-        return OQS_KEM_keypair(key->key.k, key->pubkey, key->privkey);
-    else
-        return OQS_SIG_keypair(key->key.s, key->pubkey, key->privkey);
+    ret = oqsx_key_allocate_keymaterial(key);
+    ON_ERR_GOTO(ret, err);
+
+    if (key->keytype == KEY_TYPE_KEM) {
+        ret = OQS_KEM_keypair(key->primitive.kem, key->pubkey, key->privkey);
+        ON_ERR_GOTO(ret, err);
+    } else if (key->keytype == KEY_TYPE_SIG) {
+        ret = OQS_SIG_keypair(key->primitive.sig, key->pubkey, key->privkey);
+        ON_ERR_GOTO(ret, err);
+    } else {
+        ret = 1;
+    }
+    err:
+    return ret;
 }
 
 int oqsx_key_parambits(OQSX_KEY *key) {
-    if (key->iskem) 
-        return 128+(key->key.k->claimed_nist_level-1)/2*64;
-    return 128+(key->key.s->claimed_nist_level-1)/2*64;
+    if (key->keytype == KEY_TYPE_KEM)
+        return 128+(key->primitive.kem->claimed_nist_level-1)/2*64;
+    return 128+(key->primitive.sig->claimed_nist_level-1)/2*64;
 }
 
 int oqsx_key_maxsize(OQSX_KEY *key) {
-    if (key->iskem)
-        return key->key.k->length_shared_secret;
-    return key->key.s->length_signature;
+    if (key->keytype == KEY_TYPE_KEM)
+        return key->primitive.kem->length_shared_secret;
+    return key->primitive.sig->length_signature;
 }
-
-


### PR DESCRIPTION
(WIP)

Hybrid KEM support for the oqs-provider:
- Combines OQS KEMs with OpenSSL EC-kex
- Uses EVP API for OpenSSL EC-kex
- Wraps hybrid KEM in OpenSSL3 KEM-API
- Extends oqsx.h structures to accomodate KEM and KEX contexts

Todos:
- Enable yml-templating for all defined combinations
- Enable more EC-kex (currently only X25519)