### PR TITLE
add cloudflare interop tests

### DIFF
--- a/scripts/oqsprovider-externalinterop.sh
+++ b/scripts/oqsprovider-externalinterop.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -e 
+
+# Use newly built oqsprovider to test interop with external sites
+
+if [ -z "$OPENSSL_APP" ]; then
+    echo "OPENSSL_APP env var not set. Exiting."
+    exit 1
+fi
+
+if [ -z "$OPENSSL_MODULES" ]; then
+    echo "Warning: OPENSSL_MODULES env var not set."
+fi
+
+# Set OSX DYLD_LIBRARY_PATH if not already externally set
+if [ -z "$DYLD_LIBRARY_PATH" ]; then
+    export DYLD_LIBRARY_PATH=$LD_LIBRARY_PATH
+fi
+
+echo " Cloudflare:"
+export OQS_CODEPOINT_X25519_KYBER512=65072
+(echo -e "GET /cdn-cgi/trace HTTP/1.1\nHost: cloudflare.com\n\n"; sleep 1; echo $'\cc') | $OPENSSL_APP s_client -connect pq.cloudflareresearch.com:443 -groups x25519_kyber768 -servername cloudflare.com -ign_eof 2>/dev/null | grep kex=X25519Kyber768Draft00
+(echo -e "GET /cdn-cgi/trace HTTP/1.1\nHost: cloudflare.com\n\n"; sleep 1; echo $'\cc') | $OPENSSL_APP s_client -connect pq.cloudflareresearch.com:443 -groups x25519_kyber512 -servername cloudflare.com -ign_eof 2>/dev/null | grep kex=X25519Kyber512Draft00
+
+

--- a/scripts/runtests.sh
+++ b/scripts/runtests.sh
@@ -180,6 +180,10 @@ fi
 
 echo
 
+# Run interop tests with external sites
+echo "External interop tests commencing"
+${OQS_PROVIDER_TESTSCRIPTS}/oqsprovider-externalinterop.sh
+
 # Run built-in tests:
 # Without removing OPENSSL_CONF ctest hangs... ???
 unset OPENSSL_CONF


### PR DESCRIPTION
Adds interop testing towards Cloudflare's test server.

Fixes #276.

I'm not totally convinced this is a good test as it most likely will have to be removed/updated once https://github.com/open-quantum-safe/liboqs/issues/1521 lands, so soliciting further feedback. Related question to @bwesterb : Any insight as to whether/when Cloudflare intends to upgrade Kyber to the FIPS version?