### PR TITLE
Standalone build

### DIFF
--- a/.github/workflows/standalone.yml
+++ b/.github/workflows/standalone.yml
@@ -1,0 +1,27 @@
+name: Tests using distributions with OpenSSL3 binaries
+
+on: [push]
+
+jobs:
+
+  linux_intel:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: jammy
+            container: ubuntu:latest
+    container:
+      image: ${{ matrix.container }}
+    env:
+      MAKE_PARAMS: "-j 18"
+    steps:
+      - name: Update container
+        run: apt update && apt install cmake ninja-build gcc libssl-dev git
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Full build
+        run: ./scripts/fullbuild.sh
+      - name: Test
+        run: ./scripts/runtests.sh -V

--- a/.github/workflows/standalone.yml
+++ b/.github/workflows/standalone.yml
@@ -18,7 +18,7 @@ jobs:
       MAKE_PARAMS: "-j 18"
     steps:
       - name: Update container
-        run: apt update && apt install cmake ninja-build gcc libssl-dev git
+        run: apt update && apt install -y cmake ninja-build gcc libssl-dev git
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Full build

--- a/README.md
+++ b/README.md
@@ -82,6 +82,14 @@ All component builds and testing described in detail below can be executed by
 running the scripts `scripts/fullbuild.sh` and `scripts/runtests.sh`
 respectively (tested on Linux Ubuntu and Mint as well as OSX).
 
+By default, these scripts always build and test against the current OpenSSL `master` branch.
+
+These scripts can be configured by setting various environment variables as documented in the scripts.
+For information the following environment settings may be of most interest:
+
+- OPENSSL_INSTALL: Directory of an existing, non-standard OpenSSL binary distribution
+- OPENSSL_BRANCH: Tag of a specific OpenSSL release to be built and used in testing
+
 
 Building and testing
 --------------------
@@ -98,7 +106,8 @@ For Linux these commands can typically be installed by running for example
 
 ### OpenSSL 3
 
-Example for building and installing OpenSSL 3 in `.local`:
+If OpenSSL3 is not already installed, the following shows an example for building
+and installing the latest/`master` branch of OpenSSL 3 in `.local`:
 
     git clone git://git.openssl.org/openssl.git
     cd openssl
@@ -199,7 +208,7 @@ explanations can be found for example
 Another alternative is to explicitly request its use on the command line.
 The following examples use that option. All examples below assume openssl (3.0)
 to be located in a folder `.local` in the local directory as per the
-building examples above. Installing openssl(3.0) in a standard location
+building examples above. Having OpenSSL(3) installed in a standard location
 eliminates the need for specific PATH setting as showcased below.
 
 ## Checking provider version information
@@ -338,9 +347,8 @@ used during TLS1.3 operations as documented in https://github.com/openssl/openss
 ## 3.2(-dev)
 
 After https://github.com/openssl/openssl/pull/19312 landed, (also PQ) signature
-algorithms are working in TLS1.3 (handshaking), but algorithms with overly long
-signatures may still fail due to specific message size limitations built into
-OpenSSL and/or the TLS specifications.
+algorithms are working in TLS1.3 (handshaking); after https://github.com/openssl/openssl/pull/20486
+has landed, also algorithms with very long signatures are supported.
 
 liboqs dependency
 -----------------

--- a/scripts/fullbuild.sh
+++ b/scripts/fullbuild.sh
@@ -91,11 +91,12 @@ fi
 if [ ! -f "_build/oqsprov/oqsprovider.so" ]; then
    echo "oqsprovider not built: Building..."
    # for full debug build add: -DCMAKE_BUILD_TYPE=Debug
+   BUILD_TYPE=""
    # for omitting public key in private keys add -DNOPUBKEY_IN_PRIVKEY=ON
    if [ -z "$OPENSSL_INSTALL" ]; then
-       cmake -DOPENSSL_ROOT_DIR=$(pwd)/.local -DCMAKE_PREFIX_PATH=$(pwd)/.local -S . -B _build && cmake --build _build
+       cmake -DOPENSSL_ROOT_DIR=$(pwd)/.local $BUILD_TYPE -DCMAKE_PREFIX_PATH=$(pwd)/.local -S . -B _build && cmake --build _build
    else
-       cmake -DOPENSSL_ROOT_DIR=$OPENSSL_INSTALL -DCMAKE_PREFIX_PATH=$(pwd)/.local -S . -B _build && cmake --build _build
+       cmake -DOPENSSL_ROOT_DIR=$OPENSSL_INSTALL $BUILD_TYPE -DCMAKE_PREFIX_PATH=$(pwd)/.local -S . -B _build && cmake --build _build
    fi
    if [ $? -ne 0 ]; then
      echo "provider build failed. Exiting."

