### PR TITLE
Get Windows CI to work again

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -215,7 +215,7 @@ jobs:
         msarch:
           - x64
         type:
-#          - Debug
+          - Debug
           - Release
     runs-on: ${{matrix.os}}
     steps:


### PR DESCRIPTION
Fixes #290 #291 

The architecture of OpenSSL building is wrong