### PR TITLE
Protecting from NULL parameters

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,9 @@ We only support the most recent release.
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 0.5.1   | :white_check_mark: |
+| 0.5.3   | :white_check_mark: |
+| 0.5.2   | :x:                |
+| 0.5.1   | :x:                |
 | < 0.5   | :x:                |
 
 ## Reporting a Vulnerability

--- a/oqsprov/oqs_kmgmt.c
+++ b/oqsprov/oqs_kmgmt.c
@@ -133,6 +133,11 @@ static int oqsx_match(const void *keydata1, const void *keydata2, int selection)
                    keydata2);
     OQS_KM_PRINTF2("OQSKEYMGMT: match called for selection %d\n", selection);
 
+    if (key1 == NULL || key2 == NULL) {
+        ERR_raise(ERR_LIB_USER, OQSPROV_R_WRONG_PARAMETERS);
+        return 0;
+    }
+
 #ifdef NOPUBKEY_IN_PRIVKEY
     /* Now this is a "leap of faith" logic: If a public-only PKEY and a
      * private-only PKEY are tested for equality we cannot do anything other
@@ -297,7 +302,7 @@ static int oqsx_export(void *keydata, int selection, OSSL_CALLBACK *param_cb,
     }
 
     params = OSSL_PARAM_BLD_to_param(tmpl);
-    if (params == NULL) {
+    if (params == NULL || param_cb == NULL) {
         ok = 0;
         goto err;
     }
@@ -327,6 +332,11 @@ static int oqsx_get_params(void *key, OSSL_PARAM params[])
 {
     OQSX_KEY *oqsxk = key;
     OSSL_PARAM *p;
+
+    if (oqsxk == NULL || params == NULL) {
+        ERR_raise(ERR_LIB_USER, OQSPROV_R_WRONG_PARAMETERS);
+        return 0;
+    }
 
     OQS_KM_PRINTF2("OQSKEYMGMT: get_params called for %s\n", params[0].key);
     if ((p = OSSL_PARAM_locate(params, OSSL_PKEY_PARAM_BITS)) != NULL
@@ -413,6 +423,10 @@ static int oqsx_set_params(void *key, const OSSL_PARAM params[])
     const OSSL_PARAM *p;
 
     OQS_KM_PRINTF("OQSKEYMGMT: set_params called\n");
+    if (oqsxkey == NULL) {
+        ERR_raise(ERR_LIB_USER, OQSPROV_R_WRONG_PARAMETERS);
+        return 0;
+    }
     p = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_ENCODED_PUBLIC_KEY);
     if (p != NULL) {
         size_t used_len;
@@ -485,10 +499,10 @@ static void *oqsx_genkey(struct oqsx_gen_ctx *gctx)
 {
     OQSX_KEY *key;
 
-    OQS_KM_PRINTF3("OQSKEYMGMT: gen called for %s (%s)\n", gctx->oqs_name,
-                   gctx->tls_name);
     if (gctx == NULL)
         return NULL;
+    OQS_KM_PRINTF3("OQSKEYMGMT: gen called for %s (%s)\n", gctx->oqs_name,
+                   gctx->tls_name);
     if ((key = oqsx_key_new(gctx->libctx, gctx->oqs_name, gctx->tls_name,
                             gctx->primitive, gctx->propq, gctx->bit_security,
                             gctx->alg_idx))

--- a/oqsprov/oqs_kmgmt.c
+++ b/oqsprov/oqs_kmgmt.c
@@ -283,8 +283,8 @@ static int oqsx_export(void *keydata, int selection, OSSL_CALLBACK *param_cb,
      * In this implementation, only public and private keys can be exported,
      * nothing else
      */
-    if (key == NULL) {
-        ERR_raise(ERR_LIB_USER, OQSPROV_UNEXPECTED_NULL);
+    if (key == NULL || param_cb == NULL) {
+        ERR_raise(ERR_LIB_USER, OQSPROV_R_WRONG_PARAMETERS);
         return 0;
     }
 
@@ -302,7 +302,7 @@ static int oqsx_export(void *keydata, int selection, OSSL_CALLBACK *param_cb,
     }
 
     params = OSSL_PARAM_BLD_to_param(tmpl);
-    if (params == NULL || param_cb == NULL) {
+    if (params == NULL) {
         ok = 0;
         goto err;
     }

--- a/oqsprov/oqs_prov.h
+++ b/oqsprov/oqs_prov.h
@@ -85,7 +85,7 @@ typedef struct prov_oqs_ctx_st {
 PROV_OQS_CTX *oqsx_newprovctx(OSSL_LIB_CTX *libctx,
                               const OSSL_CORE_HANDLE *handle, BIO_METHOD *bm);
 void oqsx_freeprovctx(PROV_OQS_CTX *ctx);
-#define PROV_OQS_LIBCTX_OF(provctx) (((PROV_OQS_CTX *)provctx)->libctx)
+#define PROV_OQS_LIBCTX_OF(provctx) provctx?(((PROV_OQS_CTX *)provctx)->libctx):NULL
 
 #include "oqs/oqs.h"
 #ifdef USE_ENCODING_LIB

--- a/oqsprov/oqs_prov.h
+++ b/oqsprov/oqs_prov.h
@@ -85,7 +85,8 @@ typedef struct prov_oqs_ctx_st {
 PROV_OQS_CTX *oqsx_newprovctx(OSSL_LIB_CTX *libctx,
                               const OSSL_CORE_HANDLE *handle, BIO_METHOD *bm);
 void oqsx_freeprovctx(PROV_OQS_CTX *ctx);
-#define PROV_OQS_LIBCTX_OF(provctx) provctx?(((PROV_OQS_CTX *)provctx)->libctx):NULL
+#define PROV_OQS_LIBCTX_OF(provctx) \
+    provctx ? (((PROV_OQS_CTX *)provctx)->libctx) : NULL
 
 #include "oqs/oqs.h"
 #ifdef USE_ENCODING_LIB


### PR DESCRIPTION
This adds more protections against incorrect use of the [OpenSSL<->provider API](https://www.openssl.org/docs/manmaster/man7/provider-base.html), notably incorrect NULL pointers passed.

Thanks again to @pcwizz for pointing these out. Please check that the issues found are indeed resolved with this PR.

This PR also updates missing release information in SECURITY.md.
