### PR TITLE
Revert "Use `build` directory instead of `_build`. (#314)"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ jobs:
           name: Clone and build liboqs (<< parameters.CMAKE_ARGS >>)
           command: |
              git clone --depth 1 --branch main https://github.com/open-quantum-safe/liboqs.git &&
-             cd liboqs && mkdir build && cd build &&
+             cd liboqs && mkdir _build && cd _build &&
              cmake -GNinja << parameters.CMAKE_ARGS >> -DCMAKE_INSTALL_PREFIX=$(pwd)/../../.local .. && ninja install &&
              cd .. && cd .. && pwd
       - when:
@@ -61,9 +61,9 @@ jobs:
                   if << parameters.OQS_PROVIDER_BUILD_STATIC >> ; then
                     oqsprovider_cmake_args="${oqsprovider_cmake_args} -DOQS_PROVIDER_BUILD_STATIC=ON"
                   fi
-                  mkdir build && cd build && cmake -GNinja ${oqsprovider_cmake_args} -DUSE_ENCODING_LIB=ON -DOPENSSL_ROOT_DIR=$(pwd)/../.local -DCMAKE_PREFIX_PATH=$(pwd)/../.local .. && ninja && cd ..
+                  mkdir _build && cd _build && cmake -GNinja ${oqsprovider_cmake_args} -DUSE_ENCODING_LIB=ON -DOPENSSL_ROOT_DIR=$(pwd)/../.local -DCMAKE_PREFIX_PATH=$(pwd)/../.local .. && ninja && cd ..
                   if << parameters.OQS_PROVIDER_BUILD_STATIC >> ; then
-                    file build/lib/oqsprovider.a
+                    file _build/lib/oqsprovider.a
                   fi
       - when:
           condition:
@@ -76,15 +76,15 @@ jobs:
                   if << parameters.OQS_PROVIDER_BUILD_STATIC >> ; then
                     oqsprovider_cmake_args="${oqsprovider_cmake_args} -DOQS_PROVIDER_BUILD_STATIC=ON"
                   fi
-                  mkdir build && cd build && cmake -GNinja ${oqsprovider_cmake_args} -DUSE_ENCODING_LIB=ON -DCMAKE_PREFIX_PATH=$(pwd)/../.local .. && ninja && cd ..
+                  mkdir _build && cd _build && cmake -GNinja ${oqsprovider_cmake_args} -DUSE_ENCODING_LIB=ON -DCMAKE_PREFIX_PATH=$(pwd)/../.local .. && ninja && cd ..
                   if << parameters.OQS_PROVIDER_BUILD_STATIC >> ; then
-                    file build/lib/oqsprovider.a
+                    file _build/lib/oqsprovider.a
                   fi
       - run:
           name: Run tests
           command: |
              if << parameters.OQS_PROVIDER_BUILD_STATIC >> ; then
-               ctest --test-dir build/
+               ctest --test-dir _build/
              else
                ./scripts/runtests.sh -V
              fi
@@ -107,15 +107,15 @@ jobs:
             if << parameters.OQS_PROVIDER_BUILD_STATIC >> ; then
               oqsprovider_cmake_args="${oqsprovider_cmake_args} -DOQS_PROVIDER_BUILD_STATIC=ON"
             fi
-            rm -rf build && mkdir build && cd build && cmake -GNinja ${oqsprovider_cmake_args} -DNOPUBKEY_IN_PRIVKEY=ON -DUSE_ENCODING_LIB=ON -DOPENSSL_ROOT_DIR=$(pwd)/../.local -DCMAKE_PREFIX_PATH=$(pwd)/../.local .. && ninja
+            rm -rf _build && mkdir _build && cd _build && cmake -GNinja ${oqsprovider_cmake_args} -DNOPUBKEY_IN_PRIVKEY=ON -DUSE_ENCODING_LIB=ON -DOPENSSL_ROOT_DIR=$(pwd)/../.local -DCMAKE_PREFIX_PATH=$(pwd)/../.local .. && ninja
             if << parameters.OQS_PROVIDER_BUILD_STATIC >> ; then
-              file build/lib/oqsprovider.a
+              file _build/lib/oqsprovider.a
             fi
       - run:
           name: Run tests (-DNOPUBKEY_IN_PRIVKEY=ON)
           command: |
              if << parameters.OQS_PROVIDER_BUILD_STATIC >> ; then
