### PR TITLE
Fix hybrid key import

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -13,6 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        ossl-branch: [openssl-3.1.0, master]
         include:
           - name: alpine
             container: openquantumsafe/ci-alpine-amd64:latest
@@ -29,7 +30,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Full build
-        run: ./scripts/fullbuild.sh
+        run: OPENSSL_BRANCH=${{ matrix.ossl-branch }} ./scripts/fullbuild.sh
       - name: Enable sibling oqsprovider for testing
         run: cd _build/lib && ln -s oqsprovider.so oqsprovider2.so
       - name: Test
@@ -38,6 +39,7 @@ jobs:
         run: |
           git config --global user.name "ciuser" && \
           git config --global user.email "ci@openquantumsafe.org" && \
+          git config --global --add safe.directory `pwd` && \
           export LIBOQS_SRC_DIR=`pwd`/liboqs && \
           ! pip3 install -r oqs-template/requirements.txt 2>&1 | grep ERROR && \
           python3 oqs-template/generate.py && \

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -30,6 +30,8 @@ jobs:
         uses: actions/checkout@v2
       - name: Full build
         run: ./scripts/fullbuild.sh
+      - name: Enable sibling oqsprovider for testing
+        run: cd _build/lib && ln -s oqsprovider.so oqsprovider2.so
       - name: Test
         run: ./scripts/runtests.sh -V
       - name: Verify nothing changes on re-generate code

--- a/oqsprov/oqs_sig.c
+++ b/oqsprov/oqs_sig.c
@@ -5,11 +5,6 @@
  *
  * Code strongly inspired by OpenSSL DSA signature provider.
  * 
- * ToDo:  Go beyone EVP use cases/testing
- *
- * Significant hurdle: Signature providers of new algorithms are not utilized 
- * properly in OpenSSL3 yet -> Integration won't be seamless and probably 
- * requires quite some (upstream) OpenSSL3 dev investment.
  */
 
 #include "oqs/sig.h"
