### PR TITLE
Add OQS_init and OQS_destroy & GithubCI on PRs

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,7 +1,11 @@
 name: Linux tests
 
-on: [push]
-
+on:
+  push:
+    branches: [ '*' ]
+  pull_request:
+    branches: [ "main" ]
+    
 jobs:
 
   linux_intel:

--- a/.github/workflows/standalone.yml
+++ b/.github/workflows/standalone.yml
@@ -1,7 +1,11 @@
 name: Tests using distributions with OpenSSL3 binaries
 
-on: [push]
-
+on:
+  push:
+    branches: [ '*' ]
+  pull_request:
+    branches: [ "main" ]
+    
 jobs:
 
   linux_intel:

--- a/oqsprov/oqsprov.c
+++ b/oqsprov/oqsprov.c
@@ -552,6 +552,7 @@ static const OSSL_ALGORITHM *oqsprovider_query(void *provctx, int operation_id,
 static void oqsprovider_teardown(void *provctx)
 {
    oqsx_freeprovctx((PROV_OQS_CTX*)provctx);
+   OQS_destroy();
 }
 
 /* Functions we provide to the core */
@@ -576,6 +577,8 @@ int OSSL_provider_init(const OSSL_CORE_HANDLE *handle,
     BIO_METHOD *corebiometh;
     OSSL_LIB_CTX *libctx = NULL;
     int i, rc = 0;
+
+    OQS_init();
 
     if (!oqs_prov_bio_from_dispatch(in))
         return 0;


### PR DESCRIPTION
- Adds OQS_init() and OQS_destroy() on provider load / teardown (required after https://github.com/open-quantum-safe/liboqs/pull/1431)
- Run GithubCI on PRs

Closes #144 

<!-- Please give a brief explanation of the purpose of this pull request. -->

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->
