### PR TITLE
add OCTET STRING wrap for pubkeys

### DIFF
--- a/oqsprov/oqs_encode_key2any.c
+++ b/oqsprov/oqs_encode_key2any.c
@@ -509,10 +509,14 @@ static int prepare_oqsx_params(const void *oqsxkey, int nid, int save,
 
 # define prepare_ecx_params NULL
 
+#define ENCODE_UINT16(pbuf, i)  (pbuf)[0] = (unsigned char)((i>>8) & 0xff); \
+                                (pbuf)[1] = (unsigned char)((i   ) & 0xff)
+
 static int oqsx_spki_pub_to_der(const void *vecxkey, unsigned char **pder)
 {
     const OQSX_KEY *oqsxkey = vecxkey;
     unsigned char *keyblob;
+    int retlen;
 
     OQS_ENC_PRINTF("OQS ENC provider: oqsx_spki_pub_to_der called\n");
 
@@ -521,14 +525,31 @@ static int oqsx_spki_pub_to_der(const void *vecxkey, unsigned char **pder)
         return 0;
     }
 
-    keyblob = OPENSSL_memdup(oqsxkey->pubkey, oqsxkey->pubkeylen);
+    if (getenv("DRAFT_MASSIMO_LAMPS_PQ_SIG_CERTIFICATES_00")) { // support for inefficient OCTET STRING wrapping
+        retlen = oqsxkey->pubkeylen+4;
+        keyblob = OPENSSL_malloc(retlen);
+        if (keyblob) {
+            // encode TLV for OCTET_STRING
+            keyblob[0] = (char)V_ASN1_OCTET_STRING;
+            keyblob[1] = (char)0x82; // support for longer pub keys not foreseen
+            if (oqsxkey->pubkeylen > 65535) {
+                OQS_ENC_PRINTF2("OQS ENC provider: pub key longer than permitted for OCTET STRING wrap: %ld\n", oqsxkey->pubkeylen);
+                ERR_raise(ERR_LIB_USER, OQSPROV_R_INVALID_ENCODING);
+	    }
+            ENCODE_UINT16(keyblob+2, oqsxkey->pubkeylen);
+            memcpy(keyblob+4, oqsxkey->pubkey, oqsxkey->pubkeylen);
+	}
+    }
+    else {
+        keyblob = OPENSSL_memdup(oqsxkey->pubkey, retlen = oqsxkey->pubkeylen);
+    }
     if (keyblob == NULL) {
         ERR_raise(ERR_LIB_USER, ERR_R_MALLOC_FAILURE);
         return 0;
     }
 
     *pder = keyblob;
-    return oqsxkey->pubkeylen;
+    return retlen;
 }
 
 static int oqsx_pki_priv_to_der(const void *vecxkey, unsigned char **pder)

--- a/oqsprov/oqsprov_keys.c
+++ b/oqsprov/oqsprov_keys.c
@@ -254,7 +254,11 @@ static OQSX_KEY *oqsx_key_op(const X509_ALGOR *palg,
     }
 
     if (op == KEY_OP_PUBLIC) {
-        if (key->pubkeylen != plen) {
+	// strip blindly inefficient OCTET STRING wrapping if indicated by env var
+	// TBD: do proper TLV decoding if this really becomes a standard
+	int octet_string_adjust = getenv("DRAFT_MASSIMO_LAMPS_PQ_SIG_CERTIFICATES_00")?4:0;
+	// length check will fail if pubkeys longer than 65535 (TLV-0482xxxx) are encoded this way:
+        if (key->pubkeylen != (plen-octet_string_adjust)) {
             ERR_raise(ERR_LIB_USER, OQSPROV_R_INVALID_ENCODING);
             goto err;
         }
@@ -262,7 +266,7 @@ static OQSX_KEY *oqsx_key_op(const X509_ALGOR *palg,
             ERR_raise(ERR_LIB_USER, ERR_R_MALLOC_FAILURE);
             goto err;
         }
-        memcpy(key->pubkey, p, plen);
+        memcpy(key->pubkey, p+octet_string_adjust, plen-octet_string_adjust);
     } else {
 	int classical_privatekey_len = 0;
 	// for plain OQS keys, we expect OQS priv||OQS pub key

--- a/scripts/runtests.sh
+++ b/scripts/runtests.sh
@@ -69,6 +69,10 @@ if [ $? -eq 0 ]; then
    echo "No OQS-OpenSSL111 interop tests due to skip instruction in $OQS_SKIP_TESTS"
    export LOCALTESTONLY="Yes"
 fi
+if [ ! -z "${DRAFT_MASSIMO_LAMPS_PQ_SIG_CERTIFICATES_00}" ]; then
+   echo "No OQS-OpenSSL111 interop tests due to DRAFT_MASSIMO_LAMPS_PQ_SIG_CERTIFICATES_00"
+   export LOCALTESTONLY="Yes"
+fi
 
 echo "OpenSSL app: $OPENSSL_APP"
 


### PR DESCRIPTION
This enables wrapping public keys in OCTET STRINGS as per https://datatracker.ietf.org/doc/draft-ietf-lamps-dilithium-certificates. As the purpose of this is not yet entirely clear and as it breaks interoperability with oqs-openssl111 the functionality is only enabled when setting the environment variable [DRAFT_MASSIMO_LAMPS_PQ_SIG_CERTIFICATES_00](https://github.com/open-quantum-safe/oqs-provider/wiki/Interoperability#draft_massimo_lamps_pq_sig_certificates_00).