### PR TITLE
detach oqs-provider template from oqs-openssl111

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,6 @@ openssl
 liboqs
 # installed SW
 .local
-# obtained from main OQS-OpenSSL repo
-oqs-template/generate.yml
 # build directory
 _build
 # generated from openssl src:

--- a/oqs-template/generate.yml
+++ b/oqs-template/generate.yml
@@ -1,0 +1,841 @@
+# N.B: For interoperability, NIDS must match the curve IDs used in
+# https://docs.google.com/spreadsheets/d/12YarzaNv3XQNLnvDsWLlRKwtZFhRrDdWf36YlzwrPeg/edit#gid=0
+kems:
+  -
+    family: 'FrodoKEM'
+    name_group: 'frodo640aes'
+    nid: '0x0200'
+    nid_hybrid: '0x2F00'
+    oqs_alg: 'OQS_KEM_alg_frodokem_640_aes'
+  -
+    family: 'FrodoKEM'
+    name_group: 'frodo640shake'
+    nid: '0x0201'
+    nid_hybrid: '0x2F01'
+    oqs_alg: 'OQS_KEM_alg_frodokem_640_shake'
+  -
+    family: 'FrodoKEM'
+    name_group: 'frodo976aes'
+    nid: '0x0202'
+    nid_hybrid: '0x2F02'
+    oqs_alg: 'OQS_KEM_alg_frodokem_976_aes'
+  -
+    family: 'FrodoKEM'
+    name_group: 'frodo976shake'
+    nid: '0x0203'
+    nid_hybrid: '0x2F03'
+    oqs_alg: 'OQS_KEM_alg_frodokem_976_shake'
+  -
+    family: 'FrodoKEM'
+    name_group: 'frodo1344aes'
+    nid: '0x0204'
+    nid_hybrid: '0x2F04'
+    oqs_alg: 'OQS_KEM_alg_frodokem_1344_aes'
+  -
+    family: 'FrodoKEM'
+    name_group: 'frodo1344shake'
+    nid: '0x0205'
+    nid_hybrid: '0x2F05'
+    oqs_alg: 'OQS_KEM_alg_frodokem_1344_shake'
+  -
+    family: 'BIKE'
+    name_group: 'bike1l1cpa'
+    bit_security: 128
+    extra_nids:
+      old:
+        - implementation_version: NIST Round 2 submission
+          nist-round: 2
+          nid: '0x0206'
+        - implementation_version: NIST Round 2 submission
+          nist-round: 2
+          hybrid_group: secp256_r1
+          nid: '0x2F06'
+    oqs_alg: 'OQS_KEM_alg_bike1_l1_cpa'
+  -
+    family: 'BIKE'
+    name_group: 'bike1l3cpa'
+    bit_security: 192
+    extra_nids:
+      old:
+        - implementation_version: NIST Round 2 submission
+          nist-round: 2
+          nid: '0x0207'
+        - implementation_version: NIST Round 2 submission
+          nist-round: 2
+          hybrid_group: secp384_r1
+          nid: '0x2F07'
+    oqs_alg: 'OQS_KEM_alg_bike1_l3_cpa'
+  -
+    family: 'CRYSTALS-Kyber'
+    name_group: 'kyber512'
+    nid: '0x023A'
+    nid_hybrid: '0x2F3A'
+    oqs_alg: 'OQS_KEM_alg_kyber_512'
+    extra_nids:
+      current:
+        - hybrid_group: "x25519"
+          nid: '0x2F39'
+      old:
+        - implementation_version: NIST Round 2 submission
+          nist-round: 2
+          nid: '0x020F'
+        - implementation_version: NIST Round 2 submission
+          nist-round: 2
+          hybrid_group: secp256_r1
+          nid: '0x2F0F'
+        - implementation_version: NIST Round 2 submission
+          nist-round: 2
+          hybrid_group: x25519
+          nid: '0x2F26'
+  -
+    family: 'CRYSTALS-Kyber'
+    name_group: 'kyber768'
+    nid: '0x023C'
+    nid_hybrid: '0x2F3C'
+    extra_nids:
+      old:
+        - implementation_version: NIST Round 2 submission
+          nist-round: 2
+          nid: '0x0210'
+        - implementation_version: NIST Round 2 submission
+          nist-round: 2
+          hybrid_group: secp384_r1
+          nid: '0x2F10'
+    oqs_alg: 'OQS_KEM_alg_kyber_768'
+  -
+    family: 'CRYSTALS-Kyber'
+    name_group: 'kyber1024'
+    nid: '0x023D'
+    nid_hybrid: '0x2F3D'
+    extra_nids:
+      old:
+        - implementation_version: NIST Round 2 submission
+          nist-round: 2
+          nid: '0x0211'
+        - implementation_version: NIST Round 2 submission
+          nist-round: 2
+          hybrid_group: secp521_r1
+          nid: '0x2F11'
+    oqs_alg: 'OQS_KEM_alg_kyber_1024'
+  -
+    family: 'BIKE'
+    name_group: 'bike1l1fo'
+    bit_security: 128
+    extra_nids:
+      old:
+        - implementation_version: NIST Round 2 submission
+          nist-round: 2
+          nid: '0x0223'
+        - implementation_version: NIST Round 2 submission
+          nist-round: 2
+          hybrid_group: secp256_r1
+          nid: '0x2F23'
+        - implementation_version: NIST Round 2 submission
+          nist-round: 2
+          hybrid_group: "x25519"
+          nid: '0x2F28'
+    oqs_alg: 'OQS_KEM_alg_bike1_l1_fo'
+  -
+    family: 'BIKE'
+    name_group: 'bike1l3fo'
+    bit_security: 192
+    extra_nids:
+      old:
+        - implementation_version: NIST Round 2 submission
+          nist-round: 2
+          nid: '0x0224'
+        - implementation_version: NIST Round 2 submission
+          nist-round: 2
+          hybrid_group: secp384_r1
+          nid: '0x2F24'
+    oqs_alg: 'OQS_KEM_alg_bike1_l3_fo'
+  -
+    family: 'BIKE'
+    name_group: 'bikel1'
+    implementation_version: '4.1'
+    nid: '0x0238'
+    nid_hybrid: '0x2F38'
+    oqs_alg: 'OQS_KEM_alg_bike_l1'
+    extra_nids:
+      current:
+        - hybrid_group: "x25519"
+          nid: '0x2F37'
+          implementation_version: '4.1'
+  -
+    family: 'BIKE'
+    name_group: 'bikel3'
+    implementation_version: '4.1'
+    nid: '0x023B'
+    nid_hybrid: '0x2F3B'
+    oqs_alg: 'OQS_KEM_alg_bike_l3'
+  -
+    family: 'CRYSTALS-Kyber'
+    name_group: 'kyber90s512'
+    nid: '0x023E'
+    nid_hybrid: '0x2F3E'
+    extra_nids:
+      old:
+        - implementation_version: NIST Round 2 submission
+          nist-round: 2
+          nid: '0x0229'
+        - implementation_version: NIST Round 2 submission
+          nist-round: 2
+          hybrid_group: secp256_r1
+          nid: '0x2F29'
+    oqs_alg: 'OQS_KEM_alg_kyber_512_90s'
+  -
+    family: 'CRYSTALS-Kyber'
+    name_group: 'kyber90s768'
+    nid: '0x023F'
+    nid_hybrid: '0x2F3F'
+    extra_nids:
+      old:
+        - implementation_version: NIST Round 2 submission
+          nist-round: 2
+          nid: '0x022A'
+        - implementation_version: NIST Round 2 submission
+          nist-round: 2
+          hybrid_group: secp384_r1
+          nid: '0x2F2A'
+    oqs_alg: 'OQS_KEM_alg_kyber_768_90s'
+  -
+    family: 'CRYSTALS-Kyber'
+    name_group: 'kyber90s1024'
+    nid: '0x0240'
+    nid_hybrid: '0x2F40'
+    extra_nids:
+      old:
+        - implementation_version: NIST Round 2 submission
+          nist-round: 2
+          nid: '0x022B'
+        - implementation_version: NIST Round 2 submission
+          nist-round: 2
+          hybrid_group: secp521_r1
+          nid: '0x2F2B'
+    oqs_alg: 'OQS_KEM_alg_kyber_1024_90s'
+  -
+    family: 'HQC'
+    name_group: 'hqc128'
+    nid: '0x022C'
+    nid_hybrid: '0x2F2C'
+    oqs_alg: 'OQS_KEM_alg_hqc_128'
+  -
+    family: 'HQC'
+    name_group: 'hqc192'
+    nid: '0x022D'
+    nid_hybrid: '0x2F2D'
+    oqs_alg: 'OQS_KEM_alg_hqc_192'
+  -
+    family: 'HQC'
+    name_group: 'hqc256'
+    nid: '0x022E'
+    nid_hybrid: '0x2F2E'
+    oqs_alg: 'OQS_KEM_alg_hqc_256'
+
+kem_nid_end: '0x0250'
+kem_nid_hybrid_end: '0x2FFF'
+# need to edit ssl_local.h macros IS_OQS_KEM_CURVEID and IS_OQS_KEM_HYBRID_CURVEID with the above _end values
+
+# N.B: For interoperability, code-points and OIDs must match those used in
+# https://docs.google.com/spreadsheets/d/12YarzaNv3XQNLnvDsWLlRKwtZFhRrDdWf36YlzwrPeg/edit#gid=0
+sigs:
+  # -
+    # iso (1)
+    # identified-organization (3)
+    # reserved (9999)
+    # oqs_sig_default (1)
+    # disabled
+    #variants:
+    #  -
+    #    name: 'oqs_sig_default'
+    #    pretty_name: 'OQS Default Signature Algorithm'
+    #    oqs_meth: 'OQS_SIG_alg_default'
+    #    oid: '1.3.9999.1.1'
+    #    code_point: '0xfe00'
+    #    enable: true
+    #    mix_with: [{'name': 'p256',
+    #                'pretty_name': 'ECDSA p256',
+    #                'oid': '1.3.9999.1.2',
+    #                'code_point': '0xfe01'},
+    #               {'name': 'rsa3072',
+    #                'pretty_name': 'RSA3072',
+    #                'oid': '1.3.9999.1.3',
+    #                'code_point': '0xfe02'}]
+  -
+    # OID scheme for hybrid variants of Dilithium:
+    # iso (1)
+    # identified-organization (3)
+    # reserved (9999)
+    # dilithium (2)
+    # OID scheme for plain Dilithium:
+    # iso (1)
+    # identified-organization (3)
+    # dod (6)
+    # internet (1)
+    # private (4)
+    # enterprise (1)
+    # IBM (2)
+    # qsc (267)
+    # Dilithium-r3 (7)
+    family: 'CRYSTALS-Dilithium'
+    variants:
+      -
+        name: 'dilithium2'
+        pretty_name: 'Dilithium2'
+        oqs_meth: 'OQS_SIG_alg_dilithium_2'
+        oid: '1.3.6.1.4.1.2.267.7.4.4'
+        code_point: '0xfea0'
+        enable: true
+        mix_with: [{'name': 'p256',
+                    'pretty_name': 'ECDSA p256',
+                    'oid': '1.3.9999.2.7.1',
+                    'code_point': '0xfea1'},
+                   {'name': 'rsa3072',
+                    'pretty_name': 'RSA3072',
+                    'oid': '1.3.9999.2.7.2',
+                    'code_point': '0xfea2'}]
+      -
+        name: 'dilithium3'
+        pretty_name: 'Dilithium3'
+        oqs_meth: 'OQS_SIG_alg_dilithium_3'
+        oid: '1.3.6.1.4.1.2.267.7.6.5'
+        code_point: '0xfea3'
+        enable: true
+        mix_with: [{'name': 'p384',
+                    'pretty_name': 'ECDSA p384',
+                    'oid': '1.3.9999.2.7.3',
+                    'code_point': '0xfea4'}]
+      -
+        name: 'dilithium5'
+        pretty_name: 'Dilithium5'
+        oqs_meth: 'OQS_SIG_alg_dilithium_5'
+        oid: '1.3.6.1.4.1.2.267.7.8.7'
+        code_point: '0xfea5'
+        enable: true
+        mix_with: [{'name': 'p521',
+                    'pretty_name': 'ECDSA p521',
+                    'oid': '1.3.9999.2.7.4',
+                    'code_point': '0xfea6'}]
+      -
+        name: 'dilithium2_aes'
+        pretty_name: 'Dilithium2_AES'
+        oqs_meth: 'OQS_SIG_alg_dilithium_2_aes'
+        oid: '1.3.6.1.4.1.2.267.11.4.4'
+        code_point: '0xfea7'
+        enable: true
+        mix_with: [{'name': 'p256',
+                    'pretty_name': 'ECDSA p256',
+                    'oid': '1.3.9999.2.11.1',
+                    'code_point': '0xfea8'},
+                   {'name': 'rsa3072',
+                    'pretty_name': 'RSA3072',
+                    'oid': '1.3.9999.2.11.2',
+                    'code_point': '0xfea9'}]
+      -
+        name: 'dilithium3_aes'
+        pretty_name: 'Dilithium3_AES'
+        oqs_meth: 'OQS_SIG_alg_dilithium_3_aes'
+        oid: '1.3.6.1.4.1.2.267.11.6.5'
+        code_point: '0xfeaa'
+        enable: true
+        mix_with: [{'name': 'p384',
+                    'pretty_name': 'ECDSA p384',
+                    'oid': '1.3.9999.2.11.3',
+                    'code_point': '0xfeab'}]
+      -
+        name: 'dilithium5_aes'
+        pretty_name: 'Dilithium5_AES'
+        oqs_meth: 'OQS_SIG_alg_dilithium_5_aes'
+        oid: '1.3.6.1.4.1.2.267.11.8.7'
+        code_point: '0xfeac'
+        enable: true
+        mix_with: [{'name': 'p521',
+                    'pretty_name': 'ECDSA p521',
+                    'oid': '1.3.9999.2.11.4',
+                    'code_point': '0xfead'}]
+  -
+    # iso (1)
+    # identified-organization (3)
+    # reserved (9999)
+    # falcon (3)
+    family: 'Falcon'
+    variants:
+      -
+        name: 'falcon512'
+        pretty_name: 'Falcon-512'
+        oqs_meth: 'OQS_SIG_alg_falcon_512'
+        oid: '1.3.9999.3.1'
+        code_point: '0xfe0b'
+        enable: true
+        mix_with: [{'name': 'p256',
+                    'pretty_name': 'ECDSA p256',
+                    'oid': '1.3.9999.3.2',
+                    'code_point': '0xfe0c'},
+                   {'name': 'rsa3072',
+                    'pretty_name': 'RSA3072',
+                    'oid': '1.3.9999.3.3',
+                    'code_point': '0xfe0d'}]
+      -
+        name: 'falcon1024'
+        pretty_name: 'Falcon-1024'
+        oqs_meth: 'OQS_SIG_alg_falcon_1024'
+        oid: '1.3.9999.3.4'
+        code_point: '0xfe0e'
+        enable: true
+        mix_with: [{'name': 'p521',
+                    'pretty_name': 'ECDSA p521',
+                    'oid': '1.3.9999.3.5',
+                    'code_point': '0xfe0f'}]
+  -
+    family: 'SPHINCS-Haraka'
+    variants:
+      -
+        name: 'sphincsharaka128frobust'
+        pretty_name: 'SPHINCS+-Haraka-128f-robust'
+        oqs_meth: 'OQS_SIG_alg_sphincs_haraka_128f_robust'
+        oid: '1.3.9999.6.1.1'
+        code_point: '0xfe42'
+        enable: true
+        mix_with: [{'name': 'p256',
+                    'pretty_name': 'ECDSA p256',
+                    'oid': '1.3.9999.6.1.2',
+                    'code_point': '0xfe43'},
+                   {'name': 'rsa3072',
+                    'pretty_name': 'RSA3072',
+                    'oid': '1.3.9999.6.1.3',
+                    'code_point': '0xfe44'}]
+      -
+        name: 'sphincsharaka128fsimple'
+        pretty_name: 'SPHINCS+-Haraka-128f-simple'
+        oqs_meth: 'OQS_SIG_alg_sphincs_haraka_128f_simple'
+        oid: '1.3.9999.6.1.4'
+        code_point: '0xfe45'
+        enable: true
+        mix_with: [{'name': 'p256',
+                    'pretty_name': 'ECDSA p256',
+                    'oid': '1.3.9999.6.1.5',
+                    'code_point': '0xfe46'},
+                   {'name': 'rsa3072',
+                    'pretty_name': 'RSA3072',
+                    'oid': '1.3.9999.6.1.6',
+                    'code_point': '0xfe47'}]
+      -
+        name: 'sphincsharaka128srobust'
+        pretty_name: 'SPHINCS+-Haraka-128s-robust'
+        oqs_meth: 'OQS_SIG_alg_sphincs_haraka_128s_robust'
+        oid: '1.3.9999.6.1.7'
+        code_point: '0xfe48'
+        enable: false
+        mix_with: [{'name': 'p256',
+                    'pretty_name': 'ECDSA p256',
+                    'oid': '1.3.9999.6.1.8',
+                    'code_point': '0xfe49'},
+                   {'name': 'rsa3072',
+                    'pretty_name': 'RSA3072',
+                    'oid': '1.3.9999.6.1.9',
+                    'code_point': '0xfe4a'}]
+      -
+        name: 'sphincsharaka128ssimple'
+        pretty_name: 'SPHINCS+-Haraka-128s-simple'
+        oqs_meth: 'OQS_SIG_alg_sphincs_haraka_128s_simple'
+        oid: '1.3.9999.6.1.10'
+        code_point: '0xfe4b'
+        enable: false
+        mix_with: [{'name': 'p256',
+                    'pretty_name': 'ECDSA p256',
+                    'oid': '1.3.9999.6.1.11',
+                    'code_point': '0xfe4c'},
+                   {'name': 'rsa3072',
+                    'pretty_name': 'RSA3072',
+                    'oid': '1.3.9999.6.1.12',
+                    'code_point': '0xfe4d'}]
+      -
+        name: 'sphincsharaka192frobust'
+        pretty_name: 'SPHINCS+-Haraka-192f-robust'
+        oqs_meth: 'OQS_SIG_alg_sphincs_haraka_192f_robust'
+        oid: '1.3.9999.6.2.1'
+        code_point: '0xfe4e'
+        enable: false
+        mix_with: [{'name': 'p384',
+                    'pretty_name': 'ECDSA p384',
+                    'oid': '1.3.9999.6.2.2',
+                    'code_point': '0xfe4f'}]
+      -
+        name: 'sphincsharaka192fsimple'
+        pretty_name: 'SPHINCS+-Haraka-192f-simple'
+        oqs_meth: 'OQS_SIG_alg_sphincs_haraka_192f_simple'
+        oid: '1.3.9999.6.2.3'
+        code_point: '0xfe50'
+        enable: false
+        mix_with: [{'name': 'p384',
+                    'pretty_name': 'ECDSA p384',
+                    'oid': '1.3.9999.6.2.4',
+                    'code_point': '0xfe51'}]
+      -
+        name: 'sphincsharaka192srobust'
+        pretty_name: 'SPHINCS+-Haraka-192s-robust'
+        oqs_meth: 'OQS_SIG_alg_sphincs_haraka_192s_robust'
+        oid: '1.3.9999.6.2.5'
+        code_point: '0xfe52'
+        enable: false
+        mix_with: [{'name': 'p384',
+                    'pretty_name': 'ECDSA p384',
+                    'oid': '1.3.9999.6.2.6',
+                    'code_point': '0xfe53'}]
+      -
+        name: 'sphincsharaka192ssimple'
+        pretty_name: 'SPHINCS+-Haraka-192s-simple'
+        oqs_meth: 'OQS_SIG_alg_sphincs_haraka_192s_simple'
+        oid: '1.3.9999.6.2.7'
+        code_point: '0xfe54'
+        enable: false
+        mix_with: [{'name': 'p384',
+                    'pretty_name': 'ECDSA p384',
+                    'oid': '1.3.9999.6.2.8',
+                    'code_point': '0xfe55'}]
+      -
+        name: 'sphincsharaka256frobust'
+        pretty_name: 'SPHINCS+-Haraka-256f-robust'
+        oqs_meth: 'OQS_SIG_alg_sphincs_haraka_256f_robust'
+        oid: '1.3.9999.6.3.1'
+        code_point: '0xfe56'
+        enable: false
+        mix_with: [{'name': 'p521',
+                    'pretty_name': 'ECDSA p521',
+                    'oid': '1.3.9999.6.3.2',
+                    'code_point': '0xfe57'}]
+      -
+        name: 'sphincsharaka256fsimple'
+        pretty_name: 'SPHINCS+-Haraka-256f-simple'
+        oqs_meth: 'OQS_SIG_alg_sphincs_haraka_256f_simple'
+        oid: '1.3.9999.6.3.3'
+        code_point: '0xfe58'
+        enable: false
+        mix_with: [{'name': 'p521',
+                    'pretty_name': 'ECDSA p521',
+                    'oid': '1.3.9999.6.3.4',
+                    'code_point': '0xfe59'}]
+      -
+        name: 'sphincsharaka256srobust'
+        pretty_name: 'SPHINCS+-Haraka-256s-robust'
+        oqs_meth: 'OQS_SIG_alg_sphincs_haraka_256s_robust'
+        oid: '1.3.9999.6.3.5'
+        code_point: '0xfe5a'
+        enable: false
+        mix_with: [{'name': 'p521',
+                    'pretty_name': 'ECDSA p521',
+                    'oid': '1.3.9999.6.3.6',
+                    'code_point': '0xfe5b'}]
+      -
+        name: 'sphincsharaka256ssimple'
+        pretty_name: 'SPHINCS+-Haraka-256s-simple'
+        oqs_meth: 'OQS_SIG_alg_sphincs_haraka_256s_simple'
+        oid: '1.3.9999.6.3.7'
+        code_point: '0xfe5c'
+        enable: false
+        mix_with: [{'name': 'p521',
+                    'pretty_name': 'ECDSA p521',
+                    'oid': '1.3.9999.6.3.8',
+                    'code_point': '0xfe5d'}]
+  -
+    family: 'SPHINCS-SHA256'
+    variants:
+      -
+        name: 'sphincssha256128frobust'
+        pretty_name: 'SPHINCS+-SHA256-128f-robust'
+        oqs_meth: 'OQS_SIG_alg_sphincs_sha256_128f_robust'
+        oid: '1.3.9999.6.4.1'
+        code_point: '0xfe5e'
+        enable: true
+        mix_with: [{'name': 'p256',
+                    'pretty_name': 'ECDSA p256',
+                    'oid': '1.3.9999.6.4.2',
+                    'code_point': '0xfe5f'},
+                   {'name': 'rsa3072',
+                    'pretty_name': 'RSA3072',
+                    'oid': '1.3.9999.6.4.3',
+                    'code_point': '0xfe60'}]
+      -
+        name: 'sphincssha256128fsimple'
+        pretty_name: 'SPHINCS+-SHA256-128f-simple'
+        oqs_meth: 'OQS_SIG_alg_sphincs_sha256_128f_simple'
+        oid: '1.3.9999.6.4.4'
+        code_point: '0xfe61'
+        enable: false
+        mix_with: [{'name': 'p256',
+                    'pretty_name': 'ECDSA p256',
+                    'oid': '1.3.9999.6.4.5',
+                    'code_point': '0xfe62'},
+                   {'name': 'rsa3072',
+                    'pretty_name': 'RSA3072',
+                    'oid': '1.3.9999.6.4.6',
+                    'code_point': '0xfe63'}]
+      -
+        name: 'sphincssha256128srobust'
+        pretty_name: 'SPHINCS+-SHA256-128s-robust'
+        oqs_meth: 'OQS_SIG_alg_sphincs_sha256_128s_robust'
+        oid: '1.3.9999.6.4.7'
+        code_point: '0xfe64'
+        enable: false
+        mix_with: [{'name': 'p256',
+                    'pretty_name': 'ECDSA p256',
+                    'oid': '1.3.9999.6.4.8',
+                    'code_point': '0xfe65'},
+                   {'name': 'rsa3072',
+                    'pretty_name': 'RSA3072',
+                    'oid': '1.3.9999.6.4.9',
+                    'code_point': '0xfe66'}]
+      -
+        name: 'sphincssha256128ssimple'
+        pretty_name: 'SPHINCS+-SHA256-128s-simple'
+        oqs_meth: 'OQS_SIG_alg_sphincs_sha256_128s_simple'
+        oid: '1.3.9999.6.4.10'
+        code_point: '0xfe67'
+        enable: true
+        mix_with: [{'name': 'p256',
+                    'pretty_name': 'ECDSA p256',
+                    'oid': '1.3.9999.6.4.11',
+                    'code_point': '0xfe68'},
+                   {'name': 'rsa3072',
+                    'pretty_name': 'RSA3072',
+                    'oid': '1.3.9999.6.4.12',
+                    'code_point': '0xfe69'}]
+      -
+        name: 'sphincssha256192frobust'
+        pretty_name: 'SPHINCS+-SHA256-192f-robust'
+        oqs_meth: 'OQS_SIG_alg_sphincs_sha256_192f_robust'
+        oid: '1.3.9999.6.5.1'
+        code_point: '0xfe6a'
+        enable: false
+        mix_with: [{'name': 'p384',
+                    'pretty_name': 'ECDSA p384',
+                    'oid': '1.3.9999.6.5.2',
+                    'code_point': '0xfe6b'}]
+      -
+        name: 'sphincssha256192fsimple'
+        pretty_name: 'SPHINCS+-SHA256-192f-simple'
+        oqs_meth: 'OQS_SIG_alg_sphincs_sha256_192f_simple'
+        oid: '1.3.9999.6.5.3'
+        code_point: '0xfe6c'
+        enable: false
+        mix_with: [{'name': 'p384',
+                    'pretty_name': 'ECDSA p384',
+                    'oid': '1.3.9999.6.5.4',
+                    'code_point': '0xfe6d'}]
+      -
+        name: 'sphincssha256192srobust'
+        pretty_name: 'SPHINCS+-SHA256-192s-robust'
+        oqs_meth: 'OQS_SIG_alg_sphincs_sha256_192s_robust'
+        oid: '1.3.9999.6.5.5'
+        code_point: '0xfe6e'
+        enable: false
+        mix_with: [{'name': 'p384',
+                    'pretty_name': 'ECDSA p384',
+                    'oid': '1.3.9999.6.5.6',
+                    'code_point': '0xfe6f'}]
+      -
+        name: 'sphincssha256192ssimple'
+        pretty_name: 'SPHINCS+-SHA256-192s-simple'
+        oqs_meth: 'OQS_SIG_alg_sphincs_sha256_192s_simple'
+        oid: '1.3.9999.6.5.7'
+        code_point: '0xfe70'
+        enable: false
+        mix_with: [{'name': 'p384',
+                    'pretty_name': 'ECDSA p384',
+                    'oid': '1.3.9999.6.5.8',
+                    'code_point': '0xfe71'}]
+      -
+        name: 'sphincssha256256frobust'
+        pretty_name: 'SPHINCS+-SHA256-256f-robust'
+        oqs_meth: 'OQS_SIG_alg_sphincs_sha256_256f_robust'
+        oid: '1.3.9999.6.6.1'
+        code_point: '0xfe72'
+        enable: false
+        mix_with: [{'name': 'p521',
+                    'pretty_name': 'ECDSA p521',
+                    'oid': '1.3.9999.6.6.2',
+                    'code_point': '0xfe73'}]
+      -
+        name: 'sphincssha256256fsimple'
+        pretty_name: 'SPHINCS+-SHA256-256f-simple'
+        oqs_meth: 'OQS_SIG_alg_sphincs_sha256_256f_simple'
+        oid: '1.3.9999.6.6.3'
+        code_point: '0xfe74'
+        enable: false
+        mix_with: [{'name': 'p521',
+                    'pretty_name': 'ECDSA p521',
+                    'oid': '1.3.9999.6.6.4',
+                    'code_point': '0xfe75'}]
+      -
+        name: 'sphincssha256256srobust'
+        pretty_name: 'SPHINCS+-SHA256-256s-robust'
+        oqs_meth: 'OQS_SIG_alg_sphincs_sha256_256s_robust'
+        oid: '1.3.9999.6.6.5'
+        code_point: '0xfe76'
+        enable: false
+        mix_with: [{'name': 'p521',
+                    'pretty_name': 'ECDSA p521',
+                    'oid': '1.3.9999.6.6.6',
+                    'code_point': '0xfe77'}]
+      -
+        name: 'sphincssha256256ssimple'
+        pretty_name: 'SPHINCS+-SHA256-256s-simple'
+        oqs_meth: 'OQS_SIG_alg_sphincs_sha256_256s_simple'
+        oid: '1.3.9999.6.6.7'
+        code_point: '0xfe78'
+        enable: false
+        mix_with: [{'name': 'p521',
+                    'pretty_name': 'ECDSA p521',
+                    'oid': '1.3.9999.6.6.8',
+                    'code_point': '0xfe79'}]
+  -
+    family: 'SPHINCS-SHAKE256'
+    variants:
+      -
+        name: 'sphincsshake256128frobust'
+        pretty_name: 'SPHINCS+-SHAKE256-128f-robust'
+        oqs_meth: 'OQS_SIG_alg_sphincs_shake256_128f_robust'
+        oid: '1.3.9999.6.7.1'
+        code_point: '0xfe7a'
+        enable: false
+        mix_with: [{'name': 'p256',
+                    'pretty_name': 'ECDSA p256',
+                    'oid': '1.3.9999.6.7.2',
+                    'code_point': '0xfe7b'},
+                   {'name': 'rsa3072',
+                    'pretty_name': 'RSA3072',
+                    'oid': '1.3.9999.6.7.3',
+                    'code_point': '0xfe7c'}]
+      -
+        name: 'sphincsshake256128fsimple'
+        pretty_name: 'SPHINCS+-SHAKE256-128f-simple'
+        oqs_meth: 'OQS_SIG_alg_sphincs_shake256_128f_simple'
+        oid: '1.3.9999.6.7.4'
+        code_point: '0xfe7d'
+        enable: true
+        mix_with: [{'name': 'p256',
+                    'pretty_name': 'ECDSA p256',
+                    'oid': '1.3.9999.6.7.5',
+                    'code_point': '0xfe7e'},
+                   {'name': 'rsa3072',
+                    'pretty_name': 'RSA3072',
+                    'oid': '1.3.9999.6.7.6',
+                    'code_point': '0xfe7f'}]
+      -
+        name: 'sphincsshake256128srobust'
+        pretty_name: 'SPHINCS+-SHAKE256-128s-robust'
+        oqs_meth: 'OQS_SIG_alg_sphincs_shake256_128s_robust'
+        oid: '1.3.9999.6.7.7'
+        code_point: '0xfe80'
+        enable: false
+        mix_with: [{'name': 'p256',
+                    'pretty_name': 'ECDSA p256',
+                    'oid': '1.3.9999.6.7.8',
+                    'code_point': '0xfe81'},
+                   {'name': 'rsa3072',
+                    'pretty_name': 'RSA3072',
+                    'oid': '1.3.9999.6.7.9',
+                    'code_point': '0xfe82'}]
+      -
+        name: 'sphincsshake256128ssimple'
+        pretty_name: 'SPHINCS+-SHAKE256-128s-simple'
+        oqs_meth: 'OQS_SIG_alg_sphincs_shake256_128s_simple'
+        oid: '1.3.9999.6.7.10'
+        code_point: '0xfe83'
+        enable: false
+        mix_with: [{'name': 'p256',
+                    'pretty_name': 'ECDSA p256',
+                    'oid': '1.3.9999.6.7.11',
+                    'code_point': '0xfe84'},
+                   {'name': 'rsa3072',
+                    'pretty_name': 'RSA3072',
+                    'oid': '1.3.9999.6.7.12',
+                    'code_point': '0xfe85'}]
+      -
+        name: 'sphincsshake256192frobust'
+        pretty_name: 'SPHINCS+-SHAKE256-192f-robust'
+        oqs_meth: 'OQS_SIG_alg_sphincs_shake256_192f_robust'
+        oid: '1.3.9999.6.8.1'
+        code_point: '0xfe86'
+        enable: false
+        mix_with: [{'name': 'p384',
+                    'pretty_name': 'ECDSA p384',
+                    'oid': '1.3.9999.6.8.2',
+                    'code_point': '0xfe87'}]
+      -
+        name: 'sphincsshake256192fsimple'
+        pretty_name: 'SPHINCS+-SHAKE256-192f-simple'
+        oqs_meth: 'OQS_SIG_alg_sphincs_shake256_192f_simple'
+        oid: '1.3.9999.6.8.3'
+        code_point: '0xfe88'
+        enable: false
+        mix_with: [{'name': 'p384',
+                    'pretty_name': 'ECDSA p384',
+                    'oid': '1.3.9999.6.8.4',
+                    'code_point': '0xfe89'}]
+      -
+        name: 'sphincsshake256192srobust'
+        pretty_name: 'SPHINCS+-SHAKE256-192s-robust'
+        oqs_meth: 'OQS_SIG_alg_sphincs_shake256_192s_robust'
+        oid: '1.3.9999.6.8.5'
+        code_point: '0xfe8a'
+        enable: false
+        mix_with: [{'name': 'p384',
+                    'pretty_name': 'ECDSA p384',
+                    'oid': '1.3.9999.6.8.6',
+                    'code_point': '0xfe8b'}]
+      -
+        name: 'sphincsshake256192ssimple'
+        pretty_name: 'SPHINCS+-SHAKE256-192s-simple'
+        oqs_meth: 'OQS_SIG_alg_sphincs_shake256_192s_simple'
+        oid: '1.3.9999.6.8.7'
+        code_point: '0xfe8c'
+        enable: false
+        mix_with: [{'name': 'p384',
+                    'pretty_name': 'ECDSA p384',
+                    'oid': '1.3.9999.6.8.8',
+                    'code_point': '0xfe8d'}]
+      -
+        name: 'sphincsshake256256frobust'
+        pretty_name: 'SPHINCS+-SHAKE256-256f-robust'
+        oqs_meth: 'OQS_SIG_alg_sphincs_shake256_256f_robust'
+        oid: '1.3.9999.6.9.1'
+        code_point: '0xfe8e'
+        enable: false
+        mix_with: [{'name': 'p521',
+                    'pretty_name': 'ECDSA p521',
+                    'oid': '1.3.9999.6.9.2',
+                    'code_point': '0xfe8f'}]
+      -
+        name: 'sphincsshake256256fsimple'
+        pretty_name: 'SPHINCS+-SHAKE256-256f-simple'
+        oqs_meth: 'OQS_SIG_alg_sphincs_shake256_256f_simple'
+        oid: '1.3.9999.6.9.3'
+        code_point: '0xfe90'
+        enable: false
+        mix_with: [{'name': 'p521',
+                    'pretty_name': 'ECDSA p521',
+                    'oid': '1.3.9999.6.9.4',
+                    'code_point': '0xfe91'}]
+      -
+        name: 'sphincsshake256256srobust'
+        pretty_name: 'SPHINCS+-SHAKE256-256s-robust'
+        oqs_meth: 'OQS_SIG_alg_sphincs_shake256_256s_robust'
+        oid: '1.3.9999.6.9.5'
+        code_point: '0xfe92'
+        enable: false
+        mix_with: [{'name': 'p521',
+                    'pretty_name': 'ECDSA p521',
+                    'oid': '1.3.9999.6.9.6',
+                    'code_point': '0xfe93'}]
+      -
+        name: 'sphincsshake256256ssimple'
+        pretty_name: 'SPHINCS+-SHAKE256-256s-simple'
+        oqs_meth: 'OQS_SIG_alg_sphincs_shake256_256s_simple'
+        oid: '1.3.9999.6.9.7'
+        code_point: '0xfe94'
+        enable: false
+        mix_with: [{'name': 'p521',
+                    'pretty_name': 'ECDSA p521',
+                    'oid': '1.3.9999.6.9.8',
+                    'code_point': '0xfe95'}]


### PR DESCRIPTION
Complements #104 allowing oqs-provider to be (documented and built) fully independent from oqs-openssl111