### PR TITLE
Fix DOQS_ALGS_ENABLED setting for cmake

### DIFF
--- a/scripts/fullbuild.sh
+++ b/scripts/fullbuild.sh
@@ -34,7 +34,7 @@ fi
 if [ -z "$OQS_ALGS_ENABLED" ]; then
    export DOQS_ALGS_ENABLED=""
 else
-   export DOQS_ALGS_ENABLED="$OQS_ALGS_ENABLED"
+   export DOQS_ALGS_ENABLED="-DOQS_ALGS_ENABLED=$OQS_ALGS_ENABLED"
 fi
 
 if [ -z "$OPENSSL_INSTALL" ]; then


### PR DESCRIPTION
This fixes the cmake flag so it reads `-DOQS_ALGS_ENABLED=<value>` on line 109.

This is based on the notion that the script works based on an environment variable that only contains the word "All" or "STD" for the setting rather than the entire cmake flag, and is consistent with the way the cmake flag for openssl location is set on line 100.