--- a/scripts/oqsprovider-certgen.sh
+++ b/scripts/oqsprovider-certgen.sh
@@ -24,9 +24,9 @@ fi
 
 #rm -rf tmp
 mkdir -p tmp
-$OPENSSL_APP req -x509 -new -newkey $1 -keyout tmp/$1_CA.key -out tmp/$1_CA.crt -nodes -subj "/CN=oqstest CA" -days 365 -config $OPENSSL_APP.cnf -provider oqsprovider -provider default && \
+$OPENSSL_APP req -x509 -new -newkey $1 -keyout tmp/$1_CA.key -out tmp/$1_CA.crt -nodes -subj "/CN=oqstest CA" -days 365 -provider oqsprovider -provider default && \
 $OPENSSL_APP genpkey -algorithm $1 -out tmp/$1_srv.key -provider oqsprovider -provider default && \
-$OPENSSL_APP req -new -newkey $1 -keyout tmp/$1_srv.key -out tmp/$1_srv.csr -nodes -subj "/CN=oqstest server" -config $OPENSSL_APP.cnf -provider oqsprovider -provider default && \
+$OPENSSL_APP req -new -newkey $1 -keyout tmp/$1_srv.key -out tmp/$1_srv.csr -nodes -subj "/CN=oqstest server" -provider oqsprovider -provider default && \
 $OPENSSL_APP x509 -req -in tmp/$1_srv.csr -out tmp/$1_srv.crt -CA tmp/$1_CA.crt -CAkey tmp/$1_CA.key -CAcreateserial -days 365 -provider oqsprovider -provider default && \
 $OPENSSL_APP verify -provider oqsprovider -provider default -CAfile tmp/$1_CA.crt tmp/$1_srv.crt
 

--- a/scripts/oqsprovider-certverify.sh
+++ b/scripts/oqsprovider-certverify.sh
@@ -24,7 +24,7 @@ fi
 
 # check that CSR can be output OK
 
-$OPENSSL_APP req -text -in tmp/$1_srv.csr -noout -provider oqsprovider -provider default -config $OPENSSL_APP.cnf 2>&1 | grep Error
+$OPENSSL_APP req -text -in tmp/$1_srv.csr -noout -provider oqsprovider -provider default 2>&1 | grep Error
 if [ $? -eq 0 ]; then
     echo "Couldn't print CSR correctly. Exiting."
     exit 1

--- a/scripts/runtests.sh
+++ b/scripts/runtests.sh
@@ -64,9 +64,6 @@ if [ ! -z "$OPENSSL_INSTALL" ]; then
     if [ -f $OPENSSL_INSTALL/ssl/openssl.cnf ]; then
         export OPENSSL_CONF=$OPENSSL_INSTALL/ssl/openssl.cnf
     fi
-else
-    # removing the need to pass explicit -conf parameter to all tests:
-    export OPENSSL_CONF=$OQS_PROVIDER_TESTSCRIPTS/openssl-ca.cnf
 fi
 
 if [ -z "$OPENSSL_APP" ]; then
@@ -93,6 +90,7 @@ echo "Test setup:"
 echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH"
 echo "OPENSSL_APP=$OPENSSL_APP"
 echo "OPENSSL_CONF=$OPENSSL_CONF"
+echo "OPENSSL_MODULES=$OPENSSL_MODULES"
 
 # check if we can use docker or not:
 docker info 2>&1 | grep Server > /dev/null
@@ -106,8 +104,6 @@ fi
 # comment the following line if they should be run; be sure to
 # have alignment in algorithms supported in that case
 export LOCALTESTONLY="Yes"
-
-echo "OpenSSL app: $OPENSSL_APP"
 
 echo "Version information:"
 $OPENSSL_APP version

--- a/scripts/runtests.sh
+++ b/scripts/runtests.sh
@@ -18,6 +18,7 @@ localalgtest() {
     $OQS_PROVIDER_TESTSCRIPTS/oqsprovider-certgen.sh $1 >> interop.log 2>&1 && $OQS_PROVIDER_TESTSCRIPTS/oqsprovider-certverify.sh $1 >> interop.log 2>&1 && $OQS_PROVIDER_TESTSCRIPTS/oqsprovider-cmssign.sh $1 >> interop.log 2>&1 &&  $OQS_PROVIDER_TESTSCRIPTS/oqsprovider-ca.sh $1 >> interop.log 2>&1
     if [ $? -ne 0 ]; then
         echo "localalgtest $1 failed. Exiting.".
+        cat interop.log
         exit 1
     fi
 }
@@ -67,7 +68,7 @@ if [ ! -z "$OPENSSL_INSTALL" ]; then
     fi
 else
     if [ -z "$OPENSSL_CONF" ]; then
-        export OPENSSL_CONF=$(pwd)/test/oqs.cnf
+        export OPENSSL_CONF=$(pwd)/scripts/openssl-ca.cnf
     fi
 fi
 

