### PR TITLE
Automatically run release tests on liboqs release candidates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,40 @@
+name: Release tests
+
+on:
+  repository_dispatch:
+    types: [ "liboqs-release" ]
+
+jobs:
+  release-test:
+    runs-on: ubuntu-latest
+    container:
+      image: openquantumsafe/ci-ubuntu-jammy:latest
+
+    steps:
+      - name: Check if tracker branch exists
+        env:
+          tracker_branch: ${{ github.event.client_payload.tag }}-tracker
+        run: |
+          curl --silent \
+               --output /dev/null \
+               --write-out "\n%{response_code}\n" \
+               --request GET \
+               --header "Accept: application/vnd.github+json" \
+               --header "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+               --header "X-GitHub-Api-Version: 2022-11-28" \
+               https://api.github.com/repos/open-quantum-safe/oqs-provider/branches/$tracker_branch | tee curl_out \
+            && grep -q "200" curl_out \
+            && echo "target_branch=$tracker_branch" >> "$GITHUB_ENV" \
+            || echo "target_branch=main" >> "$GITHUB_ENV"
+      - name: Checkout oqs-provider on tracker branch if it exists; otherwise, fall back to main
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.target_branch }}
+      - name: Checkout liboqs at release tag
+        uses: actions/checkout@v4
+        with:
+          repository: open-quantum-safe/liboqs
+          path: liboqs
+          ref: ${{ github.event.client_payload.tag }}
+      - name: Run release tests
+        run: ./scripts/release-test.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,23 @@ on:
   repository_dispatch:
     types: [ "liboqs-release" ]
 
+# To trigger this job, generate a GitHub personal access token and run the following command:
+#
+# curl --request POST \
+#      --header "Accept: application/vnd.github+json" \
+#      --header "Authorization: Bearer YOUR_TOKEN_HERE" \
+#      --header "X-GitHub-Api-Version: 2022-11-28" \
+#      --data '{
+#                "event_type": "liboqs-release", \
+#                "client_payload": { \
+#                                    "provider_ref": "heads/PROVIDER_BRANCH_NAME_HERE", \
+#                                    "liboqs_ref": "heads/LIBOQS_BRANCH_NAME_HERE" \
+#                                  } \
+#              }' \
+#      https://api.github.com/repos/open-quantum-safe/oqs-provider/dispatches
+#
+# If you wish to target a tag instead of a branch, use "tags/TAG_NAME_HERE" instead of "heads/BRANCH_NAME_HERE".
+
 jobs:
   release-test:
     runs-on: ubuntu-latest
@@ -11,9 +28,9 @@ jobs:
       image: openquantumsafe/ci-ubuntu-jammy:latest
 
     steps:
-      - name: Check if tracker branch exists
+      - name: Check if requested ref exists
         env:
-          tracker_branch: ${{ github.event.client_payload.tag }}-tracker
+          provider_ref: ${{ github.event.client_payload.provider_ref }}
         run: |
           curl --silent \
                --output /dev/null \
@@ -22,19 +39,20 @@ jobs:
                --header "Accept: application/vnd.github+json" \
                --header "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
                --header "X-GitHub-Api-Version: 2022-11-28" \
-               https://api.github.com/repos/open-quantum-safe/oqs-provider/branches/$tracker_branch | tee curl_out \
+               https://api.github.com/repos/open-quantum-safe/oqs-provider/git/ref/$provider_ref | tee curl_out \
             && grep -q "200" curl_out \
-            && echo "target_branch=$tracker_branch" >> "$GITHUB_ENV" \
-            || echo "target_branch=main" >> "$GITHUB_ENV"
-      - name: Checkout oqs-provider on tracker branch if it exists; otherwise, fall back to main
+            && echo "provider_ref=$provider_ref" >> "$GITHUB_ENV" \
+            || echo "provider_ref=main" >> "$GITHUB_ENV"
+      - name: Checkout oqs-provider on requested ref if it exists; otherwise, fall back to main
         uses: actions/checkout@v4
         with:
-          ref: ${{ env.target_branch }}
-      - name: Checkout liboqs at release tag
+          ref: ${{ env.provider_ref }}
+      # This is designed to be triggered automatically from liboqs CI, so don't bother validating the liboqs ref.
+      - name: Checkout liboqs at requested ref
         uses: actions/checkout@v4
         with:
           repository: open-quantum-safe/liboqs
           path: liboqs
-          ref: ${{ github.event.client_payload.tag }}
+          ref: ${{ github.event.client_payload.liboqs_ref }}
       - name: Run release tests
-        run: ./scripts/release-test.sh
+        run: ./scripts/release-test-ci.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,15 +11,13 @@ on:
 #      --header "Authorization: Bearer YOUR_TOKEN_HERE" \
 #      --header "X-GitHub-Api-Version: 2022-11-28" \
 #      --data '{
