### PR TITLE
check empty params lists passed

### DIFF
--- a/oqsprov/oqs_encode_key2any.c
+++ b/oqsprov/oqs_encode_key2any.c
@@ -944,6 +944,7 @@ static int key2any_set_ctx_params(void *vctx, const OSSL_PARAM params[])
         }
     }
     OQS_ENC_PRINTF2(" cipher set to %p: \n", ctx->cipher);
+    // not passing in a cipher param will lead to no-op hence no error
     return 1;
 }
 

--- a/oqsprov/oqs_kmgmt.c
+++ b/oqsprov/oqs_kmgmt.c
@@ -257,6 +257,7 @@ int oqsx_key_to_params(const OQSX_KEY *key, OSSL_PARAM_BLD *tmpl,
                 goto err;
         }
     }
+    // not passing in params to respond to is no error; the response is empty
     ret = 1;
 err:
     return ret;
@@ -373,6 +374,7 @@ static int oqsx_get_params(void *key, OSSL_PARAM params[])
             return 0;
     }
 
+    // not passing in params to respond to is no error
     return 1;
 }
 
@@ -443,6 +445,7 @@ static int oqsx_set_params(void *key, const OSSL_PARAM params[])
         }
     }
 
+    // not passing in params to set is no error, just a no-op
     return 1;
 }
 
@@ -571,6 +574,7 @@ static int oqsx_gen_set_params(void *genctx, const OSSL_PARAM params[])
         if (gctx->propq == NULL)
             return 0;
     }
+    // not passing in params is no error; subsequent operations may fail, though
     return 1;
 }
 

--- a/oqsprov/oqs_sig.c
+++ b/oqsprov/oqs_sig.c
@@ -745,6 +745,7 @@ static int oqs_sig_set_ctx_params(void *vpoqs_sigctx, const OSSL_PARAM params[])
             return 0;
     }
 
+    // not passing in parameters we can act on is no error
     return 1;
 }
 

--- a/oqsprov/oqsprov.c
+++ b/oqsprov/oqsprov.c
@@ -850,6 +850,7 @@ static int oqsprovider_get_params(void *provctx, OSSL_PARAM params[])
     p = OSSL_PARAM_locate(params, OSSL_PROV_PARAM_STATUS);
     if (p != NULL && !OSSL_PARAM_set_int(p, 1)) // provider is always running
         return 0;
+    // not passing in params to respond to is no error; response is empty then
     return 1;
 }
 


### PR DESCRIPTION
This checks all functions taking an OSSL_PARAM list as to whether missing parameters have a negative impact to their logic.

Fixes #295.
