### PR TITLE
Move the clang-format CI job from CircleCI to GitHub actions.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -240,19 +240,6 @@ jobs:
               fi
             fi
 
-  check-clang-format:
-    docker:
-      - image: cimg/base:2022.12
-    steps:
-      - run:
-          name: Install dependencies
-          command: sudo apt-get update && sudo apt-get install -y clang-format
-      - checkout
-      - run:
-          name: Check coding style using clang-format
-          command: |
-            find . -type f -and '(' -name '*.h' -or -name '*.c' -or -name '*.inc' ')' | xargs clang-format --dry-run --Werror
-
   trigger-downstream-ci:
     docker:
       - image: cimg/base:2020.01
@@ -277,7 +264,6 @@ workflows:
   version: 2.1
   build:
     jobs:
-      - check-clang-format
       - ubuntu:
           name: ubuntu-focal
           context: openquantumsafe

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -1,0 +1,24 @@
+name: clang-format tests
+
+on:
+  push:
+    branches: [ '*' ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  clang-format:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    container:
+      image: openquantumsafe/ci-ubuntu-jammy:latest
+    steps:
+      - name: Install dependencies
+        run: apt-get update && apt-get install -y clang-format
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Check coding style using clang-format
+        run: find . -type f -and '(' -name '*.h' -or -name '*.c' -or -name '*.inc' ')' | xargs clang-format --dry-run --Werror


### PR DESCRIPTION
This commit contributes to fixing issue #248.