@@ -382,6 +377,9 @@ static int oqs_sig_verify(void *vpoqs_sigctx, const unsigned char *sig, size_t s
           (EVP_PKEY_verify(ctx_verify, sig + SIZE_OF_UINT32, actual_classical_sig_len, digest, digest_len) <= 0)) {
         ERR_raise(ERR_LIB_USER, OQSPROV_R_VERIFY_ERROR);
         goto endverify;
+      }
+      else {
+	OQS_SIG_PRINTF("OQS SIG: classic verification OK\n");
       }
      /* activate for using pre-existing digest:
       * }

--- a/scripts/openssl-ca.cnf
+++ b/scripts/openssl-ca.cnf
@@ -57,6 +57,8 @@ providers = provider_sect
 [provider_sect]
 default = default_sect
 oqsprovider = oqsprovider_sect
+oqsprovider2 = oqsprovider2_sect
+
 # The fips section name should match the section name inside the
 # included fipsmodule.cnf.
 # fips = fips_sect
@@ -71,7 +73,13 @@ oqsprovider = oqsprovider_sect
 # problems including inability to remotely access the system.
 [default_sect]
 activate = 1
+
 [oqsprovider_sect]
+activate = 1
+# This second provider instance can be activated (for testing) for example
+# by creating a softlink with suitable name "oqsprovider2" to the originally
+# created oqsprovider.{so|dylib|dll}
+[oqsprovider2_sect]
 activate = 1
 
 # activate = 1

--- a/scripts/oqsprovider-ca.sh
+++ b/scripts/oqsprovider-ca.sh
@@ -22,6 +22,8 @@ if [ -z "$LD_LIBRARY_PATH" ]; then
     exit 1
 fi
 
+echo "oqsprovider-ca.sh commencing..."
+
 #rm -rf tmp
 mkdir -p tmp && cd tmp
 rm -rf demoCA && mkdir -p demoCA/newcerts
@@ -49,5 +51,5 @@ if [ $? -ne 0 ]; then
 fi
 
 # Don't forget to use provider(s) when not activated via config file
-$OPENSSL_APP verify -provider oqsprovider -provider default -CAfile $1_rootCA.crt $1.crt
+$OPENSSL_APP verify -CAfile $1_rootCA.crt $1.crt
 

--- a/scripts/oqsprovider-certgen.sh
+++ b/scripts/oqsprovider-certgen.sh
@@ -22,13 +22,16 @@ if [ -z "$LD_LIBRARY_PATH" ]; then
     exit 1
 fi
 
+echo "oqsprovider-certgen.sh commencing..."
+
 #rm -rf tmp
 mkdir -p tmp
-$OPENSSL_APP req -x509 -new -newkey $1 -keyout tmp/$1_CA.key -out tmp/$1_CA.crt -nodes -subj "/CN=oqstest CA" -days 365 -provider oqsprovider -provider default && \
-$OPENSSL_APP genpkey -algorithm $1 -out tmp/$1_srv.key -provider oqsprovider -provider default && \
-$OPENSSL_APP req -new -newkey $1 -keyout tmp/$1_srv.key -out tmp/$1_srv.csr -nodes -subj "/CN=oqstest server" -provider oqsprovider -provider default && \
-$OPENSSL_APP x509 -req -in tmp/$1_srv.csr -out tmp/$1_srv.crt -CA tmp/$1_CA.crt -CAkey tmp/$1_CA.key -CAcreateserial -days 365 -provider oqsprovider -provider default && \
-$OPENSSL_APP verify -provider oqsprovider -provider default -CAfile tmp/$1_CA.crt tmp/$1_srv.crt
+
+$OPENSSL_APP req -x509 -new -newkey $1 -keyout tmp/$1_CA.key -out tmp/$1_CA.crt -nodes -subj "/CN=oqstest CA" -days 365 && \
+$OPENSSL_APP genpkey -algorithm $1 -out tmp/$1_srv.key && \
+$OPENSSL_APP req -new -newkey $1 -keyout tmp/$1_srv.key -out tmp/$1_srv.csr -nodes -subj "/CN=oqstest server" && \
+$OPENSSL_APP x509 -req -in tmp/$1_srv.csr -out tmp/$1_srv.crt -CA tmp/$1_CA.crt -CAkey tmp/$1_CA.key -CAcreateserial -days 365 && \
+$OPENSSL_APP verify -CAfile tmp/$1_CA.crt tmp/$1_srv.crt
 
 #fails:
 #$OPENSSL_APP verify -CAfile tmp/$1_CA.crt tmp/$1_srv.crt -provider oqsprovider -provider default

--- a/scripts/oqsprovider-certverify.sh
+++ b/scripts/oqsprovider-certverify.sh
@@ -22,13 +22,15 @@ if [ -z "$LD_LIBRARY_PATH" ]; then
     exit 1
 fi
 
+echo "oqsprovider-certverify.sh commencing..."
+
 # check that CSR can be output OK
 
-$OPENSSL_APP req -text -in tmp/$1_srv.csr -noout -provider oqsprovider -provider default 2>&1 | grep Error
+$OPENSSL_APP req -text -in tmp/$1_srv.csr -noout 2>&1 | grep Error
 if [ $? -eq 0 ]; then
     echo "Couldn't print CSR correctly. Exiting."
     exit 1
 fi
 
-$OPENSSL_APP verify -provider oqsprovider -provider default -CAfile tmp/$1_CA.crt tmp/$1_srv.crt 
+$OPENSSL_APP verify -CAfile tmp/$1_CA.crt tmp/$1_srv.crt 
 

--- a/scripts/oqsprovider-cmssign.sh
+++ b/scripts/oqsprovider-cmssign.sh
@@ -12,6 +12,8 @@ if [ $# -lt 1 ]; then
     exit 1
 fi
 
+echo "oqsprovider-cmssign.sh commencing..."
+
 if [ $# -eq 2 ]; then
 	DGSTNAME=$2
 else
@@ -52,11 +54,11 @@ if [[ "$openssl_version" == "OpenSSL 3.0."* ]]; then
 fi
 
 # dgst test:
-$OPENSSL_APP x509 -provider oqsprovider -provider default -in tmp/$1_srv.crt -pubkey -noout > tmp/$1_srv.pubkey && $OPENSSL_APP cms -in tmp/inputfile -sign -signer tmp/$1_srv.crt -inkey tmp/$1_srv.key -nodetach -outform pem -binary -out tmp/signedfile.cms -md $DGSTNAME -provider oqsprovider -provider default && $OPENSSL_APP dgst -provider oqsprovider -provider default -sign tmp/$1_srv.key -out tmp/dgstsignfile tmp/inputfile
+$OPENSSL_APP x509 -in tmp/$1_srv.crt -pubkey -noout > tmp/$1_srv.pubkey && $OPENSSL_APP cms -in tmp/inputfile -sign -signer tmp/$1_srv.crt -inkey tmp/$1_srv.key -nodetach -outform pem -binary -out tmp/signedfile.cms -md $DGSTNAME && $OPENSSL_APP dgst -sign tmp/$1_srv.key -out tmp/dgstsignfile tmp/inputfile
 
 if [ $? -eq 0 ]; then
 # cms test:
-   $OPENSSL_APP cms -verify -CAfile tmp/$1_CA.crt -inform pem -in tmp/signedfile.cms -crlfeol -out tmp/signeddatafile -provider oqsprovider -provider default && diff tmp/signeddatafile tmp/inputfile && $OPENSSL_APP dgst -provider oqsprovider -provider default -signature tmp/dgstsignfile -verify tmp/$1_srv.pubkey tmp/inputfile
+   $OPENSSL_APP cms -verify -CAfile tmp/$1_CA.crt -inform pem -in tmp/signedfile.cms -crlfeol -out tmp/signeddatafile && diff tmp/signeddatafile tmp/inputfile && $OPENSSL_APP dgst -signature tmp/dgstsignfile -verify tmp/$1_srv.pubkey tmp/inputfile
 else
    exit -1
 fi

--- a/scripts/oqsprovider-cmsverify.sh
+++ b/scripts/oqsprovider-cmsverify.sh
@@ -36,7 +36,7 @@ fi
 # Assumes certgen has been run before: Quick check for CMS file:
 
 if [ -f tmp/signedfile.cms ]; then
-    $OPENSSL_APP cms -verify -CAfile tmp/$1_CA.crt -inform pem -in tmp/signedfile.cms -crlfeol -out tmp/signeddatafile -provider oqsprovider -provider default
+    $OPENSSL_APP cms -verify -CAfile tmp/$1_CA.crt -inform pem -in tmp/signedfile.cms -crlfeol -out tmp/signeddatafile 
     diff tmp/signeddatafile tmp/inputfile
 else
    echo "File tmp/signedfile.cms not found. Did CMS sign run before? Exiting."

--- a/scripts/runtests.sh
+++ b/scripts/runtests.sh
@@ -35,7 +35,7 @@ interop() {
     fi
 
     # Check whether algorithm is supported at all:
-    $OPENSSL_APP list -signature-algorithms -provider oqsprovider | grep $1 > /dev/null 2>&1
+    $OPENSSL_APP list -signature-algorithms | grep $1 > /dev/null 2>&1
     if [ $? -ne 1 ]; then
 	if [ -z "$LOCALTESTONLY" ]; then
             provider2openssl $1 >> interop.log 2>&1 && openssl2provider $1 >> interop.log 2>&1

--- a/scripts/runtests.sh
+++ b/scripts/runtests.sh
@@ -112,8 +112,11 @@ fi
 export LOCALTESTONLY="Yes"
 
 echo "Version information:"
-$OPENSSL_APP version
-$OPENSSL_APP list -providers -verbose -provider-path _build/lib -provider oqsprovider
+$OPENSSL_APP version && $OPENSSL_APP list -providers -verbose -provider-path _build/lib -provider oqsprovider
+if [ $? -ne 0 ]; then
+   echo "Baseline openssl invocation failed. Exiting test."
+   exit 1
+fi
 
 # Run interop-tests:
 echo "Cert gen/verify, CMS sign/verify, CA tests for all enabled algorithms commencing..."


### PR DESCRIPTION
Fixes #160. Completes fix of #148 (for hybrid algorithms on imported keys).

Also
- optimizes testing (by way of openssl.cnf file)
- adds testing for multiple provider instances
- fixes previously disregarded script exit conditions
- uncovered https://github.com/openssl/openssl/issues/20981