### PR TITLE
Fix clang compiler warnings

### DIFF
--- a/oqsprov/oqs_kem.c
+++ b/oqsprov/oqs_kem.c
@@ -234,7 +234,7 @@ static int oqs_evp_kem_decaps_keyslot(void *vpkemctx, unsigned char *secret, siz
     size_t privkey_kexlen = evp_ctx->evp_info->length_private_key;
 
     // Free at err:
-    EVP_PKEY_CTX *ctx;
+    EVP_PKEY_CTX *ctx = NULL;
     EVP_PKEY *pkey = NULL, *peerpkey = NULL;
 
     *secretlen = kexDeriveLen;

--- a/oqsprov/oqs_sig.c
+++ b/oqsprov/oqs_sig.c
@@ -103,7 +103,7 @@ typedef struct {
     EVP_MD_CTX *mdctx;
     size_t mdsize;
     // for collecting data if no MD is active:
-    char* mddata;
+    unsigned char* mddata;
     int operation;
 } PROV_OQSSIG_CTX;
 
@@ -473,7 +473,7 @@ int oqs_sig_digest_signverify_update(void *vpoqs_sigctx, const unsigned char *da
     if (poqs_sigctx->mddata) {
 	int mdlen = poqs_sigctx->mdsize;
 	poqs_sigctx->mdsize += datalen;
-	char* newdata = OPENSSL_malloc(poqs_sigctx->mdsize);
+	unsigned char* newdata = OPENSSL_malloc(poqs_sigctx->mdsize);
 	memcpy(newdata, poqs_sigctx->mddata, mdlen);
 	memcpy(newdata+mdlen, data, datalen);
 	OPENSSL_free(poqs_sigctx->mddata);

--- a/oqsprov/oqsprov_keys.c
+++ b/oqsprov/oqsprov_keys.c
@@ -199,9 +199,9 @@ static OQSX_KEY *oqsx_key_new_from_nid(OSSL_LIB_CTX *libctx, const char *propq, 
  * TBD, check https://github.com/openssl/openssl/issues/16989
  */
 EVP_PKEY* setECParams(EVP_PKEY *eck, int nid) {
-    const char p256params[] = { 0x06, 0x08, 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x03, 0x01, 0x07 };
-    const char p384params[] = { 0x06, 0x05, 0x2b, 0x81, 0x04, 0x00, 0x22 };
-    const char p521params[] = { 0x06, 0x05, 0x2b, 0x81, 0x04, 0x00, 0x23 };
+    const unsigned char p256params[] = { 0x06, 0x08, 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x03, 0x01, 0x07 };
+    const unsigned char p384params[] = { 0x06, 0x05, 0x2b, 0x81, 0x04, 0x00, 0x22 };
+    const unsigned char p521params[] = { 0x06, 0x05, 0x2b, 0x81, 0x04, 0x00, 0x23 };
 
     const unsigned char* params;
     switch(nid) {
@@ -426,7 +426,7 @@ static int oqsx_hybsig_init(int bit_security, OQSX_EVP_CTX *evp_ctx, char* algna
     return ret;
 }
 
-static int oqshybkem_init_ecp(int bit_security, OQSX_EVP_CTX *evp_ctx)
+static const int oqshybkem_init_ecp(int bit_security, OQSX_EVP_CTX *evp_ctx)
 {
     int ret = 1;
     int idx = (bit_security - 128) / 64;
@@ -450,7 +450,7 @@ static int oqshybkem_init_ecp(int bit_security, OQSX_EVP_CTX *evp_ctx)
     return ret;
 }
 
-static int oqshybkem_init_ecx(int bit_security, OQSX_EVP_CTX *evp_ctx)
+static const int oqshybkem_init_ecx(int bit_security, OQSX_EVP_CTX *evp_ctx)
 {
     int ret = 1;
     int idx = (bit_security - 128) / 64;

--- a/test/test_common.c
+++ b/test/test_common.c
@@ -24,7 +24,7 @@ int alg_is_enabled(const char *algname) {
 
     if (alglist == NULL) return 1;
 
-    while(comma = index(alglist, ',')) {
+    while((comma = index(alglist, ','))) {
         memcpy(totest, alglist, MIN(200,comma-alglist));
         totest[comma-alglist]='\0';
         if (strstr(algname, totest)) return 0;


### PR DESCRIPTION
- Fixes a few warnings when compiling with clang.
Clang warnings: [clang-warnings.txt](https://github.com/open-quantum-safe/oqs-provider/files/9121845/clang-warnings.txt)
- Also makes sure that `EVP_PKEY_CTX *ctx = NULL` in KEM decapsulation. Freeing the context could otherwise fail if there are errors during decapsulation.