### PR TITLE
enable support for specific liboqs releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,7 +348,7 @@ therefore represent the interoperability level at a specific point in time (of d
 of `oqsprovider` and `liboqs`).
 
 By default, `oqsprovider` always uses the most current version of `liboqs` code, but by
-setting the environment variable "LIBOQS_BRANCH" when running the `scripts/fullbuild.sh"
+setting the environment variable "LIBOQS_BRANCH" when running the `scripts/fullbuild.sh`
 script, code will be generated to utilize a specific, supported `liboqs` release. The
 script `scripts/revertmain.sh` can be used to revert all code back to the default,
 `main`-branch tracking strategy. This can be used, for example, to facilitate a release

--- a/README.md
+++ b/README.md
@@ -327,13 +327,32 @@ supported: The resolution of https://github.com/openssl/openssl/issues/17717
 has not been not getting back-ported to OpenSSL3.0.
 
 Also not supported in this version are provider-based signature algorithms
-used during TLS operations as documented in https://github.com/openssl/openssl/issues/10512.
+used during TLS1.3 operations as documented in https://github.com/openssl/openssl/issues/10512.
 
-## 3.2-dev
+## 3.2(-dev)
 
-If https://github.com/openssl/openssl/pull/19312 lands, TLS1.3 signature
-algorithms will work, but algorithms with overly long signatures still fail due to
-specific message size limitations built into OpenSSL and/or the TLS specifications.
+After https://github.com/openssl/openssl/pull/19312 landed, (also PQ) signature
+algorithms are working in TLS1.3 (handshaking), but algorithms with overly long
+signatures may still fail due to specific message size limitations built into
+OpenSSL and/or the TLS specifications.
+
+liboqs dependency
+-----------------
+
+As `oqsprovider` is dependent on `liboqs` for the implementation of the PQ algorithms
+there is a mechanism to adapt the functionality of a specific `liboqs` version to the
+current `oqsprovider` version: The use of the code generator script `oqs-template/generate.py`
+which in turn is driven by any of the `liboqs` release-specific `oqs-template/generate.yml[-release]`
+files. The same file(s) also define the (default) TLS IDs of all algorithms included and
+therefore represent the interoperability level at a specific point in time (of development
+of `oqsprovider` and `liboqs`).
+
+By default, `oqsprovider` always uses the most current version of `liboqs` code, but by
+setting the environment variable "LIBOQS_BRANCH" when running the `scripts/fullbuild.sh"
+script, code will be generated to utilize a specific, supported `liboqs` release. The
+script `scripts/revertmain.sh` can be used to revert all code back to the default,
+`main`-branch tracking strategy. This can be used, for example, to facilitate a release
+of `oqsprovider` to track an old `liboqs` release.
 
 Team
 ----

