### PR TITLE
guard external testing against algorithm absence

### DIFF
--- a/scripts/oqsprovider-externalinterop.sh
+++ b/scripts/oqsprovider-externalinterop.sh
@@ -26,7 +26,19 @@ else
     export USE_PROXY=""
 fi
 
+# Ascertain algorithms are available:
+
 echo " Cloudflare:"
-export OQS_CODEPOINT_X25519_KYBER512=65072
-(echo -e "GET /cdn-cgi/trace HTTP/1.1\nHost: cloudflare.com\n\n"; sleep 1; echo $'\cc') | "${OPENSSL_APP}" s_client ${USE_PROXY} -connect pq.cloudflareresearch.com:443 -groups x25519_kyber768 -servername cloudflare.com -ign_eof 2>/dev/null | grep kex=X25519Kyber768Draft00
-(echo -e "GET /cdn-cgi/trace HTTP/1.1\nHost: cloudflare.com\n\n"; sleep 1; echo $'\cc') | "${OPENSSL_APP}" s_client ${USE_PROXY} -connect pq.cloudflareresearch.com:443 -groups x25519_kyber512 -servername cloudflare.com -ign_eof 2>/dev/null | grep kex=X25519Kyber512Draft00
+
+if ! ($OPENSSL_APP list -kem-algorithms | grep x25519_kyber768); then
+   echo "Skipping unconfigured x25519_kyber768 interop test"
+else
+   export OQS_CODEPOINT_X25519_KYBER512=65072
+   (echo -e "GET /cdn-cgi/trace HTTP/1.1\nHost: cloudflare.com\n\n"; sleep 1; echo $'\cc') | "${OPENSSL_APP}" s_client ${USE_PROXY} -connect pq.cloudflareresearch.com:443 -groups x25519_kyber768 -servername cloudflare.com -ign_eof 2>/dev/null | grep kex=X25519Kyber768Draft00
+fi
+
+if ! ($OPENSSL_APP list -kem-algorithms | grep x25519_kyber512); then
+   echo "Skipping unconfigured x25519_kyber512 interop test"
+else
+   (echo -e "GET /cdn-cgi/trace HTTP/1.1\nHost: cloudflare.com\n\n"; sleep 1; echo $'\cc') | "${OPENSSL_APP}" s_client ${USE_PROXY} -connect pq.cloudflareresearch.com:443 -groups x25519_kyber512 -servername cloudflare.com -ign_eof 2>/dev/null | grep kex=X25519Kyber512Draft00
+fi


### PR DESCRIPTION
This PR introduces a check for algorithm presence to avoid recurrence of [CI failures](https://app.circleci.com/pipelines/github/open-quantum-safe/oqs-provider/1159/workflows/0e82312f-a472-492a-943d-16dbb5450a03/jobs/4859) due to bad `liboqs` configuration(s).
