### PR TITLE
Add .DS_Store (macOS), .vscode (visual studio code), and .idea (Jetbr…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,13 @@ tmp
 interop.log
 # pycache
 oqs-template/__pycache__
+
+# Visual Studio Code
+.vscode
+
+# Jetbrains IDEs
+.idea
+
+# MacOS
+.DS_Store
+


### PR DESCRIPTION
…ains IDE) to .gitignore

<!-- Please give a brief explanation of the purpose of this pull request. -->

Adds common filetypes to .gitignore, so that developers don't accidentally checkin files that are
typically modified locally.

.vscode -- this is used to store Microsoft Visual Studio code workspace information
.idea - this is used by Jetbrains IDEs like CLion (or IntelliJ)
.DS_Store - this stores additional attributes on macOS

In my case I was experimenting with building the provider for the first time, and was trying out the two IDEs, and
noticed these modifications, so it seemed appropriate to clean them up.

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->
