### PR TITLE
test/CMakeLists.txt: Tolerate out-of-tree builds of OpenSSL

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -27,20 +27,29 @@ add_executable(oqs_test_kems oqs_test_kems.c test_common.c)
 target_include_directories(oqs_test_kems PRIVATE ${CMAKE_SOURCE_DIR}/.local/include)
 target_link_libraries(oqs_test_kems ${OPENSSL_CRYPTO_LIBRARY})
 
-if (NOT DEFINED OPENSSL_BLDTOP)
-   set(OPENSSL_BLDTOP "${CMAKE_CURRENT_SOURCE_DIR}/../openssl")
+if (DEFINED OPENSSL_SRCTOP)
+    if (NOT DEFINED OPENSSL_BLDTOP)
+        set(OPENSSL_BLDTOP "${OPENSSL_SRCTOP}")
+    endif()
+else()
+    if (NOT DEFINED OPENSSL_BLDTOP)
+        set(OPENSSL_BLDTOP "${CMAKE_CURRENT_SOURCE_DIR}/../openssl")
+    endif()
+    set(OPENSSL_SRCTOP "${OPENSSL_BLDTOP}")
 endif()
 
-if (NOT IS_DIRECTORY ${OPENSSL_BLDTOP})
-    message(WARNING "OpenSSL source build directory '${OPENSSL_BLDTOP}' not present. Some dependent tests will be skipped.") 
+if (NOT IS_DIRECTORY ${OPENSSL_SRCTOP})
+    message(WARNING "OpenSSL source directory '${OPENSSL_SRCTOP}' not present. Some dependent tests will be skipped.") 
+elseif (NOT IS_DIRECTORY ${OPENSSL_BLDTOP})
+    message(WARNING "OpenSSL build directory '${OPENSSL_BLDTOP}' not present. Some dependent tests will be skipped.") 
 else()
 add_test(
     NAME oqs_groups
     COMMAND oqs_test_groups
             "oqsprovider"
             "${CMAKE_CURRENT_SOURCE_DIR}/oqs.cnf"
-            "${OPENSSL_BLDTOP}/test/certs"
-            "${OPENSSL_BLDTOP}/test/recipes/90-test_sslapi_data/passwd.txt"
+            "${OPENSSL_SRCTOP}/test/certs"
+            "${OPENSSL_SRCTOP}/test/recipes/90-test_sslapi_data/passwd.txt"
 )
 set_tests_properties(oqs_groups
     PROPERTIES ENVIRONMENT "OPENSSL_MODULES=${CMAKE_BINARY_DIR}/lib"
@@ -64,9 +73,9 @@ add_executable(oqs_test_tlssig oqs_test_tlssig.c test_common.c tlstest_helpers.c
 target_link_libraries(oqs_test_tlssig ${OPENSSL_SSL_LIBRARY} ${OPENSSL_CRYPTO_LIBRARY})
 
 add_executable(oqs_test_endecode oqs_test_endecode.c test_common.c)
-target_include_directories(oqs_test_endecode PRIVATE ${OPENSSL_BLDTOP}/include)
-target_include_directories(oqs_test_endecode PRIVATE ${OPENSSL_BLDTOP}/test)
-target_include_directories(oqs_test_endecode PRIVATE ${OPENSSL_BLDTOP}/apps/include)
+target_include_directories(oqs_test_endecode PRIVATE ${OPENSSL_SRCTOP}/include)
+target_include_directories(oqs_test_endecode PRIVATE ${OPENSSL_SRCTOP}/test)
+target_include_directories(oqs_test_endecode PRIVATE ${OPENSSL_SRCTOP}/apps/include)
 
 target_link_libraries(oqs_test_endecode ${OPENSSL_CRYPTO_LIBRARY} ${OPENSSL_BLDTOP}/test/libtestutil.a )
 add_test(


### PR DESCRIPTION
Add a new variable `OEPNSSL_SRCTOP` to parallel the existing `OPENSSL_BLDTOP`.  This refers to the actual source directory, from which we find header files, rather than the build directory which contains libraries, most notably `libtestutil.a`.

As I've set things up, each variable defaults from the other.  This is probably not great long-term: it's intended as a transition measure.  It seems more sensible to me to have the source directory be the primary setting, and have the build directory be subsidiary; but existing scripts (and finger-macros) know nothing of the new source-directory setting, so preserving compatibility seems valuable for now.

<!-- Please give a brief explanation of the purpose of this pull request. -->

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->