-               ctest --test-dir build/
+               ctest --test-dir _build/
              else
                ./scripts/runtests.sh -V
              fi
@@ -159,7 +159,7 @@ jobs:
           name: Clone and build liboqs
           command: |
              git clone --depth 1 --branch main https://github.com/open-quantum-safe/liboqs.git &&
-             export LIBOQS_INSTALLPATH=$(pwd)/.local && cd liboqs && mkdir build && cd build &&
+             export LIBOQS_INSTALLPATH=$(pwd)/.local && cd liboqs && mkdir _build && cd _build &&
              export OPENSSL_INSTALL="$(brew --prefix << parameters.OPENSSL_PREINSTALL >> || echo "")"
              cmake -GNinja -DOPENSSL_ROOT_DIR="${OPENSSL_INSTALL}" -DCMAKE_INSTALL_PREFIX=$LIBOQS_INSTALLPATH << parameters.CMAKE_ARGS >> .. && ninja install &&
              cd .. && cd .. && echo "export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:$LIBOQS_INSTALLPATH/lib" >> "$BASH_ENV"
@@ -180,9 +180,9 @@ jobs:
                   if << parameters.OQS_PROVIDER_BUILD_STATIC >> ; then
                     oqsprovider_cmake_args="${oqsprovider_cmake_args} -DOQS_PROVIDER_BUILD_STATIC=ON"
                   fi
-                  export OPENSSL_INSTALL=$(pwd)/.local && mkdir build && cd build && cmake -GNinja -DOPENSSL_ROOT_DIR=$OPENSSL_INSTALL -DCMAKE_PREFIX_PATH=$(pwd)/../.local ${oqsprovider_cmake_args} .. && ninja && echo "export OPENSSL_INSTALL=$OPENSSL_INSTALL" >> "$BASH_ENV"
+                  export OPENSSL_INSTALL=$(pwd)/.local && mkdir _build && cd _build && cmake -GNinja -DOPENSSL_ROOT_DIR=$OPENSSL_INSTALL -DCMAKE_PREFIX_PATH=$(pwd)/../.local ${oqsprovider_cmake_args} .. && ninja && echo "export OPENSSL_INSTALL=$OPENSSL_INSTALL" >> "$BASH_ENV"
                   if << parameters.OQS_PROVIDER_BUILD_STATIC >> ; then
-                    file build/lib/oqsprovider.a
+                    file _build/lib/oqsprovider.a
                   fi
       - when:
           condition:
@@ -196,15 +196,15 @@ jobs:
                     oqsprovider_cmake_args="${oqsprovider_cmake_args} -DOQS_PROVIDER_BUILD_STATIC=ON"
                   fi
                   export OPENSSL_INSTALL="$(brew --prefix << parameters.OPENSSL_PREINSTALL >>)"
-                  mkdir build && cd build && liboqs_DIR=`pwd`/../.local cmake -GNinja -DOPENSSL_ROOT_DIR="${OPENSSL_INSTALL}" ${oqsprovider_cmake_args} .. && ninja && echo "export OPENSSL_INSTALL=$OPENSSL_INSTALL" >> "$BASH_ENV" && cd .. && echo "export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:$OPENSSL_INSTALL/lib" >> "$BASH_ENV"
+                  mkdir _build && cd _build && liboqs_DIR=`pwd`/../.local cmake -GNinja -DOPENSSL_ROOT_DIR="${OPENSSL_INSTALL}" ${oqsprovider_cmake_args} .. && ninja && echo "export OPENSSL_INSTALL=$OPENSSL_INSTALL" >> "$BASH_ENV" && cd .. && echo "export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:$OPENSSL_INSTALL/lib" >> "$BASH_ENV"
                   if << parameters.OQS_PROVIDER_BUILD_STATIC >> ; then
-                    file build/lib/oqsprovider.a
+                    file _build/lib/oqsprovider.a
                   fi
       - run:
           name: Run tests
           command: |
              if << parameters.OQS_PROVIDER_BUILD_STATIC >> ; then
-               ctest --test-dir build/ --output-on-failure
+               ctest --test-dir _build/ --output-on-failure
              else
                ./scripts/runtests.sh -V
              fi
