### PR TITLE
add manual approval step to use restricted CCI context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -313,6 +313,10 @@ workflows:
         - equal: [ main , << pipeline.git.branch >> ]
         - equal: [ true , << pipeline.parameters.run_downstream_tests >> ]
     jobs:
+      - hold:
+          type: approval
       - trigger-downstream-ci:
           context: openquantumsafe
+          requires:
+            - hold
 


### PR DESCRIPTION
As per [CCI documentation](https://circleci.com/docs/contexts/#approve-jobs-that-use-restricted-contexts) this is to add a manual approval step for an OQS core team member to approve use of restricted OQS environment variable(s) during final merge. Goal is to get around errors like [this](https://github.com/open-quantum-safe/oqs-provider/runs/16701152214) caused by "Unauthorized" project env var accesses when non-OQS-core-registered members contribute code.


