### PR TITLE
Removed dependency on internal ssltestlib

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,6 +380,7 @@ Contributors to the `oqsprovider` include:
 - Richard Levitte
 - Basil Hess
 - Julian Segeth
+- Alex Zaslavsky
 
 Acknowledgments
 ---------------

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -51,7 +51,7 @@ target_include_directories(oqs_test_groups PRIVATE ${OPENSSL_BLDTOP})
 target_include_directories(oqs_test_groups PRIVATE ${OPENSSL_BLDTOP}/include)
 target_include_directories(oqs_test_groups PRIVATE ${OPENSSL_BLDTOP}/test)
 target_include_directories(oqs_test_groups PRIVATE ${OPENSSL_BLDTOP}/apps/include)
-target_link_libraries(oqs_test_groups ${OPENSSL_SSL_LIBRARY} ${OPENSSL_CRYPTO_LIBRARY} ${OPENSSL_BLDTOP}/test/libtestutil.a)
+target_link_libraries(oqs_test_groups ${OPENSSL_SSL_LIBRARY} ${OPENSSL_CRYPTO_LIBRARY})
 
 add_test(
     NAME oqs_tlssig
@@ -71,7 +71,7 @@ target_include_directories(oqs_test_tlssig PRIVATE ${OPENSSL_BLDTOP})
 target_include_directories(oqs_test_tlssig PRIVATE ${OPENSSL_BLDTOP}/include)
 target_include_directories(oqs_test_tlssig PRIVATE ${OPENSSL_BLDTOP}/test)
 target_include_directories(oqs_test_tlssig PRIVATE ${OPENSSL_BLDTOP}/apps/include)
-target_link_libraries(oqs_test_tlssig ${OPENSSL_SSL_LIBRARY} ${OPENSSL_CRYPTO_LIBRARY} ${OPENSSL_BLDTOP}/test/libtestutil.a)
+target_link_libraries(oqs_test_tlssig ${OPENSSL_SSL_LIBRARY} ${OPENSSL_CRYPTO_LIBRARY})
 
 add_executable(oqs_test_endecode oqs_test_endecode.c test_common.c)
 target_include_directories(oqs_test_endecode PRIVATE ${OPENSSL_BLDTOP}/include)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -45,7 +45,7 @@ add_test(
 set_tests_properties(oqs_groups
     PROPERTIES ENVIRONMENT "OPENSSL_MODULES=${CMAKE_BINARY_DIR}/lib"
 )
-add_executable(oqs_test_groups oqs_test_groups.c test_common.c ${OPENSSL_BLDTOP}/test/helpers/ssltestlib.c)
+add_executable(oqs_test_groups oqs_test_groups.c test_common.c tlstest_helpers.c)
 # e_os.h resides in top-level for OSSL3:
 target_include_directories(oqs_test_groups PRIVATE ${OPENSSL_BLDTOP})
 target_include_directories(oqs_test_groups PRIVATE ${OPENSSL_BLDTOP}/include)
@@ -65,7 +65,7 @@ set_tests_properties(oqs_tlssig
     # Some algorithms known to overflow OpenSSL limits; TBD/resolved upstream
     PROPERTIES ENVIRONMENT "OPENSSL_MODULES=${CMAKE_BINARY_DIR}/lib;OQS_SKIP_TESTS=picnicl1full,rainbowVclassic,sphincs"
 )
-add_executable(oqs_test_tlssig oqs_test_tlssig.c test_common.c ${OPENSSL_BLDTOP}/test/helpers/ssltestlib.c)
+add_executable(oqs_test_tlssig oqs_test_tlssig.c test_common.c tlstest_helpers.c)
 # e_os.h resides in top-level for OSSL3:
 target_include_directories(oqs_test_tlssig PRIVATE ${OPENSSL_BLDTOP})
 target_include_directories(oqs_test_tlssig PRIVATE ${OPENSSL_BLDTOP}/include)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -46,11 +46,6 @@ set_tests_properties(oqs_groups
     PROPERTIES ENVIRONMENT "OPENSSL_MODULES=${CMAKE_BINARY_DIR}/lib"
 )
 add_executable(oqs_test_groups oqs_test_groups.c test_common.c tlstest_helpers.c)
-# e_os.h resides in top-level for OSSL3:
-target_include_directories(oqs_test_groups PRIVATE ${OPENSSL_BLDTOP})
-target_include_directories(oqs_test_groups PRIVATE ${OPENSSL_BLDTOP}/include)
-target_include_directories(oqs_test_groups PRIVATE ${OPENSSL_BLDTOP}/test)
-target_include_directories(oqs_test_groups PRIVATE ${OPENSSL_BLDTOP}/apps/include)
 target_link_libraries(oqs_test_groups ${OPENSSL_SSL_LIBRARY} ${OPENSSL_CRYPTO_LIBRARY})
 
 add_test(
@@ -66,11 +61,6 @@ set_tests_properties(oqs_tlssig
     PROPERTIES ENVIRONMENT "OPENSSL_MODULES=${CMAKE_BINARY_DIR}/lib;OQS_SKIP_TESTS=picnicl1full,rainbowVclassic,sphincs"
 )
 add_executable(oqs_test_tlssig oqs_test_tlssig.c test_common.c tlstest_helpers.c)
-# e_os.h resides in top-level for OSSL3:
-target_include_directories(oqs_test_tlssig PRIVATE ${OPENSSL_BLDTOP})
-target_include_directories(oqs_test_tlssig PRIVATE ${OPENSSL_BLDTOP}/include)
-target_include_directories(oqs_test_tlssig PRIVATE ${OPENSSL_BLDTOP}/test)
-target_include_directories(oqs_test_tlssig PRIVATE ${OPENSSL_BLDTOP}/apps/include)
 target_link_libraries(oqs_test_tlssig ${OPENSSL_SSL_LIBRARY} ${OPENSSL_CRYPTO_LIBRARY})
 
 add_executable(oqs_test_endecode oqs_test_endecode.c test_common.c)

--- a/test/oqs_test_groups.c
+++ b/test/oqs_test_groups.c
@@ -3,7 +3,7 @@
 #include <openssl/provider.h>
 #include <openssl/ssl.h>
 #include <string.h>
-#include "helpers/ssltestlib.h"
+#include "tlstest_helpers.h"
 #include "test_common.h"
 #include <openssl/core_names.h>
 
@@ -45,15 +45,13 @@ static int test_oqs_groups(const char *group_name)
      return 1;
   }
   testresult =
-    create_ssl_ctx_pair(libctx, TLS_server_method(), TLS_client_method(),
-                        TLS1_3_VERSION, TLS1_3_VERSION,
-                        &sctx, &cctx, cert, privkey);
+    create_tls1_3_ctx_pair(libctx, &sctx, &cctx, cert, privkey);
   if (!testresult) {
       ret = -1; goto err;
   }
 
   testresult =
-    create_ssl_objects(sctx, cctx, &serverssl, &clientssl, NULL, NULL);
+    create_tls_objects(sctx, cctx, &serverssl, &clientssl);
 
   if (!testresult) {
       ret = -2; goto err;
@@ -72,7 +70,7 @@ static int test_oqs_groups(const char *group_name)
   }
 
   testresult =
-    create_ssl_connection(serverssl, clientssl, SSL_ERROR_NONE);
+    create_tls_connection(serverssl, clientssl, SSL_ERROR_NONE);
   if (!testresult) {
       ret = -5; goto err;
   }

--- a/test/oqs_test_tlssig.c
+++ b/test/oqs_test_tlssig.c
@@ -3,7 +3,7 @@
 #include <openssl/provider.h>
 #include <openssl/ssl.h>
 #include <string.h>
-#include "helpers/ssltestlib.h"
+#include "tlstest_helpers.h"
 #include "test_common.h"
 #include <openssl/core_names.h>
 
@@ -36,23 +36,21 @@ static int test_oqs_tlssig(const char *sig_name)
   sprintf(certpath, "%s%s%s%s", certsdir, sep, sig_name, "_srv.crt");
   sprintf(privkeypath, "%s%s%s%s", certsdir, sep, sig_name, "_srv.key");
   testresult =
-    create_ssl_ctx_pair(libctx, TLS_server_method(), TLS_client_method(),
-                        TLS1_3_VERSION, TLS1_3_VERSION,
-                        &sctx, &cctx, certpath, privkeypath);
+    create_tls1_3_ctx_pair(libctx, &sctx, &cctx, certpath, privkeypath);
 
   if (!testresult) {
       ret = -1; goto err;
   }
 
   testresult =
-    create_ssl_objects(sctx, cctx, &serverssl, &clientssl, NULL, NULL);
+    create_tls_objects(sctx, cctx, &serverssl, &clientssl);
 
   if (!testresult) {
       ret = -2; goto err;
   }
 
   testresult =
-    create_ssl_connection(serverssl, clientssl, SSL_ERROR_NONE);
+    create_tls_connection(serverssl, clientssl, SSL_ERROR_NONE);
   if (!testresult) {
       ret = -5; goto err;
   }

--- a/test/tlstest_helpers.c
+++ b/test/tlstest_helpers.c
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0 AND MIT
 #include <openssl/ssl.h>
 #include <openssl/err.h>
-#include "testutil.h"
 
 
 #define MAXLOOPS    1000000
@@ -112,9 +111,9 @@ int create_bare_tls_connection(SSL *serverssl, SSL *clientssl, int want,
         }
 
         if (!clienterr && retc <= 0 && err != SSL_ERROR_WANT_READ) {
-            TEST_info("SSL_connect() failed %d, %d", retc, err);
+            fprintf(stderr, "SSL_connect() failed %d, %d", retc, err);
             if (want != SSL_ERROR_SSL)
-                TEST_openssl_errors();
+                ERR_clear_error();
             clienterr = 1;
         }
         if (want != SSL_ERROR_NONE && err == want)
@@ -130,9 +129,9 @@ int create_bare_tls_connection(SSL *serverssl, SSL *clientssl, int want,
         if (!servererr && rets <= 0
             && err != SSL_ERROR_WANT_READ
             && err != SSL_ERROR_WANT_X509_LOOKUP) {
-            TEST_info("SSL_accept() failed %d, %d", rets, err);
+            fprintf(stderr, "SSL_accept() failed %d, %d", rets, err);
             if (want != SSL_ERROR_SSL)
-                TEST_openssl_errors();
+                ERR_clear_error();
             servererr = 1;
         }
         if (want != SSL_ERROR_NONE && err == want)
@@ -141,7 +140,7 @@ int create_bare_tls_connection(SSL *serverssl, SSL *clientssl, int want,
             return 0;
 
         if (++abortctr == MAXLOOPS) {
-            TEST_info("No progress made");
+            fprintf(stderr, "No progress made");
             return 0;
         }
 
@@ -170,10 +169,9 @@ int create_tls_connection(SSL *serverssl, SSL *clientssl, int want)
      */
     for (i = 0; i < 2; i++) {
         if (SSL_read_ex(clientssl, &buf, sizeof(buf), &readbytes) > 0) {
-            if (!TEST_ulong_eq(readbytes, 0))
+            if (readbytes !=0)
                 return 0;
-        } else if (!TEST_int_eq(SSL_get_error(clientssl, 0),
-                                SSL_ERROR_WANT_READ)) {
+        } else if (SSL_get_error(clientssl, 0) != SSL_ERROR_WANT_READ) {
             return 0;
         }
     }

--- a/test/tlstest_helpers.c
+++ b/test/tlstest_helpers.c
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: Apache-2.0 AND MIT
+#include <openssl/ssl.h>
+#include <openssl/err.h>
+#include "testutil.h"
+
+
+#define MAXLOOPS    1000000
+
+int create_tls1_3_ctx_pair(OSSL_LIB_CTX *libctx, SSL_CTX **sctx, SSL_CTX **cctx,
+                        char *certfile, char *privkeyfile) {
+    SSL_CTX *serverctx = NULL, *clientctx = NULL;
+
+    if (sctx == NULL || cctx == NULL)
+        goto err;
+
+    serverctx = SSL_CTX_new_ex(libctx, NULL, TLS_server_method());
+    clientctx = SSL_CTX_new_ex(libctx, NULL, TLS_client_method());
+
+    if (serverctx == NULL || clientctx == NULL)
+        goto err;
+
+    SSL_CTX_set_options(serverctx,SSL_OP_ALLOW_CLIENT_RENEGOTIATION);
+    SSL_CTX_set_min_proto_version(serverctx,TLS1_3_VERSION);
+    SSL_CTX_set_max_proto_version(serverctx,TLS1_3_VERSION);
+    SSL_CTX_set_min_proto_version(clientctx,TLS1_3_VERSION);
+    SSL_CTX_set_max_proto_version(clientctx,TLS1_3_VERSION);
+
+    if (!SSL_CTX_use_certificate_file(serverctx, certfile,
+        SSL_FILETYPE_PEM) )
+        goto err;
+
+    if (!SSL_CTX_use_PrivateKey_file(serverctx,privkeyfile,
+        SSL_FILETYPE_PEM))
+        goto err;
+
+    if (!SSL_CTX_check_private_key(serverctx))
+        goto err;
+
+    *sctx = serverctx;
+    *cctx = clientctx;
+    return 1;
+
+    err:
+    SSL_CTX_free(serverctx);
+    SSL_CTX_free(clientctx);
+    return 0;
+}
+
+int create_tls_objects(SSL_CTX *serverctx, SSL_CTX *clientctx, SSL **sssl,
+                       SSL **cssl) {
+    SSL *serverssl = NULL, *clientssl = NULL;
+    BIO *s_to_c_bio = NULL, *c_to_s_bio = NULL;
+
+    if(serverctx == NULL || clientctx == NULL)
+        goto err;
+
+    serverssl = SSL_new(serverctx);
+    clientssl = SSL_new(clientctx);
+
+    if (serverssl == NULL || clientssl == NULL)
+        goto err;
+
+    s_to_c_bio = BIO_new(BIO_s_mem());
+    c_to_s_bio = BIO_new(BIO_s_mem());
+
+    if (s_to_c_bio == NULL || c_to_s_bio == NULL)
+        goto err;
+
+    /* Set Non-blocking IO behaviour */
+    BIO_set_mem_eof_return(s_to_c_bio, -1);
+    BIO_set_mem_eof_return(c_to_s_bio, -1);
+
+    /* Up ref these as we are passing them to two SSL objects */
+    SSL_set_bio(serverssl, c_to_s_bio, s_to_c_bio);
+    BIO_up_ref(s_to_c_bio);
+    BIO_up_ref(c_to_s_bio);
+    SSL_set_bio(clientssl, s_to_c_bio, c_to_s_bio);
+
+    *sssl = serverssl;
+    *cssl = clientssl;
+
+    return 1;
+
+    err:
+    SSL_free(serverssl);
+    SSL_free(clientssl);
+    BIO_free(s_to_c_bio);
+    BIO_free(c_to_s_bio);
+
+    return 0;
+}
+
+/* Create an SSL connection, but does not read any post-handshake
+* NewSessionTicket messages.
+* We stop the connection attempt (and return a failure value) if either peer
+* has SSL_get_error() return the value in the |want| parameter. The connection
+* attempt could be restarted by a subsequent call to this function.
+*/
+int create_bare_tls_connection(SSL *serverssl, SSL *clientssl, int want,
+                               int read)
+{
+    int retc = -1, rets = -1, err, abortctr = 0;
+    int clienterr = 0, servererr = 0;
+
+
+    do {
+        err = SSL_ERROR_WANT_WRITE;
+        while (!clienterr && retc <= 0 && err == SSL_ERROR_WANT_WRITE) {
+            retc = SSL_connect(clientssl);
+            if (retc <= 0)
+                err = SSL_get_error(clientssl, retc);
+        }
+
+        if (!clienterr && retc <= 0 && err != SSL_ERROR_WANT_READ) {
+            TEST_info("SSL_connect() failed %d, %d", retc, err);
+            if (want != SSL_ERROR_SSL)
+                TEST_openssl_errors();
+            clienterr = 1;
+        }
+        if (want != SSL_ERROR_NONE && err == want)
+            return 0;
+
+        err = SSL_ERROR_WANT_WRITE;
+        while (!servererr && rets <= 0 && err == SSL_ERROR_WANT_WRITE) {
+            rets = SSL_accept(serverssl);
+            if (rets <= 0)
+                err = SSL_get_error(serverssl, rets);
+        }
+
+        if (!servererr && rets <= 0
+            && err != SSL_ERROR_WANT_READ
+            && err != SSL_ERROR_WANT_X509_LOOKUP) {
+            TEST_info("SSL_accept() failed %d, %d", rets, err);
+            if (want != SSL_ERROR_SSL)
+                TEST_openssl_errors();
+            servererr = 1;
+        }
+        if (want != SSL_ERROR_NONE && err == want)
+            return 0;
+        if (clienterr && servererr)
+            return 0;
+
+        if (++abortctr == MAXLOOPS) {
+            TEST_info("No progress made");
+            return 0;
+        }
+
+    } while (retc <=0 || rets <= 0);
+
+    return 1;
+}
+
+/*
+ * Create an SSL connection including any post handshake NewSessionTicket
+ * messages.
+ */
+int create_tls_connection(SSL *serverssl, SSL *clientssl, int want)
+{
+    int i;
+    unsigned char buf;
+    size_t readbytes;
+
+    if (!create_bare_tls_connection(serverssl, clientssl, want, 1))
+        return 0;
+
+    /*
+     * We attempt to read some data on the client side which we expect to fail.
+     * This will ensure we have received the NewSessionTicket in TLSv1.3 where
+     * appropriate. We do this twice because there are 2 NewSessionTickets.
+     */
+    for (i = 0; i < 2; i++) {
+        if (SSL_read_ex(clientssl, &buf, sizeof(buf), &readbytes) > 0) {
+            if (!TEST_ulong_eq(readbytes, 0))
+                return 0;
+        } else if (!TEST_int_eq(SSL_get_error(clientssl, 0),
+                                SSL_ERROR_WANT_READ)) {
+            return 0;
+        }
+    }
+
+    return 1;
+}
+

--- a/test/tlstest_helpers.h
+++ b/test/tlstest_helpers.h
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: Apache-2.0 AND MIT
+
+int create_tls1_3_ctx_pair(OSSL_LIB_CTX *libctx, SSL_CTX **sctx, SSL_CTX **cctx,
+                           char *certfile, char *privkeyfile);
+
+int create_tls_objects(SSL_CTX *serverctx, SSL_CTX *clientctx, SSL **sssl,
+                       SSL **cssl);
+
+int create_tls_connection(SSL *serverssl, SSL *clientssl, int want);


### PR DESCRIPTION
This PR hopefully solves "Remove dependency on internal OpenSSL test harness #137".

- I made sure only public OSSL APIs are used in the TLS test helper functions
- TLS 1.3 handshake is used 
- Removed support for DTLS to remove unnecessary dependency (I assume the specific transport protocol is less relevant for PQC tests)
- Tested on OSSL 3.0 and 3.1 branches 

Please let me know your thoughts,
Thanks,
Alex

P.S. I believe dependency on libtestutil can also be removed.
 
