### PR TITLE
Clarify liboqs_DIR naming convention

### DIFF
--- a/CONFIGURE.md
+++ b/CONFIGURE.md
@@ -36,6 +36,7 @@ This environment variable must be set to the location of the `liboqs` installati
 utilized in the build.
 By default, this is un-set, requiring installation of `liboqs` in a standard
 location for the OS.
+This uses a feature of `cmake` which checks for local builds of a package at `<PackageName>_DIR`
 
 ### USE_ENCODING_LIB
 

--- a/CONFIGURE.md
+++ b/CONFIGURE.md
@@ -36,7 +36,8 @@ This environment variable must be set to the location of the `liboqs` installati
 utilized in the build.
 By default, this is un-set, requiring installation of `liboqs` in a standard
 location for the OS.
-This uses a feature of `cmake` which checks for local builds of a package at `<PackageName>_DIR`
+This uses the [`find_package`](https://cmake.org/cmake/help/latest/command/find_package.html)
+command in `cmake`, which checks for local builds of a package at `<PackageName>_DIR`
 
 ### USE_ENCODING_LIB
 


### PR DESCRIPTION
As per discussion in #277 we want to clarify why the env var `liboqs_DIR` does not follow standard naming convention by using lowercase.

Fixes  #277