### PR TITLE
Testing different external digest

### DIFF
--- a/oqsprov/oqs_sig.c
+++ b/oqsprov/oqs_sig.c
@@ -137,7 +137,7 @@ static int oqs_sig_setup_md(PROV_OQSSIG_CTX *ctx,
     if (mdname != NULL) {
         EVP_MD *md = EVP_MD_fetch(ctx->libctx, mdname, mdprops);
 
-        if (md == NULL) {
+        if ((md == NULL)||(EVP_MD_nid(md)==NID_undef)) {
             if (md == NULL)
                 ERR_raise_data(ERR_LIB_USER, OQSPROV_R_INVALID_DIGEST,
                                "%s could not be fetched", mdname);

--- a/scripts/oqsprovider-cmssign.sh
+++ b/scripts/oqsprovider-cmssign.sh
@@ -7,9 +7,15 @@
 # uncomment to see what's happening:
 #set -x
 
-if [ $# -ne 1 ]; then
-    echo "Usage: $0 <algorithmname>. Exiting."
+if [ $# -lt 1 ]; then
+    echo "Usage: $0 <algorithmname> [digestname]. Exiting."
     exit 1
+fi
+
+if [ $# -eq 2 ]; then
+	DGSTNAME=$2
+else
+	DGSTNAME="sha512"
 fi
 
 if [ -z "$OPENSSL_APP" ]; then
@@ -36,7 +42,7 @@ else
    exit -1
 fi
 
-$OPENSSL_APP x509 -provider oqsprovider -provider default -in tmp/$1_srv.crt -pubkey -noout > tmp/$1_srv.pubkey && $OPENSSL_APP cms -in tmp/inputfile -sign -signer tmp/$1_srv.crt -inkey tmp/$1_srv.key -nodetach -outform pem -binary -out tmp/signedfile.cms -md sha512 -provider oqsprovider -provider default && $OPENSSL_APP dgst -provider oqsprovider -provider default -sign tmp/$1_srv.key -out tmp/dgstsignfile tmp/inputfile
+$OPENSSL_APP x509 -provider oqsprovider -provider default -in tmp/$1_srv.crt -pubkey -noout > tmp/$1_srv.pubkey && $OPENSSL_APP cms -in tmp/inputfile -sign -signer tmp/$1_srv.crt -inkey tmp/$1_srv.key -nodetach -outform pem -binary -out tmp/signedfile.cms -md $DGSTNAME -provider oqsprovider -provider default && $OPENSSL_APP dgst -provider oqsprovider -provider default -sign tmp/$1_srv.key -out tmp/dgstsignfile tmp/inputfile
 
 if [ $? -eq 0 ]; then
 # run internal test:
@@ -44,3 +50,4 @@ if [ $? -eq 0 ]; then
 else
    exit -1
 fi
+

--- a/scripts/runtests.sh
+++ b/scripts/runtests.sh
@@ -3,7 +3,7 @@
 provider2openssl() {
     echo
     echo "Testing oqsprovider->oqs-openssl interop for $1:"
-    $OQS_PROVIDER_TESTSCRIPTS/scripts/oqsprovider-certgen.sh $1 && $OQS_PROVIDER_TESTSCRIPTS/scripts/oqsprovider-cmssign.sh $1 && $OQS_PROVIDER_TESTSCRIPTS/scripts/oqs-openssl-certverify.sh $1 && $OQS_PROVIDER_TESTSCRIPTS/scripts/oqs-openssl-cmsverify.sh $1
+    $OQS_PROVIDER_TESTSCRIPTS/scripts/oqsprovider-certgen.sh $1 && $OQS_PROVIDER_TESTSCRIPTS/scripts/oqsprovider-cmssign.sh $1 md5 && $OQS_PROVIDER_TESTSCRIPTS/scripts/oqs-openssl-certverify.sh $1 && $OQS_PROVIDER_TESTSCRIPTS/scripts/oqs-openssl-cmsverify.sh $1
 }
 
 openssl2provider() {

--- a/scripts/runtests.sh
+++ b/scripts/runtests.sh
@@ -3,7 +3,7 @@
 provider2openssl() {
     echo
     echo "Testing oqsprovider->oqs-openssl interop for $1:"
-    $OQS_PROVIDER_TESTSCRIPTS/scripts/oqsprovider-certgen.sh $1 && $OQS_PROVIDER_TESTSCRIPTS/scripts/oqsprovider-cmssign.sh $1 md5 && $OQS_PROVIDER_TESTSCRIPTS/scripts/oqs-openssl-certverify.sh $1 && $OQS_PROVIDER_TESTSCRIPTS/scripts/oqs-openssl-cmsverify.sh $1
+    $OQS_PROVIDER_TESTSCRIPTS/scripts/oqsprovider-certgen.sh $1 && $OQS_PROVIDER_TESTSCRIPTS/scripts/oqsprovider-cmssign.sh $1 sha3-384 && $OQS_PROVIDER_TESTSCRIPTS/scripts/oqs-openssl-certverify.sh $1 && $OQS_PROVIDER_TESTSCRIPTS/scripts/oqs-openssl-cmsverify.sh $1
 }
 
 openssl2provider() {


### PR DESCRIPTION
Fixes #70. 

Test for [EVP_md_null](https://beta.openssl.org/docs/man3.0/man3/EVP_MD_name.html) is also possible via the new `digestname` parameter (passing "NULL") but execution is rejected -- arguably sensibly: Using a digest returning nothing (to sign) isn't really sensible: See [implementation test for EVP_md_null](https://github.com/openssl/openssl/blob/523e0577305bbcc732d22bcb063c6c8ca658874a/test/evp_extra_test.c#L1550-L1556).

~Possibly open question: Should oqsprovider itself actively _prohibit_ use of EVP_md_null? Presently, passing `mdname` "NULL" is possible and will lead to 0 bytes to be signed. This test can easily be enhanced to facilitate that: https://github.com/open-quantum-safe/oqs-provider/blob/7cd2963695c3aa8f1ebe212500d83ae54f28504a/oqsprov/oqs_sig.c#L137~

Disregard the above: EVP_md_null is now disabled in line with oqs-openssl111.