--- a/scripts/runtests.sh
+++ b/scripts/runtests.sh
@@ -54,10 +54,16 @@ if [ -z "$OQS_PROVIDER_TESTSCRIPTS" ]; then
 fi
 
 if [ ! -z "$OPENSSL_INSTALL" ]; then
-    # setting config variables suitably for pre-existing OpenSSL installation
-    export OPENSSL_APP=$OPENSSL_INSTALL/bin/openssl
-    export LD_LIBRARY_PATH=$OPENSSL_INSTALL/lib64
-    export OPENSSL_CONF=$OPENSSL_INSTALL/ssl/openssl.cnf
+    # trying to set config variables suitably for pre-existing OpenSSL installation
+    if [ -f $OPENSSL_INSTALL/bin/openssl ]; then
+        export OPENSSL_APP=$OPENSSL_INSTALL/bin/openssl
+    fi
+    if [ -d $OPENSSL_INSTALL/lib64 ]; then
+        export LD_LIBRARY_PATH=$OPENSSL_INSTALL/lib64
+    fi
+    if [ -f $OPENSSL_INSTALL/ssl/openssl.cnf ]; then
+        export OPENSSL_CONF=$OPENSSL_INSTALL/ssl/openssl.cnf
+    fi
 else
     # removing the need to pass explicit -conf parameter to all tests:
     export OPENSSL_CONF=$OQS_PROVIDER_TESTSCRIPTS/openssl-ca.cnf

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -10,6 +10,7 @@ set_tests_properties(oqs_signatures
 )
 
 add_executable(oqs_test_signatures oqs_test_signatures.c test_common.c)
+target_include_directories(oqs_test_signatures PRIVATE ${CMAKE_SOURCE_DIR}/.local/include)
 target_link_libraries(oqs_test_signatures ${OPENSSL_CRYPTO_LIBRARY})
 
 add_test(
@@ -23,6 +24,7 @@ set_tests_properties(oqs_kems
 )
 
 add_executable(oqs_test_kems oqs_test_kems.c test_common.c)
+target_include_directories(oqs_test_kems PRIVATE ${CMAKE_SOURCE_DIR}/.local/include)
 target_link_libraries(oqs_test_kems ${OPENSSL_CRYPTO_LIBRARY})
 
 if (NOT DEFINED OPENSSL_BLDTOP)
@@ -30,7 +32,7 @@ if (NOT DEFINED OPENSSL_BLDTOP)
 endif()
 
 if (NOT IS_DIRECTORY ${OPENSSL_BLDTOP})
-    message(WARNING "OpenSSL build directory '${OPENSSL_BLDTOP}' not present. Some dependent tests will be skipped.") 
+    message(WARNING "OpenSSL source build directory '${OPENSSL_BLDTOP}' not present. Some dependent tests will be skipped.") 
 else()
 add_test(
     NAME oqs_groups

--- a/test/README.md
+++ b/test/README.md
@@ -1,4 +1,4 @@
 # oqs-provider testing
 
-The tests in this folder are running separately from the OpenSSL test framework but utilize some of its plumbing. Therefore the OpenSSL code base, incl. its "test" directory must be locally available. The script `../scripts/fullbuild.sh`ensures this.
+The tests in this folder are running separately from the OpenSSL test framework, but smoe tests utilize some of its plumbing. Therefore the OpenSSL code base, incl. its "test" directory must be locally available for all tests to be executed. The script `../scripts/fullbuild.sh` ensures this if no explicit hint to an OpenSSL binary installation is given (via the environment variable "OPENSSL_INSTALL").
 

--- a/test/README.md
+++ b/test/README.md
@@ -1,4 +1,4 @@
 # oqs-provider testing
 
-The tests in this folder are running separately from the OpenSSL test framework, but smoe tests utilize some of its plumbing. Therefore the OpenSSL code base, incl. its "test" directory must be locally available for all tests to be executed. The script `../scripts/fullbuild.sh` ensures this if no explicit hint to an OpenSSL binary installation is given (via the environment variable "OPENSSL_INSTALL").
+The tests in this folder are running separately from the OpenSSL test framework, but some tests utilize some of its plumbing. Therefore the OpenSSL code base, incl. its "test" directory must be locally available for all tests to be executed. The script `../scripts/fullbuild.sh` ensures this if no explicit hint to an OpenSSL binary installation is given (via the environment variable "OPENSSL_INSTALL").
 


### PR DESCRIPTION
Fixes #136 

Also adds option to build specific OpenSSL release.

Also fixes 
- incorrect error return on `ctest` failure (as documented in https://github.com/open-quantum-safe/oqs-provider/issues/132#issuecomment-1488851771)
- bad use of OPENSSL_CONF in scripts (also thanks to @mouse07410 for highlighting that)
