### PR TITLE
fix for runtests.sh: skip non-working OpenSSL versions

### DIFF
--- a/scripts/runtests.sh
+++ b/scripts/runtests.sh
@@ -136,7 +136,7 @@ export LOCALTESTONLY="Yes"
 echo "Version information:"
 "${OPENSSL_APP}" version
 
-# Disable testing for version a few versions: Buggy as hell:
+# Disable testing for a few versions: Buggy as hell:
 if "${OPENSSL_APP}" version | grep -qE 'OpenSSL (3\.0\.(0|1|4)) '; then
    echo "Skipping testing of buggy OpenSSL versions 3.0.0, 3.0.1 and 3.0.4"
    exit 0

--- a/scripts/runtests.sh
+++ b/scripts/runtests.sh
@@ -136,9 +136,9 @@ export LOCALTESTONLY="Yes"
 echo "Version information:"
 "${OPENSSL_APP}" version
 
-# Disable testing for version 3.0.1: Buggy as hell:
-if "${OPENSSL_APP}" version | grep -q "OpenSSL 3.0.1"; then
-   echo "Skipping testing of buggy OpenSSL 3.0.1"
+# Disable testing for version a few versions: Buggy as hell:
+if "${OPENSSL_APP}" version | grep -qE 'OpenSSL (3\.0\.(0|1|4)) '; then
+   echo "Skipping testing of buggy OpenSSL versions 3.0.0, 3.0.1 and 3.0.4"
    exit 0
 fi
 


### PR DESCRIPTION
As noted in https://github.com/open-quantum-safe/oqs-provider/pull/243#discussion_r1314878720
Skips runtests.sh with OpenSSL 3.0.(0|1|4) & avoids mistakenly skipping tests with 3.0.10.
