### PR TITLE
commithash in version

### DIFF
--- a/oqsprov/CMakeLists.txt
+++ b/oqsprov/CMakeLists.txt
@@ -1,5 +1,12 @@
 include(GNUInstallDirs)
+execute_process(
+  COMMAND git log -1 --format=%h
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+  OUTPUT_VARIABLE GIT_COMMIT_HASH
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+)
 add_definitions(-DOQSPROVIDER_VERSION_TEXT="${OQSPROVIDER_VERSION_TEXT}")
+add_definitions(-DOQS_PROVIDER_COMMIT=" \(${GIT_COMMIT_HASH}\)")
 add_compile_options(-Wunused-function)
 set(PROVIDER_SOURCE_FILES
   oqsprov.c oqsprov_capabilities.c oqsprov_keys.c

--- a/oqsprov/CMakeLists.txt
+++ b/oqsprov/CMakeLists.txt
@@ -6,6 +6,7 @@ execute_process(
   OUTPUT_STRIP_TRAILING_WHITESPACE
 )
 add_definitions(-DOQSPROVIDER_VERSION_TEXT="${OQSPROVIDER_VERSION_TEXT}")
+message(STATUS "Building commit ${GIT_COMMIT_HASH} in ${CMAKE_SOURCE_DIR}")
 add_definitions(-DOQS_PROVIDER_COMMIT=" \(${GIT_COMMIT_HASH}\)")
 add_compile_options(-Wunused-function)
 set(PROVIDER_SOURCE_FILES

--- a/oqsprov/oqsprov.c
+++ b/oqsprov/oqsprov.c
@@ -419,7 +419,7 @@ static const OSSL_PARAM *oqsprovider_gettable_params(void *provctx)
     return oqsprovider_param_types;
 }
 
-#define OQS_PROVIDER_BUILD_INFO_STR "OQS Provider v." OQS_PROVIDER_VERSION_STR " based on liboqs v." OQS_VERSION_TEXT
+#define OQS_PROVIDER_BUILD_INFO_STR "OQS Provider v." OQS_PROVIDER_VERSION_STR OQS_PROVIDER_COMMIT " based on liboqs v." OQS_VERSION_TEXT
 
 static int oqsprovider_get_params(void *provctx, OSSL_PARAM params[])
 {


### PR DESCRIPTION
As `oqs-provider` releases are currently not done more frequently than `liboqs` releases, significant provider functionality deviations exist within versions/that are not visible in the externally displayed version information.

This PR adds information about the commit hash to remedy this situation.

