### PR TITLE
Change oqsprovider target from MODULE to SHARED

### DIFF
--- a/oqsprov/CMakeLists.txt
+++ b/oqsprov/CMakeLists.txt
@@ -18,7 +18,7 @@ set(PROVIDER_SOURCE_FILES
 set(PROVIDER_HEADER_FILES
   oqs_prov.h oqs_endecoder_local.h
 )
-add_library(oqsprovider MODULE ${PROVIDER_SOURCE_FILES})
+add_library(oqsprovider SHARED ${PROVIDER_SOURCE_FILES})
 set_target_properties(oqsprovider
     PROPERTIES
     PREFIX ""


### PR DESCRIPTION
On macOS / Apple clang version 14.0.0, I get the following error when compiling oqsprovider:

```
clang: error: invalid argument '-compatibility_version 1.0.0' only allowed with '-dynamiclib'
make[2]: *** [lib/oqsprovider.so] Error 1
make[1]: *** [oqsprov/CMakeFiles/oqsprovider.dir/all] Error 2
make: *** [all] Error 2
```

Looking at the answer in https://stackoverflow.com/questions/42183903/cmake-wont-create-so-version-and-soversion-symlinks, `VERSION` and `SOVERSION` seem to not be compatible with MODULE targets.

Therefore this PR changes the oqsprovider cmake target MODULE to SHARED. This way the build passes on macOS.