### PR TITLE
cloudflare-specific hybrid kyber768 support

### DIFF
--- a/oqsprov/oqs_prov.h
+++ b/oqsprov/oqs_prov.h
@@ -9,6 +9,9 @@
 
 /* Internal OQS functions for other submodules: not for application use */
 
+/* Set this define to create support for x25519_kyber768 as done by cloudflare */
+// #define CLOUDFLARE
+
 #ifndef OQSX_H
 # define OQSX_H
 
@@ -70,9 +73,16 @@
     (secbits == 128 ? "p256_" #oqsname "" : \
      secbits == 192 ? "p384_" #oqsname "" : \
                       "p521_" #oqsname "")
+
+#ifdef CLOUDFLARE
 #define ECX_NAME(secbits, oqsname) \
-    (secbits == 128 ? "x25519_" #oqsname "" : \
+    (((secbits == 128) || (!strcmp("kyber768", ""#oqsname""))) ? "x25519_" #oqsname "" : \
                         "x448_" #oqsname "")
+#else
+#define ECX_NAME(secbits, oqsname) \
+    ((secbits == 128) ? "x25519_" #oqsname "" : \
+                        "x448_" #oqsname "")
+#endif
 
 typedef struct prov_oqs_ctx_st {
     const OSSL_CORE_HANDLE *handle;

--- a/oqsprov/oqsprov_capabilities.c
+++ b/oqsprov/oqsprov_capabilities.c
@@ -20,13 +20,7 @@
 // internal, but useful OSSL define:
 # define OSSL_NELEM(x)    (sizeof(x)/sizeof((x)[0]))
 
-#define ECP_NAME(secbits, oqsname) \
-    (secbits == 128 ? "p256_" #oqsname "" : \
-     secbits == 192 ? "p384_" #oqsname "" : \
-                      "p521_" #oqsname "")
-#define ECX_NAME(secbits, oqsname) \
-    (secbits == 128 ? "x25519_" #oqsname "" : \
-                        "x448_" #oqsname "")
+#include "oqs_prov.h"
 
 typedef struct oqs_group_constants_st {
     unsigned int group_id;           /* Group ID */

--- a/oqsprov/oqsprov_keys.c
+++ b/oqsprov/oqsprov_keys.c
@@ -568,7 +568,7 @@ OQSX_KEY *oqsx_key_new(OSSL_LIB_CTX *libctx, char* oqs_name, char* tls_name, int
 
         ret2 = (init_kex_fun[primitive - KEY_TYPE_ECP_HYB_KEM])
 #ifdef CLOUDFLARE
-                ((!strcmp("Kyber768", oqs_name))?128:bit_security, evp_ctx);
+                (((!strcmp("Kyber768", oqs_name)&&(primitive==KEY_TYPE_ECX_HYB_KEM)))?128:bit_security, evp_ctx);
 #else
                 (bit_security, evp_ctx);
 #endif

--- a/oqsprov/oqsprov_keys.c
+++ b/oqsprov/oqsprov_keys.c
@@ -567,7 +567,11 @@ OQSX_KEY *oqsx_key_new(OSSL_LIB_CTX *libctx, char* oqs_name, char* tls_name, int
         ON_ERR_GOTO(!evp_ctx, err);
 
         ret2 = (init_kex_fun[primitive - KEY_TYPE_ECP_HYB_KEM])
+#ifdef CLOUDFLARE
+                ((!strcmp("Kyber768", oqs_name))?128:bit_security, evp_ctx);
+#else
                 (bit_security, evp_ctx);
+#endif
         ON_ERR_GOTO(ret2 <= 0 || !evp_ctx->keyParam || !evp_ctx->ctx, err);
 
         ret->numkeys = 2;


### PR DESCRIPTION
As per discussion in https://github.com/open-quantum-safe/openssl/issues/388 this is to create "minimally invasive" support for cloudflare's hybrid choice of x25519_kyber768.

To activate, set #define CLOUDFLARE in oqs_prov.h.

Tested to run successfully against cloudflare infrastructure & code point:
```
OQS_CODEPOINT_X448_KYBER768=65073  ./openssl/apps/openssl s_client -groups x25519_kyber768 -connect cloudflare.com:443 -provider-path _build/oqsprov -provider oqsprovider -provider default
[...]
read R BLOCK
HTTP/1.1 200 OK
Date: Wed, 19 Oct 2022 09:19:03 GMT
Content-Type: text/plain
Transfer-Encoding: chunked
Connection: keep-alive
Access-Control-Allow-Origin: *
Server: cloudflare
CF-RAY: 75c86e05a8c1cc62-ZRH
X-Frame-Options: DENY
X-Content-Type-Options: nosniff
Expires: Thu, 01 Jan 1970 00:00:01 GMT
Cache-Control: no-cache

e5
fl=64f31
h=cloudflare.com
ip=2a01:2ac:51dd:d483:3c5f:d979:73f5:bdfa
ts=1666171143.48
visit_scheme=https
uag=
colo=ZRH
sliver=010-tier1
http=http/1.1
loc=CH
tls=TLSv1.3
sni=plaintext
warp=off
gateway=off
kex=X25519Kyber768Draft00

```