### PR TITLE
Build a module instead of a shared library.

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -80,11 +80,8 @@ jobs:
           key: ${{ runner.os }}-cygwinopenssl32
       - name: build oqs-provider
         run: bash -c "git config --global --add safe.directory $(cygpath -u $PWD) && liboqs_DIR='${{ env.IP }}' cmake -GNinja -DCMAKE_C_COMPILER=gcc -DOPENSSL_ROOT_DIR=/opt/openssl32 -S . -B _build && cd _build && ninja && cd .."
-      - name: Adapt oqsprovider.dll name
-        run: bash -c "cp oqsprovider-1.dll oqsprovider.dll"
-        working-directory: _build/bin
       - name: Check Openssl providers
-        run: bash -c "OPENSSL_MODULES=_build/bin /opt/openssl32/bin/openssl list -providers -provider oqsprovider -provider default"
+        run: bash -c "OPENSSL_MODULES=_build/lib /opt/openssl32/bin/openssl list -providers -provider oqsprovider -provider default"
       - name: Run tests
         run: bash -c "echo $PATH && PATH=/opt/openssl32/bin:/usr/bin ctest -V"
         working-directory: _build
@@ -200,5 +197,5 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: oqs-provider-msvc
-          path: D:/a/oqs-provider/oqs-provider/_build/bin/oqsprovider.dll
+          path: D:/a/oqs-provider/oqs-provider/_build/lib/oqsprovider.dll
 

--- a/oqsprov/CMakeLists.txt
+++ b/oqsprov/CMakeLists.txt
@@ -31,7 +31,7 @@ set(PROVIDER_SOURCE_FILES
 set(PROVIDER_HEADER_FILES
   oqs_prov.h oqs_endecoder_local.h
 )
-add_library(oqsprovider SHARED ${PROVIDER_SOURCE_FILES})
+add_library(oqsprovider MODULE ${PROVIDER_SOURCE_FILES})
 if (USE_ENCODING_LIB)
   add_dependencies(oqsprovider encoder)
 endif()
@@ -43,8 +43,35 @@ set_target_properties(oqsprovider
     LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
     VERSION ${OQSPROVIDER_VERSION_TEXT}
     SOVERSION 1
+    # Compatibility version (-compatibility_version) and current version
+    # (-current_version) are not compatible with a `MODULE` library.
+    # However, `VERSION` and `SOVERSION` set these two flags.
+    # The following two flags remove them.
+    MACHO_COMPATIBILITY_VERSION OFF
+    MACHO_CURRENT_VERSION OFF
     # For Windows DLLs
     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")
+
+if (APPLE)
+  # OpenSSL looks for `.dylib` files on XNU-based platforms.
+  # Because `MODULE` writes to a `.so` file by default, we must explicitely
+  # set the suffix here.
+  set_target_properties(oqsprovider
+    PROPERTIES
+    SUFFIX ".dylib"
+  )
+endif()
+
+if (CYGWIN OR MSVC)
+  # OpenSSL looks for `.dll` files on Windows platforms.
+  # Because `MODULE` writes to a `.so` file by default, we must explicitely
+  # set the suffix here.
+  set_target_properties(oqsprovider
+    PROPERTIES
+    SUFFIX ".dll"
+  )
+endif()
+
 target_link_libraries(oqsprovider OQS::oqs ${OPENSSL_CRYPTO_LIBRARY} ${OQS_ADDL_SOCKET_LIBS})
 if (USE_ENCODING_LIB)
   target_link_libraries(oqsprovider qsc_key_encoder)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,9 +1,5 @@
 include(GNUInstallDirs)
-if (WIN32 OR CYGWIN)
-set(OQS_PROV_BINARY_DIR ${CMAKE_BINARY_DIR}/bin)
-else()
 set(OQS_PROV_BINARY_DIR ${CMAKE_BINARY_DIR}/lib)
-endif()
 
 add_test(
   NAME oqs_signatures


### PR DESCRIPTION
Fix #202.

This commit switches the default type in CMake from `SHARED` to `MODULE`.

Two issues have been found.

## First issue

I ran into an issue while testing this commit on macOS. Here is the error I got from clang:

```shell
clang: error: invalid argument '-compatibility_version 1.0.0' only allowed with '-dynamiclib'
```

After some investigation, I found out that the [`SOVERSION` and `VERSION`](https://cmake.org/cmake/help/latest/prop_tgt/SOVERSION.html) properties should not be used when building a shared library. This doesn't seem to lead to an error on Linux, but on macOS, it happens to set the following two flags:
  * `-compatibility_version` (given by `SOVERSION`)
  * `-current_version` (given by `VERSION`)

However, CMake uses the `-bundle` flag when linking, instead of the `-dynamiclib` flag.

I found a fix by reading the documentation:

> For shared libraries, the MACHO_COMPATIBILITY_VERSION and MACHO_CURRENT_VERSION
> properties can be used to override the compatibility version and current
> version respectively.

Setting these two flags to `OFF` removes `-compatibility_version` and `-current_version`.

Perhaps we should simply remove `SOVERSION` and `VERSION`, as they're only meant to be used for shared libraries?

## Second issue

OpenSSL has an API to load dynamic objects and libraries called `DSO`. When loading a provider, a call to `dlfcn_name_converter` is made to compute the name of the file:

https://github.com/openssl/openssl/blob/79fa5873a9c2f2df392bc4b39146d8db37640118/crypto/dso/dso_dlfcn.c#L253-L280

Reader may notice that OpenSSL appends the macro `DSO_EXTENSION` to the end of the provider's name.
`DSO_EXTENSION` is platform-specific: its value is `.so` on Unix, and `.dylib` on macOS.
Because we're building a `MODULE` library here instead of a `SHARED` library, the output file's extension is `.so` instead of `.dylib`. Thus, OpenSSL fails to find the `oqs-provider` to load.

To solve this issue, I used the [`SUFFIX`](https://cmake.org/cmake/help/latest/prop_tgt/SUFFIX.html) property of CMake targets to explicitely specify the extension when building for a XNU-based platform (macOS, iOS, watchOS, etc.).

<!-- Please give a brief explanation of the purpose of this pull request. -->

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->
