### PR TITLE
Rename variable OQS_ALGS_ENABLED to DOQS_ALGS_ENABLED in fullbuild.sh

### DIFF
--- a/scripts/fullbuild.sh
+++ b/scripts/fullbuild.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -x #echo on
+
 # The following variables influence the operation of this build script:
 # Argument -f: Soft clean, ensuring re-build of oqs-provider binary
 # Argument -F: Hard clean, ensuring checkout and build of all dependencies


### PR DESCRIPTION
<!-- Please give a brief explanation of the purpose of this pull request. -->

This pull request includes a minor modification to the ``fullbuild.sh`` script. The variable ``OQS_ALGS_ENABLED`` has been renamed to ``DOQS_ALGS_ENABLED.`` This change also affects the export statement, which now reflects the new variable name.

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

This modification doesn’t seem to resolve any specific issue, but appears to be a part of a larger refactoring or renaming process within the codebase. 

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->
