### PR TITLE
Add brew to preinstall test matrix

### DIFF
--- a/.github/workflows/standalone.yml
+++ b/.github/workflows/standalone.yml
@@ -13,14 +13,14 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-      - name: Pull prerequisites
-        run: brew install openssl@3 liboqs && brew info openssl@3 && brew info liboqs
-      - name: Checkout code
+      - name: Install prerequisites
+        run: brew install liboqs
+      - name: Checkout oqsprovider code
         uses: actions/checkout@v2
-      - name: Full build
-        run: OPENSSL_INSTALL=/usr/local/opt/openssl@3 ./scripts/fullbuild.sh
-      - name: Test
-        run: ./scripts/runtests.sh -V
+      - name: Build oqsprovider
+        run: cmake -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl@3 -S . -B _build && cmake --build _build
+      - name: Test oqsprovider
+        run: ctest --test-dir _build
 
   linux_intel:
     runs-on: ubuntu-latest

--- a/.github/workflows/standalone.yml
+++ b/.github/workflows/standalone.yml
@@ -8,6 +8,20 @@ on:
     
 jobs:
 
+  macos_intel:
+    runs-on: macos-13
+    strategy:
+      fail-fast: false
+    steps:
+      - name: Pull prerequisites
+        run: brew install openssl@3 liboqs && brew info openssl@3 && brew info liboqs
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Full build
+        run: OPENSSL_INSTALL=/usr/local/opt/openssl@3 ./scripts/fullbuild.sh
+      - name: Test
+        run: ./scripts/runtests.sh -V
+
   linux_intel:
     runs-on: ubuntu-latest
     strategy:
@@ -29,3 +43,4 @@ jobs:
         run: ./scripts/fullbuild.sh
       - name: Test
         run: ./scripts/runtests.sh -V
+

--- a/.github/workflows/standalone.yml
+++ b/.github/workflows/standalone.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Build oqsprovider
         run: cmake -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl@3 -S . -B _build && cmake --build _build
       - name: Test oqsprovider
-        run: ctest --test-dir _build
+        run: ctest --parallel 5 --test-dir _build
 
   linux_intel:
     runs-on: ubuntu-latest


### PR DESCRIPTION
As `liboqs` and `openssl`(3) are readily available in `brew` this PR adds macos to this CI test case.
