### PR TITLE
Fix minor typos in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ via the standard commands, i.e.,
 
 In addition, algorithms not denoted with "\*" above are not enabled for
 TLS operations. This designation [can be changed by modifying the
-"enabled" flags in the main alorithm configuration file](CONFIGURE.md#pre-build-configuration).
+"enabled" flags in the main algorithm configuration file](CONFIGURE.md#pre-build-configuration).
 
 In order to support parallel use of classic and quantum-safe cryptography 
 this provider also provides different hybrid algorithms, combining classic

--- a/STANDARDS.md
+++ b/STANDARDS.md
@@ -26,5 +26,5 @@ components, this provider implements the following standards:
   - Hybrid post-quantum / traditional private keys:
     - Simple concatenation of traditional and post-quantum components in plain binary / OCTET_STRING representations.
 
-Additionally worthwhile noting is that only quantum-safe [signature algorithms](#signature-algorithms) are persisted via PKCS#8 and X.509. No corresponding encoder/decoder logic exists for quantum safe [KEM algorithms](#kem-algorithms) -- See also #194.
+Additionally worthwhile noting is that only quantum-safe [signature algorithms](README.md#signature-algorithms) are persisted via PKCS#8 and X.509. No corresponding encoder/decoder logic exists for quantum safe [KEM algorithms](README.md#kem-algorithms) -- See also [#194](https://github.com/open-quantum-safe/oqs-provider/issues/194).
 


### PR DESCRIPTION
Fixed minor typos and incorrect links in README.md and STANDARDS.md


