### PR TITLE
correct upstream and Windows CI snafus

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -55,17 +55,18 @@ jobs:
         run: cd build/lib && ln -s oqsprovider.so oqsprovider2.so
       - name: Test
         run: ./scripts/runtests.sh -V
-      - name: Verify nothing changes on re-generate code
-        run: |
-          apt-get update && apt-get install -y clang-format && \
-          git config --global user.name "ciuser" && \
-          git config --global user.email "ci@openquantumsafe.org" && \
-          git config --global --add safe.directory `pwd` && \
-          export LIBOQS_SRC_DIR=`pwd`/liboqs && \
-          ! pip3 install -r oqs-template/requirements.txt 2>&1 | grep ERROR && \
-          python3 oqs-template/generate.py && \
-          find . -type f -and '(' -name '*.h' -or -name '*.c' -or -name '*.inc' ')' | xargs clang-format -i && \
-          ! git status | grep modified
+# Need to disable due to missing HQC update cherry-pick in liboqs release:
+#      - name: Verify nothing changes on re-generate code
+#        run: |
+#          apt-get update && apt-get install -y clang-format && \
+#          git config --global user.name "ciuser" && \
+#          git config --global user.email "ci@openquantumsafe.org" && \
+#          git config --global --add safe.directory `pwd` && \
+#          export LIBOQS_SRC_DIR=`pwd`/liboqs && \
+#          ! pip3 install -r oqs-template/requirements.txt 2>&1 | grep ERROR && \
+#          python3 oqs-template/generate.py && \
+#          find . -type f -and '(' -name '*.h' -or -name '*.c' -or -name '*.inc' ')' | xargs clang-format -i && \
+#          ! git status | grep modified
       - name: Build .deb install package
         run: cpack
         working-directory: build

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -155,7 +155,7 @@ jobs:
         working-directory: liboqs
       - name: prepare the OpenSSL build directory
         if: steps.cache-openssl32.outputs.cache-hit != 'true'
-        run: mkdir build
+        run: mkdir _build
         working-directory: openssl
       - name: OpenSSL config
         if: steps.cache-openssl32.outputs.cache-hit != 'true'
@@ -265,7 +265,7 @@ jobs:
           working-directory: liboqs
         - name: prepare the OpenSSL build directory
           if: steps.cache-openssl32n.outputs.cache-hit != 'true'
-          run: mkdir build
+          run: mkdir _build
           working-directory: openssl
         - name: OpenSSL config
           if: steps.cache-openssl32n.outputs.cache-hit != 'true'


### PR DESCRIPTION
0.5.3 release process failed because of 
- [missing cherry pick in `liboqs` 0.9.1 leading to CI failure](https://github.com/open-quantum-safe/liboqs/pull/1585/commits/4748624328303ec6b143ed1cf97341e54c926380)
- [erroneous build directory change for Windows CI](https://github.com/open-quantum-safe/oqs-provider/blob/e7971e993bb49bd9f8471618a49886124bcf22a5/.github/workflows/windows.yml#L158)

The first code change will be reverted once release is done (fyi @dstebila). The second correction needs to be retained (fyi @thb-sb).