--- a/oqs-template/generate.yml-0.7.2
+++ b/oqs-template/generate.yml-0.7.2
@@ -1,0 +1,1240 @@
+# N.B: For interoperability, NIDS must match the curve IDs used in
+# https://docs.google.com/spreadsheets/d/12YarzaNv3XQNLnvDsWLlRKwtZFhRrDdWf36YlzwrPeg/edit#gid=0
+kems:
+  -
+    family: 'FrodoKEM'
+    name_group: 'frodo640aes'
+    nid: '0x0200'
+    nid_hybrid: '0x2F00'
+    oqs_alg: 'OQS_KEM_alg_frodokem_640_aes'
+    extra_nids:
+      current:
+        - hybrid_group: "x25519"
+          nid: '0x2F80'
+  -
+    family: 'FrodoKEM'
+    name_group: 'frodo640shake'
+    nid: '0x0201'
+    nid_hybrid: '0x2F01'
+    oqs_alg: 'OQS_KEM_alg_frodokem_640_shake'
+    extra_nids:
+      current:
+        - hybrid_group: "x25519"
+          nid: '0x2F81'
+  -
+    family: 'FrodoKEM'
+    name_group: 'frodo976aes'
+    nid: '0x0202'
+    nid_hybrid: '0x2F02'
+    oqs_alg: 'OQS_KEM_alg_frodokem_976_aes'
+    extra_nids:
+      current:
+        - hybrid_group: "x448"
+          nid: '0x2F82'
+  -
+    family: 'FrodoKEM'
+    name_group: 'frodo976shake'
+    nid: '0x0203'
+    nid_hybrid: '0x2F03'
+    oqs_alg: 'OQS_KEM_alg_frodokem_976_shake'
+    extra_nids:
+      current:
+        - hybrid_group: "x448"
+          nid: '0x2F83'
+  -
+    family: 'FrodoKEM'
+    name_group: 'frodo1344aes'
+    nid: '0x0204'
+    nid_hybrid: '0x2F04'
+    oqs_alg: 'OQS_KEM_alg_frodokem_1344_aes'
+  -
+    family: 'FrodoKEM'
+    name_group: 'frodo1344shake'
+    nid: '0x0205'
+    nid_hybrid: '0x2F05'
+    oqs_alg: 'OQS_KEM_alg_frodokem_1344_shake'
+  -
+    family: 'BIKE'
+    name_group: 'bike1l1cpa'
+    bit_security: 128
+    extra_nids:
+      old:
+        - implementation_version: NIST Round 2 submission
+          nist-round: 2
+          nid: '0x0206'
+        - implementation_version: NIST Round 2 submission
+          nist-round: 2
+          hybrid_group: secp256_r1
+          nid: '0x2F06'
+    oqs_alg: 'OQS_KEM_alg_bike1_l1_cpa'
+  -
+    family: 'BIKE'
+    name_group: 'bike1l3cpa'
+    bit_security: 192
+    extra_nids:
+      old:
+        - implementation_version: NIST Round 2 submission
+          nist-round: 2
+          nid: '0x0207'
+        - implementation_version: NIST Round 2 submission
+          nist-round: 2
+          hybrid_group: secp384_r1
+          nid: '0x2F07'
+    oqs_alg: 'OQS_KEM_alg_bike1_l3_cpa'
+  -
+    family: 'CRYSTALS-Kyber'
+    name_group: 'kyber512'
+    nid: '0x023A'
+    nid_hybrid: '0x2F3A'
+    oqs_alg: 'OQS_KEM_alg_kyber_512'
+    extra_nids:
+      current:
+        - hybrid_group: "x25519"
+          nid: '0x2F39'
+      old:
+        - implementation_version: NIST Round 2 submission
+          nist-round: 2
+          nid: '0x020F'
+        - implementation_version: NIST Round 2 submission
+          nist-round: 2
+          hybrid_group: secp256_r1
+          nid: '0x2F0F'
+        - implementation_version: NIST Round 2 submission
+          nist-round: 2
+          hybrid_group: x25519
+          nid: '0x2F26'
+  -
+    family: 'CRYSTALS-Kyber'
+    name_group: 'kyber768'
+    nid: '0x023C'
+    nid_hybrid: '0x2F3C'
+    extra_nids:
+      current:
+        - hybrid_group: "x448"
+          nid: '0x2F90'
+      old:
+        - implementation_version: NIST Round 2 submission
+          nist-round: 2
+          nid: '0x0210'
+        - implementation_version: NIST Round 2 submission
+          nist-round: 2
+          hybrid_group: secp384_r1
+          nid: '0x2F10'
+    oqs_alg: 'OQS_KEM_alg_kyber_768'
+  -
+    family: 'CRYSTALS-Kyber'
+    name_group: 'kyber1024'
+    nid: '0x023D'
+    nid_hybrid: '0x2F3D'
+    extra_nids:
+      old:
+        - implementation_version: NIST Round 2 submission
+          nist-round: 2
+          nid: '0x0211'
+        - implementation_version: NIST Round 2 submission
+          nist-round: 2
+          hybrid_group: secp521_r1
+          nid: '0x2F11'
+    oqs_alg: 'OQS_KEM_alg_kyber_1024'
+  -
+    family: 'NTRU'
+    name_group: 'ntru_hps2048509'
+    nid: '0x0214'
+    nid_hybrid: '0x2F14'
+    oqs_alg: 'OQS_KEM_alg_ntru_hps2048509'
+    extra_nids:
+      current:
+        - hybrid_group: "x25519"
+          nid: '0x2F94'
+  -
+    family: 'NTRU'
+    name_group: 'ntru_hps2048677'
+    nid: '0x0215'
+    nid_hybrid: '0x2F15'
+    oqs_alg: 'OQS_KEM_alg_ntru_hps2048677'
+    extra_nids:
+      current:
+        - hybrid_group: "x448"
+          nid: '0x2F95'
+  -
+    family: 'NTRU'
+    name_group: 'ntru_hps4096821'
+    nid: '0x0216'
+    nid_hybrid: '0x2F16'
+    oqs_alg: 'OQS_KEM_alg_ntru_hps4096821'
+  -
+    family: 'NTRU'
+    name_group: 'ntru_hps40961229'
+    nid: '0x0245'
+    nid_hybrid: '0x2F45'
+    oqs_alg: 'OQS_KEM_alg_ntru_hps40961229'
+  -
+    family: 'NTRU'
+    name_group: 'ntru_hrss701'
+    nid: '0x0217'
+    nid_hybrid: '0x2F17'
+    oqs_alg: 'OQS_KEM_alg_ntru_hrss701'
+    extra_nids:
+      current:
+        - hybrid_group: "x448"
+          nid: '0x2F97'
+  -
+    family: 'NTRU'
+    name_group: 'ntru_hrss1373'
+    nid: '0x0246'
+    nid_hybrid: '0x2F46'
+    oqs_alg: 'OQS_KEM_alg_ntru_hrss1373'
+  -
+    family: 'SABER'
+    name_group: 'lightsaber'
+    nid: '0x0218'
+    nid_hybrid: '0x2F18'
+    oqs_alg: 'OQS_KEM_alg_saber_lightsaber'
+    extra_nids:
+      current:
+        - hybrid_group: "x25519"
+          nid: '0x2F98'
+  -
+    family: 'SABER'
+    name_group: 'saber'
+    nid: '0x0219'
+    nid_hybrid: '0x2F19'
+    oqs_alg: 'OQS_KEM_alg_saber_saber'
+    extra_nids:
+      current:
+        - hybrid_group: "x448"
+          nid: '0x2F99'
+  -
+    family: 'SABER'
+    name_group: 'firesaber'
+    nid: '0x021A'
+    nid_hybrid: '0x2F1A'
+    oqs_alg: 'OQS_KEM_alg_saber_firesaber'
+  -
+    family: 'BIKE'
+    name_group: 'bike1l1fo'
+    bit_security: 128
+    extra_nids:
+      old:
+        - implementation_version: NIST Round 2 submission
+          nist-round: 2
+          nid: '0x0223'
+        - implementation_version: NIST Round 2 submission
+          nist-round: 2
+          hybrid_group: secp256_r1
+          nid: '0x2F23'
+        - implementation_version: NIST Round 2 submission
+          nist-round: 2
+          hybrid_group: "x25519"
+          nid: '0x2F28'
+    oqs_alg: 'OQS_KEM_alg_bike1_l1_fo'
+  -
+    family: 'BIKE'
+    name_group: 'bike1l3fo'
+    bit_security: 192
+    extra_nids:
+      old:
+        - implementation_version: NIST Round 2 submission
+          nist-round: 2
+          nid: '0x0224'
+        - implementation_version: NIST Round 2 submission
+          nist-round: 2
+          hybrid_group: secp384_r1
+          nid: '0x2F24'
+    oqs_alg: 'OQS_KEM_alg_bike1_l3_fo'
+  -
+    family: 'BIKE'
+    name_group: 'bikel1'
+    implementation_version: '4.1'
+    nid: '0x0238'
+    nid_hybrid: '0x2F38'
+    oqs_alg: 'OQS_KEM_alg_bike_l1'
+    extra_nids:
+      current:
+        - hybrid_group: "x25519"
+          nid: '0x2F37'
+          implementation_version: '4.1'
+  -
+    family: 'BIKE'
+    name_group: 'bikel3'
+    implementation_version: '4.1'
+    nid: '0x023B'
+    nid_hybrid: '0x2F3B'
+    oqs_alg: 'OQS_KEM_alg_bike_l3'
+  -
+    family: 'CRYSTALS-Kyber'
+    name_group: 'kyber90s512'
+    nid: '0x023E'
+    nid_hybrid: '0x2F3E'
+    extra_nids:
+      current:
+        - hybrid_group: "x25519"
+          nid: '0x2FA9'
+      old:
+        - implementation_version: NIST Round 2 submission
+          nist-round: 2
+          nid: '0x0229'
+        - implementation_version: NIST Round 2 submission
+          nist-round: 2
+          hybrid_group: secp256_r1
+          nid: '0x2F29'
+    oqs_alg: 'OQS_KEM_alg_kyber_512_90s'
+  -
+    family: 'CRYSTALS-Kyber'
+    name_group: 'kyber90s768'
+    nid: '0x023F'
+    nid_hybrid: '0x2F3F'
+    extra_nids:
+      current:
+        - hybrid_group: "x448"
+          nid: '0x2FAA'
+      old:
+        - implementation_version: NIST Round 2 submission
+          nist-round: 2
+          nid: '0x022A'
+        - implementation_version: NIST Round 2 submission
+          nist-round: 2
+          hybrid_group: secp384_r1
+          nid: '0x2F2A'
+    oqs_alg: 'OQS_KEM_alg_kyber_768_90s'
+  -
+    family: 'CRYSTALS-Kyber'
+    name_group: 'kyber90s1024'
+    nid: '0x0240'
+    nid_hybrid: '0x2F40'
+    extra_nids:
+      old:
+        - implementation_version: NIST Round 2 submission
+          nist-round: 2
+          nid: '0x022B'
+        - implementation_version: NIST Round 2 submission
+          nist-round: 2
+          hybrid_group: secp521_r1
+          nid: '0x2F2B'
+    oqs_alg: 'OQS_KEM_alg_kyber_1024_90s'
+  -
+    family: 'HQC'
+    name_group: 'hqc128'
+    nid: '0x022C'
+    nid_hybrid: '0x2F2C'
+    oqs_alg: 'OQS_KEM_alg_hqc_128'
+    extra_nids:
+      current:
+        - hybrid_group: "x25519"
+          nid: '0x2FAC'
+  -
+    family: 'HQC'
+    name_group: 'hqc192'
+    nid: '0x022D'
+    nid_hybrid: '0x2F2D'
+    oqs_alg: 'OQS_KEM_alg_hqc_192'
+    extra_nids:
+      current:
+        - hybrid_group: "x448"
+          nid: '0x2FAD'
+  -
+    family: 'HQC'
+    name_group: 'hqc256'
+    nid: '0x022E'
+    nid_hybrid: '0x2F2E'
+    oqs_alg: 'OQS_KEM_alg_hqc_256'
+  -
+    family: 'NTRU-Prime'
+    name_group: 'ntrulpr653'
+    nid: '0x022F'
+    nid_hybrid: '0x2F2F'
+    oqs_alg: 'OQS_KEM_alg_ntruprime_ntrulpr653'
+    extra_nids:
+      current:
+        - hybrid_group: "x25519"
+          nid: '0x2FAF'
+  -
+    family: 'NTRU-Prime'
+    name_group: 'ntrulpr761'
+    nid: '0x0230'
+    nid_hybrid: '0x2F43'
+    extra_nids:
+      current:
+        - hybrid_group: "x25519"
+          nid: '0x2FB0'
+      old:
+        - implementation_version: Round 3 p384 hybrid
+          nist-round: 3
+          nid: '0x2F30'
+    oqs_alg: 'OQS_KEM_alg_ntruprime_ntrulpr761'
+  -
+    family: 'NTRU-Prime'
+    name_group: 'ntrulpr857'
+    nid: '0x0231'
+    nid_hybrid: '0x2F31'
+    oqs_alg: 'OQS_KEM_alg_ntruprime_ntrulpr857'
+    extra_nids:
+      current:
+        - hybrid_group: "x448"
+          nid: '0x2FB1'
+  -
+    family: 'NTRU-Prime'
+    name_group: 'ntrulpr1277'
+    nid: '0x0241'
+    nid_hybrid: '0x2F41'
+    oqs_alg: 'OQS_KEM_alg_ntruprime_ntrulpr1277'
+  -
+    family: 'NTRU-Prime'
+    name_group: 'sntrup653'
+    nid: '0x0232'
+    nid_hybrid: '0x2F32'
+    oqs_alg: 'OQS_KEM_alg_ntruprime_sntrup653'
+    extra_nids:
+      current:
+        - hybrid_group: "x25519"
+          nid: '0x2FB2'
+  -
+    family: 'NTRU-Prime'
+    name_group: 'sntrup761'
+    nid: '0x0233'
+    nid_hybrid: '0x2F44'
+    extra_nids:
+      current:
+        - hybrid_group: "x25519"
+          nid: '0x2FB3'
+      old:
+        - implementation_version: Round 3 p384 hybrid
+          nist-round: 3
+          nid: '0x2F33'
+    oqs_alg: 'OQS_KEM_alg_ntruprime_sntrup761'
+  -
+    family: 'NTRU-Prime'
+    name_group: 'sntrup857'
+    nid: '0x0234'
+    nid_hybrid: '0x2F34'
+    oqs_alg: 'OQS_KEM_alg_ntruprime_sntrup857'
+    extra_nids:
+      current:
+        - hybrid_group: "x448"
+          nid: '0x2FB4'
+  -
+    family: 'NTRU-Prime'
+    name_group: 'sntrup1277'
+    nid: '0x0242'
+    nid_hybrid: '0x2F42'
+    oqs_alg: 'OQS_KEM_alg_ntruprime_sntrup1277'
+
+kem_nid_end: '0x0250'
+kem_nid_hybrid_end: '0x2FFF'
+# need to edit ssl_local.h macros IS_OQS_KEM_CURVEID and IS_OQS_KEM_HYBRID_CURVEID with the above _end values
+
+# N.B: For interoperability, code-points and OIDs must match those used in
+# https://docs.google.com/spreadsheets/d/12YarzaNv3XQNLnvDsWLlRKwtZFhRrDdWf36YlzwrPeg/edit#gid=0
+sigs:
+  # -
+    # iso (1)
+    # identified-organization (3)
+    # reserved (9999)
+    # oqs_sig_default (1)
+    # disabled
+    #variants:
+    #  -
+    #    name: 'oqs_sig_default'
+    #    pretty_name: 'OQS Default Signature Algorithm'
+    #    oqs_meth: 'OQS_SIG_alg_default'
+    #    oid: '1.3.9999.1.1'
+    #    code_point: '0xfe00'
+    #    enable: true
+    #    mix_with: [{'name': 'p256',
+    #                'pretty_name': 'ECDSA p256',
+    #                'oid': '1.3.9999.1.2',
+    #                'code_point': '0xfe01'},
+    #               {'name': 'rsa3072',
+    #                'pretty_name': 'RSA3072',
+    #                'oid': '1.3.9999.1.3',
+    #                'code_point': '0xfe02'}]
+  -
+    # OID scheme for hybrid variants of Dilithium:
+    # iso (1)
+    # identified-organization (3)
+    # reserved (9999)
+    # dilithium (2)
+    # OID scheme for plain Dilithium:
+    # iso (1)
+    # identified-organization (3)
+    # dod (6)
+    # internet (1)
+    # private (4)
+    # enterprise (1)
+    # IBM (2)
+    # qsc (267)
+    # Dilithium-r3 (7)
+    family: 'CRYSTALS-Dilithium'
+    variants:
+      -
+        name: 'dilithium2'
+        pretty_name: 'Dilithium2'
+        oqs_meth: 'OQS_SIG_alg_dilithium_2'
+        oid: '1.3.6.1.4.1.2.267.7.4.4'
+        code_point: '0xfea0'
+        enable: true
+        mix_with: [{'name': 'p256',
+                    'pretty_name': 'ECDSA p256',
+                    'oid': '1.3.9999.2.7.1',
+                    'code_point': '0xfea1'},
+                   {'name': 'rsa3072',
+                    'pretty_name': 'RSA3072',
+                    'oid': '1.3.9999.2.7.2',
+                    'code_point': '0xfea2'}]
+      -
+        name: 'dilithium3'
+        pretty_name: 'Dilithium3'
+        oqs_meth: 'OQS_SIG_alg_dilithium_3'
+        oid: '1.3.6.1.4.1.2.267.7.6.5'
+        code_point: '0xfea3'
+        enable: true
+        mix_with: [{'name': 'p384',
+                    'pretty_name': 'ECDSA p384',
+                    'oid': '1.3.9999.2.7.3',
+                    'code_point': '0xfea4'}]
+      -
+        name: 'dilithium5'
+        pretty_name: 'Dilithium5'
+        oqs_meth: 'OQS_SIG_alg_dilithium_5'
+        oid: '1.3.6.1.4.1.2.267.7.8.7'
+        code_point: '0xfea5'
+        enable: true
+        mix_with: [{'name': 'p521',
+                    'pretty_name': 'ECDSA p521',
+                    'oid': '1.3.9999.2.7.4',
+                    'code_point': '0xfea6'}]
+      -
+        name: 'dilithium2_aes'
+        pretty_name: 'Dilithium2_AES'
+        oqs_meth: 'OQS_SIG_alg_dilithium_2_aes'
+        oid: '1.3.6.1.4.1.2.267.11.4.4'
+        code_point: '0xfea7'
+        enable: true
+        mix_with: [{'name': 'p256',
+                    'pretty_name': 'ECDSA p256',
+                    'oid': '1.3.9999.2.11.1',
+                    'code_point': '0xfea8'},
+                   {'name': 'rsa3072',
+                    'pretty_name': 'RSA3072',
+                    'oid': '1.3.9999.2.11.2',
+                    'code_point': '0xfea9'}]
+      -
+        name: 'dilithium3_aes'
+        pretty_name: 'Dilithium3_AES'
+        oqs_meth: 'OQS_SIG_alg_dilithium_3_aes'
+        oid: '1.3.6.1.4.1.2.267.11.6.5'
+        code_point: '0xfeaa'
+        enable: true
+        mix_with: [{'name': 'p384',
+                    'pretty_name': 'ECDSA p384',
+                    'oid': '1.3.9999.2.11.3',
+                    'code_point': '0xfeab'}]
+      -
+        name: 'dilithium5_aes'
+        pretty_name: 'Dilithium5_AES'
+        oqs_meth: 'OQS_SIG_alg_dilithium_5_aes'
+        oid: '1.3.6.1.4.1.2.267.11.8.7'
+        code_point: '0xfeac'
+        enable: true
+        mix_with: [{'name': 'p521',
+                    'pretty_name': 'ECDSA p521',
+                    'oid': '1.3.9999.2.11.4',
+                    'code_point': '0xfead'}]
+  -
+    # iso (1)
+    # identified-organization (3)
+    # reserved (9999)
+    # falcon (3)
+    family: 'Falcon'
+    variants:
+      -
+        name: 'falcon512'
+        pretty_name: 'Falcon-512'
+        oqs_meth: 'OQS_SIG_alg_falcon_512'
+        oid: '1.3.9999.3.1'
+        code_point: '0xfe0b'
+        enable: true
+        mix_with: [{'name': 'p256',
+                    'pretty_name': 'ECDSA p256',
+                    'oid': '1.3.9999.3.2',
+                    'code_point': '0xfe0c'},
+                   {'name': 'rsa3072',
+                    'pretty_name': 'RSA3072',
+                    'oid': '1.3.9999.3.3',
+                    'code_point': '0xfe0d'}]
+      -
+        name: 'falcon1024'
+        pretty_name: 'Falcon-1024'
+        oqs_meth: 'OQS_SIG_alg_falcon_1024'
+        oid: '1.3.9999.3.4'
+        code_point: '0xfe0e'
+        enable: true
+        mix_with: [{'name': 'p521',
+                    'pretty_name': 'ECDSA p521',
+                    'oid': '1.3.9999.3.5',
+                    'code_point': '0xfe0f'}]
+  -
+    # iso (1)
+    # identified-organization (3)
+    # dod (6)
+    # internet (1)
+    # private (4)
+    # enterprise (1)
+    # Microsoft (311)
+    # MSRCrypto (89)
+    # PQC (2)
+    # picnic (1)
+    family: 'Picnic'
+    variants:
+      -
+        name: 'picnicl1fs'
+        pretty_name: 'Picnic L1 FS'
+        oqs_meth: 'OQS_SIG_alg_picnic_L1_FS'
+        oid: '1.3.6.1.4.1.311.89.2.1.1'
+        code_point: '0xfe15'
+        enable: false
+        mix_with: [{'name': 'p256',
+                    'pretty_name': 'ECDSA p256',
+                    'oid': '1.3.6.1.4.1.311.89.2.1.2',
+                    'code_point': '0xfe16'},
+                   {'name': 'rsa3072',
+                    'pretty_name': 'RSA3072',
+                    'oid': '1.3.6.1.4.1.311.89.2.1.3',
+                    'code_point': '0xfe17'}]
+      -
+        name: 'picnicl1ur'
+        pretty_name: 'Picnic L1 UR'
+        oqs_meth: 'OQS_SIG_alg_picnic_L1_UR'
+        oid: '1.3.6.1.4.1.311.89.2.1.4'
+        code_point: '0xfe18'
+        enable: false
+        mix_with: [{'name': 'p256',
+                    'pretty_name': 'ECDSA p256',
+                    'oid': '1.3.6.1.4.1.311.89.2.1.5',
+                    'code_point': '0xfe19'},
+                   {'name': 'rsa3072',
+                    'pretty_name': 'RSA3072',
+                    'oid': '1.3.6.1.4.1.311.89.2.1.6',
+                    'code_point': '0xfe1a'}]
+      -
+        name: 'picnicl1full'
+        pretty_name: 'Picnic L1 full'
+        oqs_meth: 'OQS_SIG_alg_picnic_L1_full'
+        oid: '1.3.6.1.4.1.311.89.2.1.7'
+        code_point: '0xfe96'
+        enable: true
+        mix_with: [{'name': 'p256',
+                    'pretty_name': 'ECDSA p256',
+                    'oid': '1.3.6.1.4.1.311.89.2.1.8',
+                    'code_point': '0xfe97'},
+                   {'name': 'rsa3072',
+                    'pretty_name': 'RSA3072',
+                    'oid': '1.3.6.1.4.1.311.89.2.1.9',
+                    'code_point': '0xfe98'}]
+      -
+        name: 'picnic3l1'
+        pretty_name: 'Picnic3 L1'
+        oqs_meth: 'OQS_SIG_alg_picnic3_L1'
+        oid: '1.3.6.1.4.1.311.89.2.1.21'
+        code_point: '0xfe1b'
+        enable: true
+        mix_with: [{'name': 'p256',
+                    'pretty_name': 'ECDSA p256',
+                    'oid': '1.3.6.1.4.1.311.89.2.1.22',
+                    'code_point': '0xfe1c'},
+                   {'name': 'rsa3072',
+                    'pretty_name': 'RSA3072',
+                    'oid': '1.3.6.1.4.1.311.89.2.1.23',
+                    'code_point': '0xfe1d'}]
+      -
+        name: 'picnic3l3'
+        pretty_name: 'Picnic3 L3'
+        oqs_meth: 'OQS_SIG_alg_picnic3_L3'
+        oid: '1.3.6.1.4.1.311.89.2.1.24'
+        code_point: '0xfe1e'
+        enable: false
+        mix_with: [{'name': 'p384',
+                    'pretty_name': 'ECDSA p384',
+                    'oid': '1.3.6.1.4.1.311.89.2.1.25',
+                    'code_point': '0xfe1f'}]
+      -
+        name: 'picnic3l5'
+        pretty_name: 'Picnic3 L5'
+        oqs_meth: 'OQS_SIG_alg_picnic3_L5'
+        oid: '1.3.6.1.4.1.311.89.2.1.26'
+        code_point: '0xfe20'
+        enable: false
+        mix_with: [{'name': 'p521',
+                    'pretty_name': 'ECDSA p521',
+                    'oid': '1.3.6.1.4.1.311.89.2.1.27',
+                    'code_point': '0xfe21'}]
+  -
+    family: 'Rainbow'
+    variants:
+      -
+        name: 'rainbowIclassic'
+        pretty_name: 'Rainbow-I-Classic'
+        oqs_meth: 'OQS_SIG_alg_rainbow_I_classic'
+        extra_oids:
+            nist-round: 3
+            oid: '1.3.9999.5.1.1.1'
+            code_point: '0xfe27'
+            mix_with: [{'name': 'p256',
+                        'pretty_name': 'ECDSA p256',
+                        'oid': '1.3.9999.5.1.2.1',
+                        'code_point': '0xfe28'},
+                       {'name': 'rsa3072',
+                        'pretty_name': 'RSA3072',
+                        'oid': '1.3.9999.5.1.3.1',
+                        'code_point': '0xfe29'}]
+      -
+        name: 'rainbowIcircumzenithal'
+        pretty_name: 'Rainbow-I-Circumzenithal'
+        oqs_meth: 'OQS_SIG_alg_rainbow_I_circumzenithal'
+        extra_oids:
+            nist-round: 3
+            oid: '1.3.9999.5.1.4.1'
+            code_point: '0xfe30'
+            mix_with: [{'name': 'p256',
+                        'pretty_name': 'ECDSA p256',
+                        'oid': '1.3.9999.5.1.5.1',
+                        'code_point': '0xfe31'},
+                       {'name': 'rsa3072',
+                        'pretty_name': 'RSA3072',
+                        'oid': '1.3.9999.5.1.6.1',
+                        'code_point': '0xfe32'}]
+      -
+        name: 'rainbowIcompressed'
+        pretty_name: 'Rainbow-I-Compressed'
+        oqs_meth: 'OQS_SIG_alg_rainbow_I_compressed'
+        extra_oids:
+            nist-round: 3
+            oid: '1.3.9999.5.1.7.1'
+            code_point: '0xfe33'
+            mix_with: [{'name': 'p256',
+                        'pretty_name': 'ECDSA p256',
+                        'oid': '1.3.9999.5.1.8.1',
+                        'code_point': '0xfe34'},
+                       {'name': 'rsa3072',
+                        'pretty_name': 'RSA3072',
+                        'oid': '1.3.9999.5.1.9.1',
+                        'code_point': '0xfe35'}]
+      -
+        name: 'rainbowIIIclassic'
+        pretty_name: 'Rainbow-III-Classic'
+        oqs_meth: 'OQS_SIG_alg_rainbow_III_classic'
+        oid: '1.3.9999.5.2.1.1'
+        code_point: '0xfe36'
+        enable: false
+        mix_with: [{'name': 'p384',
+                    'pretty_name': 'ECDSA p256',
+                    'oid': '1.3.9999.5.2.2.1',
+                    'code_point': '0xfe37'}]
+      -
+        name: 'rainbowIIIcircumzenithal'
+        pretty_name: 'Rainbow-III-Circumzenithal'
+        oqs_meth: 'OQS_SIG_alg_rainbow_III_circumzenithal'
+        oid: '1.3.9999.5.2.3.1'
+        code_point: '0xfe38'
+        enable: false
+        mix_with: [{'name': 'p384',
+                    'pretty_name': 'ECDSA p384',
+                    'oid': '1.3.9999.5.2.4.1',
+                    'code_point': '0xfe39'}]
+      -
+        name: 'rainbowIIIcompressed'
+        pretty_name: 'Rainbow-III-Compressed'
+        oqs_meth: 'OQS_SIG_alg_rainbow_III_compressed'
+        oid: '1.3.9999.5.2.5.1'
+        code_point: '0xfe3a'
+        enable: false
+        mix_with: [{'name': 'p384',
+                    'pretty_name': 'ECDSA p384',
+                    'oid': '1.3.9999.5.2.6.1',
+                    'code_point': '0xfe3b'}]
+      -
+        name: 'rainbowVclassic'
+        pretty_name: 'Rainbow-V-Classic'
+        oqs_meth: 'OQS_SIG_alg_rainbow_V_classic'
+        oid: '1.3.9999.5.3.1.1'
+        code_point: '0xfe3c'
+        enable: true
+        mix_with: [{'name': 'p521',
+                    'pretty_name': 'ECDSA p521',
+                    'oid': '1.3.9999.5.3.2.1',
+                    'code_point': '0xfe3d'}]
+      -
+        name: 'rainbowVcircumzenithal'
+        pretty_name: 'Rainbow-V-Circumzenithal'
+        oqs_meth: 'OQS_SIG_alg_rainbow_V_circumzenithal'
+        oid: '1.3.9999.5.3.3.1'
+        code_point: '0xfe3e'
+        enable: false
+        mix_with: [{'name': 'p521',
+                    'pretty_name': 'ECDSA p521',
+                    'oid': '1.3.9999.5.3.4.1',
+                    'code_point': '0xfe3f'}]
+      -
+        name: 'rainbowVcompressed'
+        pretty_name: 'Rainbow-V-Compressed'
+        oqs_meth: 'OQS_SIG_alg_rainbow_V_compressed'
+        oid: '1.3.9999.5.3.5.1'
+        code_point: '0xfe40'
+        enable: false
+        mix_with: [{'name': 'p521',
+                    'pretty_name': 'ECDSA p521',
+                    'oid': '1.3.9999.5.3.6.1',
+                    'code_point': '0xfe41'}]
+  -
+    family: 'SPHINCS-Haraka'
+    variants:
+      -
+        name: 'sphincsharaka128frobust'
+        pretty_name: 'SPHINCS+-Haraka-128f-robust'
+        oqs_meth: 'OQS_SIG_alg_sphincs_haraka_128f_robust'
+        oid: '1.3.9999.6.1.1'
+        code_point: '0xfe42'
+        enable: true
+        mix_with: [{'name': 'p256',
+                    'pretty_name': 'ECDSA p256',
+                    'oid': '1.3.9999.6.1.2',
+                    'code_point': '0xfe43'},
+                   {'name': 'rsa3072',
+                    'pretty_name': 'RSA3072',
+                    'oid': '1.3.9999.6.1.3',
+                    'code_point': '0xfe44'}]
+      -
+        name: 'sphincsharaka128fsimple'
+        pretty_name: 'SPHINCS+-Haraka-128f-simple'
+        oqs_meth: 'OQS_SIG_alg_sphincs_haraka_128f_simple'
+        oid: '1.3.9999.6.1.4'
+        code_point: '0xfe45'
+        enable: false
+        mix_with: [{'name': 'p256',
+                    'pretty_name': 'ECDSA p256',
+                    'oid': '1.3.9999.6.1.5',
+                    'code_point': '0xfe46'},
+                   {'name': 'rsa3072',
+                    'pretty_name': 'RSA3072',
+                    'oid': '1.3.9999.6.1.6',
+                    'code_point': '0xfe47'}]
+      -
+        name: 'sphincsharaka128srobust'
+        pretty_name: 'SPHINCS+-Haraka-128s-robust'
+        oqs_meth: 'OQS_SIG_alg_sphincs_haraka_128s_robust'
+        oid: '1.3.9999.6.1.7'
+        code_point: '0xfe48'
+        enable: false
+        mix_with: [{'name': 'p256',
+                    'pretty_name': 'ECDSA p256',
+                    'oid': '1.3.9999.6.1.8',
+                    'code_point': '0xfe49'},
+                   {'name': 'rsa3072',
+                    'pretty_name': 'RSA3072',
+                    'oid': '1.3.9999.6.1.9',
+                    'code_point': '0xfe4a'}]
+      -
+        name: 'sphincsharaka128ssimple'
+        pretty_name: 'SPHINCS+-Haraka-128s-simple'
+        oqs_meth: 'OQS_SIG_alg_sphincs_haraka_128s_simple'
+        oid: '1.3.9999.6.1.10'
+        code_point: '0xfe4b'
+        enable: false
+        mix_with: [{'name': 'p256',
+                    'pretty_name': 'ECDSA p256',
+                    'oid': '1.3.9999.6.1.11',
+                    'code_point': '0xfe4c'},
+                   {'name': 'rsa3072',
+                    'pretty_name': 'RSA3072',
+                    'oid': '1.3.9999.6.1.12',
+                    'code_point': '0xfe4d'}]
+      -
+        name: 'sphincsharaka192frobust'
+        pretty_name: 'SPHINCS+-Haraka-192f-robust'
+        oqs_meth: 'OQS_SIG_alg_sphincs_haraka_192f_robust'
+        oid: '1.3.9999.6.2.1'
+        code_point: '0xfe4e'
+        enable: false
+        mix_with: [{'name': 'p384',
+                    'pretty_name': 'ECDSA p384',
+                    'oid': '1.3.9999.6.2.2',
+                    'code_point': '0xfe4f'}]
+      -
+        name: 'sphincsharaka192fsimple'
+        pretty_name: 'SPHINCS+-Haraka-192f-simple'
+        oqs_meth: 'OQS_SIG_alg_sphincs_haraka_192f_simple'
+        oid: '1.3.9999.6.2.3'
+        code_point: '0xfe50'
+        enable: false
+        mix_with: [{'name': 'p384',
+                    'pretty_name': 'ECDSA p384',
+                    'oid': '1.3.9999.6.2.4',
+                    'code_point': '0xfe51'}]
+      -
+        name: 'sphincsharaka192srobust'
+        pretty_name: 'SPHINCS+-Haraka-192s-robust'
+        oqs_meth: 'OQS_SIG_alg_sphincs_haraka_192s_robust'
+        oid: '1.3.9999.6.2.5'
+        code_point: '0xfe52'
+        enable: false
+        mix_with: [{'name': 'p384',
+                    'pretty_name': 'ECDSA p384',
+                    'oid': '1.3.9999.6.2.6',
+                    'code_point': '0xfe53'}]
+      -
+        name: 'sphincsharaka192ssimple'
+        pretty_name: 'SPHINCS+-Haraka-192s-simple'
+        oqs_meth: 'OQS_SIG_alg_sphincs_haraka_192s_simple'
+        oid: '1.3.9999.6.2.7'
+        code_point: '0xfe54'
+        enable: false
+        mix_with: [{'name': 'p384',
+                    'pretty_name': 'ECDSA p384',
+                    'oid': '1.3.9999.6.2.8',
+                    'code_point': '0xfe55'}]
+      -
+        name: 'sphincsharaka256frobust'
+        pretty_name: 'SPHINCS+-Haraka-256f-robust'
+        oqs_meth: 'OQS_SIG_alg_sphincs_haraka_256f_robust'
+        oid: '1.3.9999.6.3.1'
+        code_point: '0xfe56'
+        enable: false
+        mix_with: [{'name': 'p521',
+                    'pretty_name': 'ECDSA p521',
+                    'oid': '1.3.9999.6.3.2',
+                    'code_point': '0xfe57'}]
+      -
+        name: 'sphincsharaka256fsimple'
+        pretty_name: 'SPHINCS+-Haraka-256f-simple'
+        oqs_meth: 'OQS_SIG_alg_sphincs_haraka_256f_simple'
+        oid: '1.3.9999.6.3.3'
+        code_point: '0xfe58'
+        enable: false
+        mix_with: [{'name': 'p521',
+                    'pretty_name': 'ECDSA p521',
+                    'oid': '1.3.9999.6.3.4',
+                    'code_point': '0xfe59'}]
+      -
+        name: 'sphincsharaka256srobust'
+        pretty_name: 'SPHINCS+-Haraka-256s-robust'
+        oqs_meth: 'OQS_SIG_alg_sphincs_haraka_256s_robust'
+        oid: '1.3.9999.6.3.5'
+        code_point: '0xfe5a'
+        enable: false
+        mix_with: [{'name': 'p521',
+                    'pretty_name': 'ECDSA p521',
+                    'oid': '1.3.9999.6.3.6',
+                    'code_point': '0xfe5b'}]
+      -
+        name: 'sphincsharaka256ssimple'
+        pretty_name: 'SPHINCS+-Haraka-256s-simple'
+        oqs_meth: 'OQS_SIG_alg_sphincs_haraka_256s_simple'
+        oid: '1.3.9999.6.3.7'
+        code_point: '0xfe5c'
+        enable: false
+        mix_with: [{'name': 'p521',
+                    'pretty_name': 'ECDSA p521',
+                    'oid': '1.3.9999.6.3.8',
+                    'code_point': '0xfe5d'}]
+  -
+    family: 'SPHINCS-SHA256'
+    variants:
+      -
+        name: 'sphincssha256128frobust'
+        pretty_name: 'SPHINCS+-SHA256-128f-robust'
+        oqs_meth: 'OQS_SIG_alg_sphincs_sha256_128f_robust'
+        oid: '1.3.9999.6.4.1'
+        code_point: '0xfe5e'
+        enable: true
+        mix_with: [{'name': 'p256',
+                    'pretty_name': 'ECDSA p256',
+                    'oid': '1.3.9999.6.4.2',
+                    'code_point': '0xfe5f'},
+                   {'name': 'rsa3072',
+                    'pretty_name': 'RSA3072',
+                    'oid': '1.3.9999.6.4.3',
+                    'code_point': '0xfe60'}]
+      -
+        name: 'sphincssha256128fsimple'
+        pretty_name: 'SPHINCS+-SHA256-128f-simple'
+        oqs_meth: 'OQS_SIG_alg_sphincs_sha256_128f_simple'
+        oid: '1.3.9999.6.4.4'
+        code_point: '0xfe61'
+        enable: false
+        mix_with: [{'name': 'p256',
+                    'pretty_name': 'ECDSA p256',
+                    'oid': '1.3.9999.6.4.5',
+                    'code_point': '0xfe62'},
+                   {'name': 'rsa3072',
+                    'pretty_name': 'RSA3072',
+                    'oid': '1.3.9999.6.4.6',
+                    'code_point': '0xfe63'}]
+      -
+        name: 'sphincssha256128srobust'
+        pretty_name: 'SPHINCS+-SHA256-128s-robust'
+        oqs_meth: 'OQS_SIG_alg_sphincs_sha256_128s_robust'
+        oid: '1.3.9999.6.4.7'
+        code_point: '0xfe64'
+        enable: false
+        mix_with: [{'name': 'p256',
+                    'pretty_name': 'ECDSA p256',
+                    'oid': '1.3.9999.6.4.8',
+                    'code_point': '0xfe65'},
+                   {'name': 'rsa3072',
+                    'pretty_name': 'RSA3072',
+                    'oid': '1.3.9999.6.4.9',
+                    'code_point': '0xfe66'}]
+      -
+        name: 'sphincssha256128ssimple'
+        pretty_name: 'SPHINCS+-SHA256-128s-simple'
+        oqs_meth: 'OQS_SIG_alg_sphincs_sha256_128s_simple'
+        oid: '1.3.9999.6.4.10'
+        code_point: '0xfe67'
+        enable: false
+        mix_with: [{'name': 'p256',
+                    'pretty_name': 'ECDSA p256',
+                    'oid': '1.3.9999.6.4.11',
+                    'code_point': '0xfe68'},
+                   {'name': 'rsa3072',
+                    'pretty_name': 'RSA3072',
+                    'oid': '1.3.9999.6.4.12',
+                    'code_point': '0xfe69'}]
+      -
+        name: 'sphincssha256192frobust'
+        pretty_name: 'SPHINCS+-SHA256-192f-robust'
+        oqs_meth: 'OQS_SIG_alg_sphincs_sha256_192f_robust'
+        oid: '1.3.9999.6.5.1'
+        code_point: '0xfe6a'
+        enable: false
+        mix_with: [{'name': 'p384',
+                    'pretty_name': 'ECDSA p384',
+                    'oid': '1.3.9999.6.5.2',
+                    'code_point': '0xfe6b'}]
+      -
+        name: 'sphincssha256192fsimple'
+        pretty_name: 'SPHINCS+-SHA256-192f-simple'
+        oqs_meth: 'OQS_SIG_alg_sphincs_sha256_192f_simple'
+        oid: '1.3.9999.6.5.3'
+        code_point: '0xfe6c'
+        enable: false
+        mix_with: [{'name': 'p384',
+                    'pretty_name': 'ECDSA p384',
+                    'oid': '1.3.9999.6.5.4',
+                    'code_point': '0xfe6d'}]
+      -
+        name: 'sphincssha256192srobust'
+        pretty_name: 'SPHINCS+-SHA256-192s-robust'
+        oqs_meth: 'OQS_SIG_alg_sphincs_sha256_192s_robust'
+        oid: '1.3.9999.6.5.5'
+        code_point: '0xfe6e'
+        enable: false
+        mix_with: [{'name': 'p384',
+                    'pretty_name': 'ECDSA p384',
+                    'oid': '1.3.9999.6.5.6',
+                    'code_point': '0xfe6f'}]
+      -
+        name: 'sphincssha256192ssimple'
+        pretty_name: 'SPHINCS+-SHA256-192s-simple'
+        oqs_meth: 'OQS_SIG_alg_sphincs_sha256_192s_simple'
+        oid: '1.3.9999.6.5.7'
+        code_point: '0xfe70'
+        enable: false
+        mix_with: [{'name': 'p384',
+                    'pretty_name': 'ECDSA p384',
+                    'oid': '1.3.9999.6.5.8',
+                    'code_point': '0xfe71'}]
+      -
+        name: 'sphincssha256256frobust'
+        pretty_name: 'SPHINCS+-SHA256-256f-robust'
+        oqs_meth: 'OQS_SIG_alg_sphincs_sha256_256f_robust'
+        oid: '1.3.9999.6.6.1'
+        code_point: '0xfe72'
+        enable: false
+        mix_with: [{'name': 'p521',
+                    'pretty_name': 'ECDSA p521',
+                    'oid': '1.3.9999.6.6.2',
+                    'code_point': '0xfe73'}]
+      -
+        name: 'sphincssha256256fsimple'
+        pretty_name: 'SPHINCS+-SHA256-256f-simple'
+        oqs_meth: 'OQS_SIG_alg_sphincs_sha256_256f_simple'
+        oid: '1.3.9999.6.6.3'
+        code_point: '0xfe74'
+        enable: false
+        mix_with: [{'name': 'p521',
+                    'pretty_name': 'ECDSA p521',
+                    'oid': '1.3.9999.6.6.4',
+                    'code_point': '0xfe75'}]
+      -
+        name: 'sphincssha256256srobust'
+        pretty_name: 'SPHINCS+-SHA256-256s-robust'
+        oqs_meth: 'OQS_SIG_alg_sphincs_sha256_256s_robust'
+        oid: '1.3.9999.6.6.5'
+        code_point: '0xfe76'
+        enable: false
+        mix_with: [{'name': 'p521',
+                    'pretty_name': 'ECDSA p521',
+                    'oid': '1.3.9999.6.6.6',
+                    'code_point': '0xfe77'}]
+      -
+        name: 'sphincssha256256ssimple'
+        pretty_name: 'SPHINCS+-SHA256-256s-simple'
+        oqs_meth: 'OQS_SIG_alg_sphincs_sha256_256s_simple'
+        oid: '1.3.9999.6.6.7'
+        code_point: '0xfe78'
+        enable: false
+        mix_with: [{'name': 'p521',
+                    'pretty_name': 'ECDSA p521',
+                    'oid': '1.3.9999.6.6.8',
+                    'code_point': '0xfe79'}]
+  -
+    family: 'SPHINCS-SHAKE256'
+    variants:
+      -
+        name: 'sphincsshake256128frobust'
+        pretty_name: 'SPHINCS+-SHAKE256-128f-robust'
+        oqs_meth: 'OQS_SIG_alg_sphincs_shake256_128f_robust'
+        oid: '1.3.9999.6.7.1'
+        code_point: '0xfe7a'
+        enable: true
+        mix_with: [{'name': 'p256',
+                    'pretty_name': 'ECDSA p256',
+                    'oid': '1.3.9999.6.7.2',
+                    'code_point': '0xfe7b'},
+                   {'name': 'rsa3072',
+                    'pretty_name': 'RSA3072',
+                    'oid': '1.3.9999.6.7.3',
+                    'code_point': '0xfe7c'}]
+      -
+        name: 'sphincsshake256128fsimple'
+        pretty_name: 'SPHINCS+-SHAKE256-128f-simple'
+        oqs_meth: 'OQS_SIG_alg_sphincs_shake256_128f_simple'
+        oid: '1.3.9999.6.7.4'
+        code_point: '0xfe7d'
+        enable: false
+        mix_with: [{'name': 'p256',
+                    'pretty_name': 'ECDSA p256',
+                    'oid': '1.3.9999.6.7.5',
+                    'code_point': '0xfe7e'},
+                   {'name': 'rsa3072',
+                    'pretty_name': 'RSA3072',
+                    'oid': '1.3.9999.6.7.6',
+                    'code_point': '0xfe7f'}]
+      -
+        name: 'sphincsshake256128srobust'
+        pretty_name: 'SPHINCS+-SHAKE256-128s-robust'
+        oqs_meth: 'OQS_SIG_alg_sphincs_shake256_128s_robust'
+        oid: '1.3.9999.6.7.7'
+        code_point: '0xfe80'
+        enable: false
+        mix_with: [{'name': 'p256',
+                    'pretty_name': 'ECDSA p256',
+                    'oid': '1.3.9999.6.7.8',
+                    'code_point': '0xfe81'},
+                   {'name': 'rsa3072',
+                    'pretty_name': 'RSA3072',
+                    'oid': '1.3.9999.6.7.9',
+                    'code_point': '0xfe82'}]
+      -
+        name: 'sphincsshake256128ssimple'
+        pretty_name: 'SPHINCS+-SHAKE256-128s-simple'
+        oqs_meth: 'OQS_SIG_alg_sphincs_shake256_128s_simple'
+        oid: '1.3.9999.6.7.10'
+        code_point: '0xfe83'
+        enable: false
+        mix_with: [{'name': 'p256',
+                    'pretty_name': 'ECDSA p256',
+                    'oid': '1.3.9999.6.7.11',
+                    'code_point': '0xfe84'},
+                   {'name': 'rsa3072',
+                    'pretty_name': 'RSA3072',
+                    'oid': '1.3.9999.6.7.12',
+                    'code_point': '0xfe85'}]
+      -
+        name: 'sphincsshake256192frobust'
+        pretty_name: 'SPHINCS+-SHAKE256-192f-robust'
+        oqs_meth: 'OQS_SIG_alg_sphincs_shake256_192f_robust'
+        oid: '1.3.9999.6.8.1'
+        code_point: '0xfe86'
+        enable: false
+        mix_with: [{'name': 'p384',
+                    'pretty_name': 'ECDSA p384',
+                    'oid': '1.3.9999.6.8.2',
+                    'code_point': '0xfe87'}]
+      -
+        name: 'sphincsshake256192fsimple'
+        pretty_name: 'SPHINCS+-SHAKE256-192f-simple'
+        oqs_meth: 'OQS_SIG_alg_sphincs_shake256_192f_simple'
+        oid: '1.3.9999.6.8.3'
+        code_point: '0xfe88'
+        enable: false
+        mix_with: [{'name': 'p384',
+                    'pretty_name': 'ECDSA p384',
+                    'oid': '1.3.9999.6.8.4',
+                    'code_point': '0xfe89'}]
+      -
+        name: 'sphincsshake256192srobust'
+        pretty_name: 'SPHINCS+-SHAKE256-192s-robust'
+        oqs_meth: 'OQS_SIG_alg_sphincs_shake256_192s_robust'
+        oid: '1.3.9999.6.8.5'
+        code_point: '0xfe8a'
+        enable: false
+        mix_with: [{'name': 'p384',
+                    'pretty_name': 'ECDSA p384',
+                    'oid': '1.3.9999.6.8.6',
+                    'code_point': '0xfe8b'}]
+      -
+        name: 'sphincsshake256192ssimple'
+        pretty_name: 'SPHINCS+-SHAKE256-192s-simple'
+        oqs_meth: 'OQS_SIG_alg_sphincs_shake256_192s_simple'
+        oid: '1.3.9999.6.8.7'
+        code_point: '0xfe8c'
+        enable: false
+        mix_with: [{'name': 'p384',
+                    'pretty_name': 'ECDSA p384',
+                    'oid': '1.3.9999.6.8.8',
+                    'code_point': '0xfe8d'}]
+      -
+        name: 'sphincsshake256256frobust'
+        pretty_name: 'SPHINCS+-SHAKE256-256f-robust'
+        oqs_meth: 'OQS_SIG_alg_sphincs_shake256_256f_robust'
+        oid: '1.3.9999.6.9.1'
+        code_point: '0xfe8e'
+        enable: false
+        mix_with: [{'name': 'p521',
+                    'pretty_name': 'ECDSA p521',
+                    'oid': '1.3.9999.6.9.2',
+                    'code_point': '0xfe8f'}]
+      -
+        name: 'sphincsshake256256fsimple'
+        pretty_name: 'SPHINCS+-SHAKE256-256f-simple'
+        oqs_meth: 'OQS_SIG_alg_sphincs_shake256_256f_simple'
+        oid: '1.3.9999.6.9.3'
+        code_point: '0xfe90'
+        enable: false
+        mix_with: [{'name': 'p521',
+                    'pretty_name': 'ECDSA p521',
+                    'oid': '1.3.9999.6.9.4',
+                    'code_point': '0xfe91'}]
+      -
+        name: 'sphincsshake256256srobust'
+        pretty_name: 'SPHINCS+-SHAKE256-256s-robust'
+        oqs_meth: 'OQS_SIG_alg_sphincs_shake256_256s_robust'
+        oid: '1.3.9999.6.9.5'
+        code_point: '0xfe92'
+        enable: false
+        mix_with: [{'name': 'p521',
+                    'pretty_name': 'ECDSA p521',
+                    'oid': '1.3.9999.6.9.6',
+                    'code_point': '0xfe93'}]
+      -
+        name: 'sphincsshake256256ssimple'
+        pretty_name: 'SPHINCS+-SHAKE256-256s-simple'
+        oqs_meth: 'OQS_SIG_alg_sphincs_shake256_256s_simple'
+        oid: '1.3.9999.6.9.7'
+        code_point: '0xfe94'
+        enable: false
+        mix_with: [{'name': 'p521',
+                    'pretty_name': 'ECDSA p521',
+                    'oid': '1.3.9999.6.9.8',
+                    'code_point': '0xfe95'}]

--- a/scripts/revertmain.sh
+++ b/scripts/revertmain.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# This script reverts to a possibly set "main" code generator script
+
+if [ -f oqs-template/generate.yml-main ]; then
+    rm -rf liboqs && git clone --depth 1 --branch main https://github.com/open-quantum-safe/liboqs.git
+    mv oqs-template/generate.yml-main oqs-template/generate.yml
+    LIBOQS_SRC_DIR=`pwd`/liboqs python3 oqs-template/generate.py
+    if [ $? -ne 0 ]; then
+       echo "Code generation failure for main branch. Exiting."
+       exit -1
+    fi
+    # remove liboqs.a to ensure rebuild against newly generated code
+    rm .local/lib/liboqs.a
+    git status
+fi
+


### PR DESCRIPTION
This adds configuration, code and documentation to facilitate building and possibly releasing `oqsprovider` against a specific `liboqs` version (not in line with the respective projects' `main` branch).
