### PR TITLE
Fix a bug in the CMake script.

### DIFF
--- a/oqsprov/CMakeLists.txt
+++ b/oqsprov/CMakeLists.txt
@@ -58,24 +58,26 @@ set_target_properties(oqsprovider
     # For Windows DLLs
     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")
 
-if (APPLE)
-  # OpenSSL looks for `.dylib` files on XNU-based platforms.
-  # Because `MODULE` writes to a `.so` file by default, we must explicitely
-  # set the suffix here.
-  set_target_properties(oqsprovider
-    PROPERTIES
-    SUFFIX ".dylib"
-  )
-endif()
+if (NOT OQS_PROVIDER_BUILD_STATIC)
+  if (APPLE)
+    # OpenSSL looks for `.dylib` files on XNU-based platforms.
+    # Because `MODULE` writes to a `.so` file by default, we must explicitely
+    # set the suffix here.
+    set_target_properties(oqsprovider
+      PROPERTIES
+      SUFFIX ".dylib"
+    )
+  endif()
 
-if (CYGWIN OR MSVC)
-  # OpenSSL looks for `.dll` files on Windows platforms.
-  # Because `MODULE` writes to a `.so` file by default, we must explicitely
-  # set the suffix here.
-  set_target_properties(oqsprovider
-    PROPERTIES
-    SUFFIX ".dll"
-  )
+  if (CYGWIN OR MSVC)
+    # OpenSSL looks for `.dll` files on Windows platforms.
+    # Because `MODULE` writes to a `.so` file by default, we must explicitely
+    # set the suffix here.
+    set_target_properties(oqsprovider
+      PROPERTIES
+      SUFFIX ".dll"
+    )
+  endif()
 endif()
 
 target_link_libraries(oqsprovider PUBLIC OQS::oqs ${OPENSSL_CRYPTO_LIBRARY} ${OQS_ADDL_SOCKET_LIBS})


### PR DESCRIPTION
PR [#207] introduced a check for setting the right suffix to the library, depending on the target OS:

https://github.com/open-quantum-safe/oqs-provider/blob/823f3178dd50eeb5febf29eb82680400c4d9e887/oqsprov/CMakeLists.txt#L61-L7://github.com/open-quantum-safe/oqs-provider/blob/823f3178dd50eeb5febf29eb82680400c4d9e887/oqsprov/CMakeLists.txt#L61-L79

However, mixed with PR [#201] and the `OQS_PROVIDER_BUILD_STATIC` option, the library may be suffixed with the wrong extension: we may end up with a static library named `oqsprovider.dylib`, even if it's an archive:

```shell
$ cmake -GNinja \
    -DOQS_PROVIDER_BUILD_STATIC=ON \
    -B build
$ cmake --build build
$ file build/lib/oqsprovider.dylib
build/lib/oqsprovider.dylib: current ar archive random library
$ # ^ should be named `oqsprovider.a`!
```

The check mentioned above is only relevant when oqsprovider is built as a module.

This commit fixes this bug and introduces a check in the CircleCI jobs to verify that `oqsprovider.a` is actually produced.

[#201](https://github.com/open-quantum-safe/oqs-provider/pull/201)
[#207](https://github.com/open-quantum-safe/oqs-provider/pull/207)
