### PR TITLE
oqsprov/oqsprov_keys.c (oqsx_key_fromdata): Set composites after import

### DIFF
--- a/oqsprov/oqsprov_keys.c
+++ b/oqsprov/oqsprov_keys.c
@@ -821,6 +821,8 @@ int oqsx_key_fromdata(OQSX_KEY *key, const OSSL_PARAM params[], int include_priv
         }
         memcpy(key->pubkey, p->data, p->data_size);
     }
+    if (oqsx_key_set_composites(key))
+        return 0;
     return 1;
 }
 


### PR DESCRIPTION
Import is nonfunctional otherwise: the `comp_privkey' and `comp_pubkey' vectors are left unpopulated.  Trying to do anything with the key is then dicey: in testing, I've had `oqs_sig_verify' bail because the slot was null, but I've also seen junk data used as a public key; for some reason, I've not seen a segfault, but it seems distinctly possible.

I did a superficial survey of the other places in the code where `privkey' and `pubkey' get set: `oqsx_key_fromdata' is the only function which does it by hand; `oqsx_key_op' and `oqsx_key_gen' are the only callers of `oqsx_allocate_keymaterial', even though it's an external function.

It seems common to leave the `privkey' and `pubkey' buffers allocated in the event of a subsequent failure, so I just returned the failure indicator, assuming that `oqsx_key_set_composites' would have already noted the problem with OpenSSL; but in fact, `oqsx_key_set_composites' is secretly infallible anyway, so the question doesn't arise in practice.

Fixes #148
