### PR TITLE
Fix broken circleci job for macOS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,7 +166,7 @@ jobs:
       - when:
           condition:
             not:
-              equal: [ openssl@3.1, << parameters.OPENSSL_PREINSTALL >> ]
+              equal: [ openssl@3, << parameters.OPENSSL_PREINSTALL >> ]
           steps:
             - run:
                 name: Clone and build OpenSSL(3) master
@@ -186,7 +186,7 @@ jobs:
                   fi
       - when:
           condition:
-              equal: [ openssl@3.1, << parameters.OPENSSL_PREINSTALL >> ]
+              equal: [ openssl@3, << parameters.OPENSSL_PREINSTALL >> ]
           steps:
             - run:
                 name: Build OQS-OpenSSL provider

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ run the following command in the project main directory prior to finishing a PR:
 If encountering CI errors in CircleCI, it may be helpful to execute the test jobs
 locally to debug. This can be facilitated by executing the command
 
-   circleci local execute --job some-test-job
+   circleci local execute [--job] some-test-job
 
 assuming "some-test-job" is the name of the test to be executed and the CircleCI
 [command line tools have been installed](https://circleci.com/docs/local-cli).


### PR DESCRIPTION
This PR updates the openssl version to be installed for testing macOS builds

The circleci config file currently points to openssl@3.1 to install openssl for macOS. This change was made as part of the following [PR](https://github.com/open-quantum-safe/oqs-provider/commit/080c3dd2703a6b26f0aca12b265346a15f87c43e), where previously `openssl@3` pointed to `openssl v3.0.x` which was causing errors trying to build oqs-provider. So the change was made to specify `openssl@3.1`. OpenSSL v3.2 was released last week and the circleci jobs for macOS started failing since `openssl@3.1` is no longer available to install using homebrew. Instead the following are the options: `openssl@3` (which points to the current stable version, v3.2), `openssl@3.0` and `openssl@1.1`.

Changes made in this PR include:
- pointing the openssl version back to `openssl@3` since it now points to the latest 3.2
- a small doc change to the CONTRIBUTING doc to update the circleci command to run a specific job locally. (This command no longer accepts the --job option)
