### PR TITLE
Remove duplicate LIBOQS_BRANCH option in CONFIGURE.md

### DIFF
--- a/CONFIGURE.md
+++ b/CONFIGURE.md
@@ -110,8 +110,8 @@ code deficiencies related to providers in such old OpenSSL branches.
 
 This defines the branch of `liboqs` against which `oqs-provider` is built.
 This can be used, for example, to facilitate a release of `oqsprovider`
-to track an old/stable `liboqs` release.
-Default is "main" (most current code).
+to track an old/stable `liboqs` release. If this variable is not set, the
+"main" branch is built.
 
 ### liboqs_DIR
 
@@ -119,11 +119,6 @@ If this environment variable is set, `liboqs` is not being built but
 used from the directory specified in this variable: Both `include`
 and `lib` directories must be present in that location.
 By not setting this variable, `liboqs` is build from source.
-
-### LIBOQS_BRANCH
-
-If set, this environment variable designates the `liboqs` branch to
-be built. If this variable is not set, the "main" branch is built.
 
 ### MAKE_PARAMS
 


### PR DESCRIPTION
Signed-off-by: Paul S. Schweigert <paul@paulschweigert.com>

There were two entries for LIBOQS_BRANCH in the CONFIGURE doc. This change drops the second one and makes a slight tweak to the wording of the first.

<!-- Please give a brief explanation of the purpose of this pull request. -->

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->