-#                "event_type": "liboqs-release", \
-#                "client_payload": { \
-#                                    "provider_ref": "heads/PROVIDER_BRANCH_NAME_HERE", \
-#                                    "liboqs_ref": "heads/LIBOQS_BRANCH_NAME_HERE" \
-#                                  } \
+#                "event_type": "liboqs-release",
+#                "client_payload": {
+#                                    "provider_ref": "PROVIDER_BRANCH_OR_TAG_HERE",
+#                                    "liboqs_ref": "LIBOQS_BRANCH_OR_TAG_HERE"
+#                                  }
 #              }' \
 #      https://api.github.com/repos/open-quantum-safe/oqs-provider/dispatches
-#
-# If you wish to target a tag instead of a branch, use "tags/TAG_NAME_HERE" instead of "heads/BRANCH_NAME_HERE".
 
 jobs:
   release-test:
@@ -32,15 +30,17 @@ jobs:
         env:
           provider_ref: ${{ github.event.client_payload.provider_ref }}
         run: |
-          curl --silent \
-               --output /dev/null \
-               --write-out "\n%{response_code}\n" \
-               --request GET \
+          # try both branch and tag
+          wget --quiet \
                --header "Accept: application/vnd.github+json" \
                --header "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
                --header "X-GitHub-Api-Version: 2022-11-28" \
-               https://api.github.com/repos/open-quantum-safe/oqs-provider/git/ref/$provider_ref | tee curl_out \
-            && grep -q "200" curl_out \
+               https://api.github.com/repos/open-quantum-safe/oqs-provider/branches/$provider_ref || \
+          wget --quiet \
+               --header "Accept: application/vnd.github+json" \
+               --header "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+               --header "X-GitHub-Api-Version: 2022-11-28" \
+               https://api.github.com/repos/open-quantum-safe/oqs-provider/git/ref/tags/$provider_ref \
             && echo "provider_ref=$provider_ref" >> "$GITHUB_ENV" \
             || echo "provider_ref=main" >> "$GITHUB_ENV"
       - name: Checkout oqs-provider on requested ref if it exists; otherwise, fall back to main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,4 +55,4 @@ jobs:
           path: liboqs
           ref: ${{ github.event.client_payload.liboqs_ref }}
       - name: Run release tests
-        run: ./scripts/release-test-ci.sh
+        run: OPENSSL_BRANCH=master ./scripts/release-test-ci.sh

--- a/scripts/release-test-ci.sh
+++ b/scripts/release-test-ci.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# Stop in case of error
+set -e
+
+# To be run as part of a release test only on Linux
+# requires python, pytest, xdist; install e.g. via
+# sudo apt install python3 python3-pytest python3-pytest-xdist python3-psutil
+
+# must be run in main folder
+# multicore machine recommended for fast execution
+
+# expect (ideally latest/release-test) liboqs to be already build and present
+if [ -d liboqs ]; then
+   export LIBOQS_SRC_DIR=`pwd`/liboqs
+else
+   echo "liboqs not found. Exiting."
+   exit 1
+fi
+
+if [ -d oqs-template ]; then
+    # Activate all algorithms
+    sed -i "s/enable\: false/enable\: true/g" oqs-template/generate.yml
+    python3 oqs-template/generate.py
+    ./scripts/fullbuild.sh
+    ./scripts/runtests.sh
+    if [ -f .local/bin/openssl ]; then
+        OPENSSL_MODULES=`pwd`/_build/lib OPENSSL_CONF=`pwd`/scripts/openssl-ca.cnf python3 -m pytest --numprocesses=auto scripts/test_tls_full.py
+    else
+        echo "For full TLS PQ SIG/KEM matrix test, build (latest) openssl locally."
+    fi
+else
+    echo "$0 must be run in main oqs-provider folder. Exiting."
+fi
+

--- a/scripts/release-test-ci.sh
+++ b/scripts/release-test-ci.sh
@@ -31,5 +31,6 @@ if [ -d oqs-template ]; then
     fi
 else
     echo "$0 must be run in main oqs-provider folder. Exiting."
+    exit 1
 fi
 

--- a/scripts/release-test.sh
+++ b/scripts/release-test.sh
@@ -19,12 +19,9 @@ else
 fi
 
 if [ -d oqs-template ]; then
-    # just a temp setup
-    git checkout -b reltest
     # Activate all algorithms
     sed -i "s/enable\: false/enable\: true/g" oqs-template/generate.yml
     python3 oqs-template/generate.py
-    rm -rf _build
     ./scripts/fullbuild.sh
     ./scripts/runtests.sh
     if [ -f .local/bin/openssl ]; then
@@ -32,7 +29,6 @@ if [ -d oqs-template ]; then
     else
         echo "For full TLS PQ SIG/KEM matrix test, build (latest) openssl locally."
     fi
-    git reset --hard && git checkout main && git branch -D reltest
 else
     echo "$0 must be run in main oqs-provider folder. Exiting."
 fi


### PR DESCRIPTION
<!-- Please give a brief explanation of the purpose of this pull request. -->

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->

This PR proposes a release test workflow which can be triggered by `repository_dispatch` events. For example, with a corresponding PR in `liboqs`, we could trigger these workflows to run automatically on release candidates.

For a proof-of-concept, see https://github.com/SWilson4/cicd-playground-upstream and https://github.com/SWilson4/cicd-playground-downstream.