### PR TITLE
length and null checks in en/decaps

### DIFF
--- a/oqsprov/oqs_kem.c
+++ b/oqsprov/oqs_kem.c
@@ -116,7 +116,8 @@ static int oqs_qs_kem_encaps_keyslot(void *vpkemctx, unsigned char *out,
         OQS_KEM_PRINTF("OQS Warning: OQS_KEM not initialized\n");
         return -1;
     }
-    if (pkemctx->kem->comp_pubkey[keyslot] == NULL) {
+    if (pkemctx->kem->comp_pubkey == NULL
+        || pkemctx->kem->comp_pubkey[keyslot] == NULL) {
         OQS_KEM_PRINTF("OQS Warning: public key is NULL\n");
         return -1;
     }
@@ -168,7 +169,8 @@ static int oqs_qs_kem_decaps_keyslot(void *vpkemctx, unsigned char *out,
         OQS_KEM_PRINTF("OQS Warning: OQS_KEM not initialized\n");
         return -1;
     }
-    if (pkemctx->kem->comp_privkey[keyslot] == NULL) {
+    if (pkemctx->kem->comp_privkey == NULL
+        || pkemctx->kem->comp_privkey[keyslot] == NULL) {
         OQS_KEM_PRINTF("OQS Warning: private key is NULL\n");
         return -1;
     }


### PR DESCRIPTION
The functions oqs_qs_kem_encaps_keyslot and oqs_qs_kem_decaps_keyslot are provided some buffers for the input and output parameters, with pointers to return the intended length of these buffers in case they are queried, or they hold the actual length of the provided buffers when it's not a query. These lengths are not passed on and they are not checked against the kem context. This could lead to over-writes or over-reads. Null pointers are also not handled properly.