@@ -215,15 +215,15 @@ jobs:
              if << parameters.OQS_PROVIDER_BUILD_STATIC >> ; then
                oqsprovider_cmake_args="${oqsprovider_cmake_args} -DOQS_PROVIDER_BUILD_STATIC=ON"
              fi
-             rm -rf build && mkdir build && cd build && cmake -GNinja -DUSE_ENCODING_LIB=ON -DOPENSSL_ROOT_DIR=$OPENSSL_INSTALL -DCMAKE_PREFIX_PATH=$(pwd)/../.local ${oqsprovider_cmake_args} .. && ninja
+             rm -rf _build && mkdir _build && cd _build && cmake -GNinja -DUSE_ENCODING_LIB=ON -DOPENSSL_ROOT_DIR=$OPENSSL_INSTALL -DCMAKE_PREFIX_PATH=$(pwd)/../.local ${oqsprovider_cmake_args} .. && ninja
              if << parameters.OQS_PROVIDER_BUILD_STATIC >> ; then
-               file build/lib/oqsprovider.a
+               file _build/lib/oqsprovider.a
              fi
       - run:
           name: Run tests
           command: |
              if << parameters.OQS_PROVIDER_BUILD_STATIC >> ; then
-               ctest --test-dir build/ --output-on-failure
+               ctest --test-dir _build/ --output-on-failure
              else
                ./scripts/runtests.sh -V
              fi

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Full build
         run: OQSPROV_CMAKE_PARAMS=${{ matrix.cmake-params}} ./scripts/fullbuild.sh
       - name: Enable sibling oqsprovider for testing
-        run: cd build/lib && ln -s oqsprovider.so oqsprovider2.so
+        run: cd _build/lib && ln -s oqsprovider.so oqsprovider2.so
       - name: Test
         run: ./scripts/runtests.sh -V
 
@@ -52,7 +52,7 @@ jobs:
       - name: Full build
         run: OPENSSL_BRANCH=${{ matrix.ossl-branch }} LIBOQS_BRANCH=0.9.1 ./scripts/fullbuild.sh
       - name: Enable sibling oqsprovider for testing
-        run: cd build/lib && ln -s oqsprovider.so oqsprovider2.so
+        run: cd _build/lib && ln -s oqsprovider.so oqsprovider2.so
       - name: Test
         run: ./scripts/runtests.sh -V
 # Need to disable due to missing HQC update cherry-pick in liboqs release:
@@ -69,12 +69,12 @@ jobs:
 #          ! git status | grep modified
       - name: Build .deb install package
         run: cpack
-        working-directory: build
+        working-directory: _build
       - name: Retain .deb installer
         uses: actions/upload-artifact@v3
         with:
           name: oqsprovider-x64
