### PR TITLE
Use OpenSSL 3 if available to build liboqs on CircleCI/macOS.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,7 +143,8 @@ jobs:
           command: |
              git clone --depth 1 --branch main https://github.com/open-quantum-safe/liboqs.git &&
              export LIBOQS_INSTALLPATH=$(pwd)/.local && cd liboqs && mkdir _build && cd _build &&
-             cmake -GNinja -DCMAKE_INSTALL_PREFIX=$LIBOQS_INSTALLPATH << parameters.CMAKE_ARGS >> .. && ninja install &&
+             export OPENSSL_INSTALL="$(brew --prefix << parameters.OPENSSL_PREINSTALL >> || echo "")"
+             cmake -GNinja -DOPENSSL_ROOT_DIR="${OPENSSL_INSTALL}" -DCMAKE_INSTALL_PREFIX=$LIBOQS_INSTALLPATH << parameters.CMAKE_ARGS >> .. && ninja install &&
              cd .. && cd .. && echo "export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:$LIBOQS_INSTALLPATH/lib" >> "$BASH_ENV"
       - when:
           condition:
@@ -170,7 +171,8 @@ jobs:
             - run:
                 name: Build OQS-OpenSSL provider
                 command: |
-                   export OPENSSL_INSTALL=`brew config | grep HOMEBREW_PREFIX | sed -e "s/HOMEBREW_PREFIX: //g"`/opt/openssl@3 && mkdir _build && cd _build && liboqs_DIR=`pwd`/../.local cmake -GNinja -DOPENSSL_ROOT_DIR=$OPENSSL_INSTALL .. && ninja && echo "export OPENSSL_INSTALL=$OPENSSL_INSTALL" >> "$BASH_ENV" && cd .. && echo "export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:$OPENSSL_INSTALL/lib" >> "$BASH_ENV"
+                  export OPENSSL_INSTALL="$(brew --prefix << parameters.OPENSSL_PREINSTALL >>)"
+                  mkdir _build && cd _build && liboqs_DIR=`pwd`/../.local cmake -GNinja -DOPENSSL_ROOT_DIR="${OPENSSL_INSTALL}" .. && ninja && echo "export OPENSSL_INSTALL=$OPENSSL_INSTALL" >> "$BASH_ENV" && cd .. && echo "export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:$OPENSSL_INSTALL/lib" >> "$BASH_ENV"
       - run:
           name: Run tests
           command: |


### PR DESCRIPTION
This commit adds the `OPENSSL_ROOT_DIR` CMake variable to the command line for building liboqs.

The value assigned to `OPENSSL_ROOT_DIR` is the path to `openssl@3.1` (i.e. the path to the directory containing `lib`, `include` among others) if exists, else an empty string.