### PR TITLE
sigalg config warning

### DIFF
--- a/CONFIGURE.md
+++ b/CONFIGURE.md
@@ -25,6 +25,11 @@ in a standard OS deployment location.
 By setting this `cmake` configuration option to "Release" all debug output is disabled.
 This is the default setting.
 
+In case of any problem, setting this value to "Debug" is _highly_ recommended to
+activate further warning messages. In particular, when "Debug" has been set, distinct
+[debugging capabilities](https://github.com/open-quantum-safe/oqs-provider/wiki/Debugging)
+are activated and additional setup warnings are output.
+
 ### liboqs_DIR
 
 This environment variable must be set to the location of the `liboqs` installation to be

--- a/oqsprov/oqsprov_capabilities.c
+++ b/oqsprov/oqsprov_capabilities.c
@@ -425,7 +425,6 @@ static int oqs_sigalg_capability(OSSL_CALLBACK *cb, void *arg)
 int oqs_provider_get_capabilities(void *provctx, const char *capability,
                               OSSL_CALLBACK *cb, void *arg)
 {
-printf("Get capabilities for %s\n", capability);
     if (strcasecmp(capability, "TLS-GROUP") == 0)
         return oqs_group_capability(cb, arg);
 

--- a/oqsprov/oqsprov_capabilities.c
+++ b/oqsprov/oqsprov_capabilities.c
@@ -433,7 +433,7 @@ int oqs_provider_get_capabilities(void *provctx, const char *capability,
         return oqs_sigalg_capability(cb, arg);
 #else
 #ifndef NDEBUG
-    fprintf(stderr, "Warning: OSSL_CAPABILITY_TLS_SIGALG_NAME unset. OpenSSL version used that does not support pluggable signature capabilities. Recommend upgrading OpenSSL installation.\n");
+    fprintf(stderr, "Warning: OSSL_CAPABILITY_TLS_SIGALG_NAME not defined: OpenSSL version used that does not support pluggable signature capabilities.\nUpgrading OpenSSL installation recommended to enable QSC TLS signature support.\n\n");
 #endif /* NDEBUG */
 #endif /* OSSL_CAPABILITY_TLS_SIGALG_NAME */
 

--- a/oqsprov/oqsprov_capabilities.c
+++ b/oqsprov/oqsprov_capabilities.c
@@ -425,13 +425,18 @@ static int oqs_sigalg_capability(OSSL_CALLBACK *cb, void *arg)
 int oqs_provider_get_capabilities(void *provctx, const char *capability,
                               OSSL_CALLBACK *cb, void *arg)
 {
+printf("Get capabilities for %s\n", capability);
     if (strcasecmp(capability, "TLS-GROUP") == 0)
         return oqs_group_capability(cb, arg);
 
 #ifdef OSSL_CAPABILITY_TLS_SIGALG_NAME
     if (strcasecmp(capability, "TLS-SIGALG") == 0)
         return oqs_sigalg_capability(cb, arg);
-#endif
+#else
+#ifndef NDEBUG
+    fprintf(stderr, "Warning: OSSL_CAPABILITY_TLS_SIGALG_NAME unset. OpenSSL version used that does not support pluggable signature capabilities. Recommend upgrading OpenSSL installation.\n");
+#endif /* NDEBUG */
+#endif /* OSSL_CAPABILITY_TLS_SIGALG_NAME */
 
     /* We don't support this capability */
     return 0;


### PR DESCRIPTION
Fixing #231 with additional warning output (beyond [documentation](https://github.com/open-quantum-safe/oqs-provider#note-on-openssl-versions)).
