### PR TITLE
correct MAC handling and remove manual alg assertion

### DIFF
--- a/oqsprov/oqsprov_capabilities.c
+++ b/oqsprov/oqsprov_capabilities.c
@@ -365,7 +365,6 @@ static int oqs_group_capability(OSSL_CALLBACK *cb, void *arg)
 {
     size_t i;
 
-    assert(OSSL_NELEM(oqs_param_group_list) == OSSL_NELEM(oqs_group_list) * 3 - 12 /* XXX manually exclude all 256bit ECX hybrids not supported */);
     for (i = 0; i < OSSL_NELEM(oqs_param_group_list); i++) {
         if (!cb(oqs_param_group_list[i], arg))
             return 0;


### PR DESCRIPTION
- Correction of previously overly strict (re)setting of digest algorithms
- Removal of manual algorithm count assertion that is incorrect when algorithms are automatically enabled/disabled