-          path: build/*.deb
+          path: _build/*.deb
 
   asan_linux_intel:
     name: "Security checks"

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -57,17 +57,17 @@ jobs:
           key: ${{ runner.os }}-openssl32
       - name: build liboqs
         run: |
-           cmake -DOPENSSL_ROOT_DIR=../.localopenssl32 -DCMAKE_INSTALL_PREFIX=../.localliboqs ${{ matrix.params.oqsconfig }} -S . -B build
-           cmake --build build
-           cmake --install build
+           cmake -DOPENSSL_ROOT_DIR=../.localopenssl32 -DCMAKE_INSTALL_PREFIX=../.localliboqs ${{ matrix.params.oqsconfig }} -S . -B _build 
+           cmake --build _build
+           cmake --install _build
         working-directory: liboqs
       - name: build oqs-provider
-        run: liboqs_DIR=.localliboqs cmake -DOPENSSL_ROOT_DIR=.localopenssl32 -S . -B build && cmake --build build
+        run: liboqs_DIR=.localliboqs cmake -DOPENSSL_ROOT_DIR=.localopenssl32 -S . -B _build && cmake --build _build
       - name: Check Openssl providers
-        run: OPENSSL_MODULES=build/lib .localopenssl32/bin/openssl list -providers -provider oqsprovider -provider default
+        run: OPENSSL_MODULES=_build/lib .localopenssl32/bin/openssl list -providers -provider oqsprovider -provider default
       - name: Run tests
         run: PATH=../.localopenssl32/bin:$PATH ctest -V
-        working-directory: build
+        working-directory: _build
       # Try brew install of head: If error message below appears, build and test passed successfully
       - name: brew install test
         run: brew install --HEAD --formula -s oqsprovider.rb 2>&1 | grep "Empty installation"
@@ -76,4 +76,4 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: oqs-provider-${{matrix.os}}-x64
-          path: build/lib/oqsprovider.dylib
+          path: _build/lib/oqsprovider.dylib

--- a/.github/workflows/standalone.yml
+++ b/.github/workflows/standalone.yml
@@ -5,7 +5,7 @@ on:
     branches: [ '*' ]
   pull_request:
     branches: [ "main" ]
-
+    
 jobs:
 
   macos_intel:
@@ -18,9 +18,9 @@ jobs:
       - name: Checkout oqsprovider code
         uses: actions/checkout@v2
       - name: Build oqsprovider
-        run: cmake -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl@3 -S . -B build && cmake --build build
+        run: cmake -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl@3 -S . -B _build && cmake --build _build
       - name: Test oqsprovider
-        run: ctest --parallel 5 --test-dir build
+        run: ctest --parallel 5 --test-dir _build
 
   linux_intel:
     runs-on: ubuntu-latest

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -58,8 +58,8 @@ jobs:
            which cmake
            cmake --version
            gcc --version
-           mkdir build
-           cd build
+           mkdir _build
+           cd _build
            cmake -GNinja -DOPENSSL_ROOT_DIR=/opt/openssl32 -DCMAKE_INSTALL_PREFIX="${{ env.IP }}" ${{ matrix.platform.oqsconfig }} -DCMAKE_C_COMPILER=gcc ..
            ninja
            ninja install
@@ -79,17 +79,17 @@ jobs:
             c:\cygwin\opt\openssl32
           key: ${{ runner.os }}-cygwinopenssl32
       - name: build oqs-provider
-        run: bash -c "git config --global --add safe.directory $(cygpath -u $PWD) && liboqs_DIR='${{ env.IP }}' cmake -GNinja -DCMAKE_C_COMPILER=gcc -DOPENSSL_ROOT_DIR=/opt/openssl32 -S . -B build && cd build && ninja && cd .."
+        run: bash -c "git config --global --add safe.directory $(cygpath -u $PWD) && liboqs_DIR='${{ env.IP }}' cmake -GNinja -DCMAKE_C_COMPILER=gcc -DOPENSSL_ROOT_DIR=/opt/openssl32 -S . -B _build && cd _build && ninja && cd .."
       - name: Check Openssl providers
-        run: bash -c "OPENSSL_MODULES=build/lib /opt/openssl32/bin/openssl list -providers -provider oqsprovider -provider default"
+        run: bash -c "OPENSSL_MODULES=_build/lib /opt/openssl32/bin/openssl list -providers -provider oqsprovider -provider default"
       - name: Run tests
         run: bash -c "echo $PATH && PATH=/opt/openssl32/bin:/usr/bin ctest -V"
-        working-directory: build
+        working-directory: _build
       - name: Retain oqsprovider.dll
         uses: actions/upload-artifact@v3
         with:
           name: oqs-provider-cygwin
-          path: D:/a/oqs-provider/oqs-provider/build/bin/oqsprovider.dll
+          path: D:/a/oqs-provider/oqs-provider/_build/bin/oqsprovider.dll
 
   msvc:
 # Run a job for each of the specified target architectures:
@@ -140,10 +140,10 @@ jobs:
         if: steps.cache-openssl32.outputs.cache-hit != 'true'
 # OQS_USE_OPENSSL=OFF by default on Win32
 # if cmake --build fails, try explicit
-# cd build && msbuild ALL_BUILD.vcxproj -p:Configuration=Release
-# fails:          cmake -DCMAKE_C_FLAGS="/wd5105" -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_INSTALL_PREFIX="c:\liboqs" ${{ matrix.platform.oqsconfig }} -S . -B build
-#          cd build && msbuild ALL_BUILD.vcxproj -p:Configuration=Release && cd ..
-#          cmake --install build
+# cd _build && msbuild ALL_BUILD.vcxproj -p:Configuration=Release
+# fails:          cmake -DCMAKE_C_FLAGS="/wd5105" -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_INSTALL_PREFIX="c:\liboqs" ${{ matrix.platform.oqsconfig }} -S . -B _build
+#          cd _build && msbuild ALL_BUILD.vcxproj -p:Configuration=Release && cd ..
+#          cmake --install _build
       - name: build liboqs
         run: |
           cmake --version
@@ -188,17 +188,17 @@ jobs:
           key: ${{ runner.os }}-msvcopenssl32
       - name: build oqs-provider
         run: |
-          cmake -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS="/wd5105" -DOPENSSL_ROOT_DIR="c:\openssl32" -Dliboqs_DIR="c:\liboqs\lib\cmake\liboqs" -S . -B build
-          cd build
+          cmake -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS="/wd5105" -DOPENSSL_ROOT_DIR="c:\openssl32" -Dliboqs_DIR="c:\liboqs\lib\cmake\liboqs" -S . -B _build
+          cd _build
           ninja
       - name: Run tests
         run: |
-          ctest -V --test-dir build
+          ctest -V --test-dir _build
       - name: Retain oqsprovider.dll
         uses: actions/upload-artifact@v3
         with:
           name: oqs-provider-msvc
-          path: D:/a/oqs-provider/oqs-provider/build/lib/oqsprovider.dll
+          path: D:/a/oqs-provider/oqs-provider/_build/lib/oqsprovider.dll
 
   msvc_native:
 # Run a job for each of the specified target architectures:
@@ -211,7 +211,7 @@ jobs:
           - arch: win64
             oqsconfig: -DOQS_ALGS_ENABLED=STD
             osslconfig: no-shared no-fips VC-WIN64A
-        toolchain:
+        toolchain: 
         - .CMake/toolchain_windows_amd64.cmake
         msarch:
           - x64
@@ -260,7 +260,7 @@ jobs:
           run: |
             cmake --version
             cmake -B build --toolchain ${{ matrix.toolchain }} .
-            cmake --build build
+            cmake --build build 
             cmake --build build --target INSTALL
           working-directory: liboqs
         - name: prepare the OpenSSL build directory
@@ -294,14 +294,14 @@ jobs:
             key: ${{ runner.os }}-msvcopenssl32n
         - name: build oqs-provider
           run: |
-            cmake -DCMAKE_BUILD_TYPE=${{ matrix.type }} -DCMAKE_C_FLAGS="/wd5105" -DOPENSSL_ROOT_DIR="c:\openssl32n" -Dliboqs_DIR="c:\liboqs\lib\cmake\liboqs" -S . -B build
-            cmake --build build --config=${{ matrix.type }}
+            cmake -DCMAKE_BUILD_TYPE=${{ matrix.type }} -DCMAKE_C_FLAGS="/wd5105" -DOPENSSL_ROOT_DIR="c:\openssl32n" -Dliboqs_DIR="c:\liboqs\lib\cmake\liboqs" -S . -B _build
+            cmake --build _build --config=${{ matrix.type }}
         - name: Run tests
           run: |
-            ctest --test-dir build -C ${{ matrix.type }}
+            ctest --test-dir _build -C ${{ matrix.type }}
         - name: Retain oqsprovider.dll
           uses: actions/upload-artifact@v3
           with:
             name: oqs-provider-msvc
-            path: D:/a/oqs-provider/oqs-provider/build/lib/oqsprovider.dll
-
+            path: D:/a/oqs-provider/oqs-provider/_build/lib/oqsprovider.dll
+          

--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,12 @@
 # checked out OSSL variants
-openssl*/*
+openssl*/* 
 openssl
 # checked out liboqs
 liboqs
 # installed SW
 .local
 # build directory
-build
+_build
 # generated from openssl src:
 test/ssltestlib.c
 test/ssltestlib.h

--- a/ALGORITHMS.md
+++ b/ALGORITHMS.md
@@ -107,7 +107,7 @@ can be used to successfully confirm interoperability between the oqs-provider
 and the Cloudflare infrastructure using this hybrid classic/quantum-safe algorithm:
 
 ```
-OQS_CODEPOINT_X25519_KYBER512=65072  ./openssl/apps/openssl s_client -groups x25519_kyber512 -connect cloudflare.com:443 -provider-path build/oqsprov -provider oqsprovider -provider default
+OQS_CODEPOINT_X25519_KYBER512=65072  ./openssl/apps/openssl s_client -groups x25519_kyber512 -connect cloudflare.com:443 -provider-path _build/oqsprov -provider oqsprovider -provider default
 ```
 
 # OIDs

--- a/NOTES-UNIX.md
+++ b/NOTES-UNIX.md
@@ -28,30 +28,30 @@ to be present to be build, e.g., via `apt install cmake build-essential git`.
 ## Build
 
 Standard `cmake` build sequence can be used (assuming prerequisites are installed)
-to build in/install from directory `build`:
+to build in/install from directory `_build`:
 
-    cmake -S . -B build && cmake --build build && cmake --install build
+    cmake -S . -B _build && cmake --build _build && cmake --install _build
 
 If `openssl` and/or `liboqs` have not been installed to system standard locations
-use the `cmake` define "-DOPENSSL_ROOT_DIR" and/or the environment variable
+use the `cmake` define "-DOPENSSL_ROOT_DIR" and/or the environment variable 
 "liboqs_DIR" to utilize those, e.g., like this:
 
-    liboqs_DIR=../liboqs cmake -DOPENSSL_ROOT_DIR=/opt/openssl3 -S . -B build && cmake --build build && cmake --install build
+    liboqs_DIR=../liboqs cmake -DOPENSSL_ROOT_DIR=/opt/openssl3 -S . -B _build && cmake --build _build && cmake --install _build
 
 Further configuration options are documented [here](CONFIGURE.md#build-install-options).
 
 ## Test
 
-Standard `ctest` can be used to validate correct operation in build directory `build`, e.g.:
+Standard `ctest` can be used to validate correct operation in build directory `_build`, e.g.:
 
-    cd build && ctest --parallel 5 --rerun-failed --output-on-failure -V
+    cd _build && ctest --parallel 5 --rerun-failed --output-on-failure -V
 
 ## Packaging
 
 ### Debian
 
 A build target to create UNIX .deb packaging is available via the standard
-`package` target, e.g., executing `make package` in the `build` subdirectory.
+`package` target, e.g., executing `make package` in the `_build` subdirectory.
 The resultant file can be installed as usual via `dpkg -i ...`.
 
 ### MacOS

--- a/NOTES-Windows.md
+++ b/NOTES-Windows.md
@@ -17,7 +17,7 @@ A complete scripted setup is available in the [CI tooling for oqs-provider](http
 
 ### liboqs
 
-Instructions for building `liboqs` from source is available
+Instructions for building `liboqs` from source is available 
 [here](https://github.com/open-quantum-safe/liboqs#windows).
 
 ## Build tooling
@@ -28,9 +28,9 @@ a C compiler are present, e.g., as in MS Visual Studio 2022.
 ## Build
 
 A standard `cmake` build sequence can be used (assuming prerequisites are installed)
-to build in/install from directory `build`:
+to build in/install from directory `_build`:
 
-    cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS="/wd5105" -GNinja -S . -B build && cd build && ninja && ninja install
+    cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS="/wd5105" -GNinja -S . -B _build && cd _build && ninja && ninja install
 
 The specific `CMAKE_C_FLAGS` silence some overly strict warning messages and
 the specific reference to the build type ensures a shared library with
@@ -41,15 +41,15 @@ If `openssl` and/or `liboqs` have not been installed to system standard location
 use the `cmake` defines "-DOPENSSL_ROOT_DIR" and/or "-Dliboqs_DIR" to utilize
 those, e.g., like this:
 
-    cmake -DOPENSSL_ROOT_DIR=c:\opt\openssl3 -Dliboqs_DIR=c:\liboqs -S . -B build && cmake --build build && cmake --install build
+    cmake -DOPENSSL_ROOT_DIR=c:\opt\openssl3 -Dliboqs_DIR=c:\liboqs -S . -B _build && cmake --build _build && cmake --install _build
 
 Further configuration options are documented [here](CONFIGURE.md#build-install-options).
 
 ## Test
 
-Standard `ctest` can be used to validate correct operation in build directory `build`, e.g.:
+Standard `ctest` can be used to validate correct operation in build directory `_build`, e.g.:
 
-    ctest -V --test-dir build
+    ctest -V --test-dir _build
 
 ## Packaging
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ key establishment in TLS1.3 including management of such keys via the
 OpenSSL (3.0) provider interface and hybrid KEM schemes. Also, QSC
 signatures including CMS and CMP functionality are available via the OpenSSL
 EVP interface. Key persistence is provided via the encode/decode
-mechanism and X.509 data structures. Starting with OpenSSL 3.2 support for
+mechanism and X.509 data structures. Starting with OpenSSL 3.2 support for 
 TLS1.3 signature functionality is available and final glitches for CMS
 have been resolved.
 
@@ -62,7 +62,7 @@ In addition, algorithms not denoted with "\*" above are not enabled for
 TLS operations. This designation [can be changed by modifying the
 "enabled" flags in the main algorithm configuration file](CONFIGURE.md#pre-build-configuration).
 
-In order to support parallel use of classic and quantum-safe cryptography
+In order to support parallel use of classic and quantum-safe cryptography 
 this provider also provides different hybrid algorithms, combining classic
 and quantum-safe methods: These are listed above with a prefix denoting a
 classic algorithm, e.g., for elliptic curve: "p256_".
@@ -80,7 +80,7 @@ respectively (tested on Linux Ubuntu and Mint as well as MacOS).
 
 By default, these scripts always build and test against the current OpenSSL `master` branch.
 
-These scripts can be [configured by setting various variables](CONFIGURE.md#convenience-build-script-options). Please note that these scripts do _not_ install `oqsprovider`. This can be facilitated by running `cmake --install build` (and following the [activation instructions](USAGE.md#activation).
+These scripts can be [configured by setting various variables](CONFIGURE.md#convenience-build-script-options). Please note that these scripts do _not_ install `oqsprovider`. This can be facilitated by running `cmake --install _build` (and following the [activation instructions](USAGE.md#activation).
 
 Building and testing
 --------------------
@@ -104,8 +104,8 @@ for details.
 
 ## Basic steps
 
-    cmake -S . -B build && cmake --build build && ctest --test-dir build && cmake --install build
-
+    cmake -S . -B _build && cmake --build _build && ctest --test-dir _build && cmake --install _build
+    
 Using
 -----
 

--- a/scripts/common.py
+++ b/scripts/common.py
@@ -28,7 +28,7 @@ def all_pq_groups():
     ag = ""
     for kex in key_exchanges:
         if len(ag)==0:
-           ag = kex
+           ag = kex 
         else:
            ag = ag + ":" + kex
     return ag
@@ -158,7 +158,7 @@ def gen_keys(ossl, ossl_config, sig_alg, test_artifacts_dir, filename_prefix):
     # also create pubkeys from certs for dgst verify tests:
     env = os.environ
     #env["OPENSSL_CONF"]=os.path.join("scripts", "openssl.cnf")
-    #env["OPENSSL_MODULES"]=os.path.join("build", "lib")
+    #env["OPENSSL_MODULES"]=os.path.join("_build", "lib")
     run_subprocess([ossl, 'req',
                                   '-in', os.path.join(test_artifacts_dir, '{}_{}_srv.csr'.format(filename_prefix, sig_alg)),
                                   '-pubkey', '-out', os.path.join(test_artifacts_dir, '{}_{}_srv.pubk'.format(filename_prefix, sig_alg)) ],

--- a/scripts/fullbuild.sh
+++ b/scripts/fullbuild.sh
@@ -21,10 +21,10 @@ fi
 
 if [ $# -gt 0 ]; then
    if [ "$1" == "-f" ]; then
-      rm -rf build
+      rm -rf _build
    fi
    if [ "$1" == "-F" ]; then
-      rm -rf build openssl liboqs .local
+      rm -rf _build openssl liboqs .local
    fi
 fi
 
@@ -107,7 +107,7 @@ if [ -z $liboqs_DIR ]; then
   #    STD: only include NIST standardized algorithms
   #    NIST_R4: only include algorithms in round 4 of the NIST competition
   #    All: include all algorithms supported by liboqs (default)
-  cd liboqs && cmake -GNinja $DOQS_ALGS_ENABLED $CMAKE_OPENSSL_LOCATION -DCMAKE_INSTALL_PREFIX=$(pwd)/../.local -S . -B build && cd build && ninja && ninja install && cd ../..
+  cd liboqs && cmake -GNinja $DOQS_ALGS_ENABLED $CMAKE_OPENSSL_LOCATION -DCMAKE_INSTALL_PREFIX=$(pwd)/../.local -S . -B _build && cd _build && ninja && ninja install && cd ../..
   if [ $? -ne 0 ]; then
       echo "liboqs build failed. Exiting."
       exit -1
@@ -117,16 +117,16 @@ if [ -z $liboqs_DIR ]; then
 fi
 
 # Check whether provider is built:
-if [ ! -f "build/lib/oqsprovider.$SHLIBEXT" ]; then
-   echo "oqsprovider (build/lib/oqsprovider.$SHLIBEXT) not built: Building..."
+if [ ! -f "_build/lib/oqsprovider.$SHLIBEXT" ]; then
+   echo "oqsprovider (_build/lib/oqsprovider.$SHLIBEXT) not built: Building..."
    # for full debug build add: -DCMAKE_BUILD_TYPE=Debug
    #BUILD_TYPE="-DCMAKE_BUILD_TYPE=Debug"
    BUILD_TYPE=""
    # for omitting public key in private keys add -DNOPUBKEY_IN_PRIVKEY=ON
    if [ -z "$OPENSSL_INSTALL" ]; then
-       cmake -DOPENSSL_ROOT_DIR=$(pwd)/.local $BUILD_TYPE $OQSPROV_CMAKE_PARAMS -S . -B build && cmake --build build
+       cmake -DOPENSSL_ROOT_DIR=$(pwd)/.local $BUILD_TYPE $OQSPROV_CMAKE_PARAMS -S . -B _build && cmake --build _build
    else
-       cmake -DOPENSSL_ROOT_DIR=$OPENSSL_INSTALL $BUILD_TYPE $OQSPROV_CMAKE_PARAMS -S . -B build && cmake --build build
+       cmake -DOPENSSL_ROOT_DIR=$OPENSSL_INSTALL $BUILD_TYPE $OQSPROV_CMAKE_PARAMS -S . -B _build && cmake --build _build
    fi
    if [ $? -ne 0 ]; then
      echo "provider build failed. Exiting."

--- a/scripts/release-test.sh
+++ b/scripts/release-test.sh
@@ -24,11 +24,11 @@ if [ -d oqs-template ]; then
     # Activate all algorithms
     sed -i "s/enable\: false/enable\: true/g" oqs-template/generate.yml
     python3 oqs-template/generate.py
-    rm -rf build
+    rm -rf _build
     ./scripts/fullbuild.sh
     ./scripts/runtests.sh
     if [ -f .local/bin/openssl ]; then
-        OPENSSL_MODULES=`pwd`/build/lib OPENSSL_CONF=`pwd`/scripts/openssl-ca.cnf python3 -m pytest --numprocesses=auto scripts/test_tls_full.py
+        OPENSSL_MODULES=`pwd`/_build/lib OPENSSL_CONF=`pwd`/scripts/openssl-ca.cnf python3 -m pytest --numprocesses=auto scripts/test_tls_full.py
     else
         echo "For full TLS PQ SIG/KEM matrix test, build (latest) openssl locally."
     fi

--- a/scripts/runtests.sh
+++ b/scripts/runtests.sh
@@ -90,7 +90,7 @@ if [ -z "${OPENSSL_APP}" ]; then
 fi
 
 if [ -z "${OPENSSL_MODULES}" ]; then
-    export OPENSSL_MODULES="$(pwd)/build/lib"
+    export OPENSSL_MODULES="$(pwd)/_build/lib"
 fi
 
 if [ -z "${LD_LIBRARY_PATH}" ]; then
@@ -188,7 +188,7 @@ ${OQS_PROVIDER_TESTSCRIPTS}/oqsprovider-externalinterop.sh
 # Without removing OPENSSL_CONF ctest hangs... ???
 unset OPENSSL_CONF
 rv=0
-if ! ( cd build && ctest $@ ); then
+if ! ( cd _build && ctest $@ ); then
    rv=1
 fi
 


### PR DESCRIPTION
This reverts commit f205f116a82ea981278313b7bf2d9032c0710821.

See https://github.com/open-quantum-safe/oqs-provider/issues/318#issuecomment-1869069302.
