### PR TITLE
improve static build testing

### DIFF
--- a/test/oqs_test_endecode.c
+++ b/test/oqs_test_endecode.c
@@ -248,11 +248,10 @@ int main(int argc, char *argv[])
 
     keyctx = OSSL_LIB_CTX_new();
 
-    load_oqs_provider(keyctx, modulename, configfile);
+    oqsprov = load_oqs_provider(keyctx, modulename, configfile);
 
     dfltprov = OSSL_PROVIDER_load(keyctx, "default");
     keyprov = OSSL_PROVIDER_load(keyctx, modulename);
-    oqsprov = OSSL_PROVIDER_load(libctx, modulename);
 
     algs = OSSL_PROVIDER_query_operation(oqsprov, OSSL_OP_SIGNATURE,
                                          &query_nocache);

--- a/test/oqs_test_kems.c
+++ b/test/oqs_test_kems.c
@@ -87,9 +87,7 @@ int main(int argc, char *argv[])
     modulename = argv[1];
     configfile = argv[2];
 
-    load_oqs_provider(libctx, modulename, configfile);
-
-    oqsprov = OSSL_PROVIDER_load(libctx, modulename);
+    oqsprov = load_oqs_provider(libctx, modulename, configfile);
 
     kemalgs
         = OSSL_PROVIDER_query_operation(oqsprov, OSSL_OP_KEM, &query_nocache);
@@ -108,7 +106,8 @@ int main(int argc, char *argv[])
     }
 
     OSSL_LIB_CTX_free(libctx);
-
+    if (OPENSSL_VERSION_PREREQ(3, 1))
+        OSSL_PROVIDER_unload(oqsprov); // avoid crash in 3.0.x
     TEST_ASSERT(errcnt == 0)
     return !test;
 }

--- a/test/oqs_test_signatures.c
+++ b/test/oqs_test_signatures.c
@@ -103,9 +103,7 @@ int main(int argc, char *argv[])
     modulename = argv[1];
     configfile = argv[2];
 
-    load_oqs_provider(libctx, modulename, configfile);
-
-    oqsprov = OSSL_PROVIDER_load(libctx, modulename);
+    oqsprov = load_oqs_provider(libctx, modulename, configfile);
 
     sigalgs = OSSL_PROVIDER_query_operation(oqsprov, OSSL_OP_SIGNATURE,
                                             &query_nocache);
@@ -125,6 +123,8 @@ int main(int argc, char *argv[])
     }
 
     OSSL_LIB_CTX_free(libctx);
+    if (OPENSSL_VERSION_PREREQ(3, 1))
+        OSSL_PROVIDER_unload(oqsprov); // avoid crash in 3.0.x
 
     TEST_ASSERT(errcnt == 0)
     return !test;

--- a/test/oqs_test_tlssig.c
+++ b/test/oqs_test_tlssig.c
@@ -149,6 +149,7 @@ int main(int argc, char *argv[])
 {
     size_t i;
     int errcnt = 0, test = 0;
+    OSSL_PROVIDER *oqsprov = NULL;
 
 #ifndef OPENSSL_NO_TRACE
     fprintf(stderr,
@@ -163,9 +164,10 @@ int main(int argc, char *argv[])
     configfile = argv[2];
     certsdir = argv[3];
 
-    load_oqs_provider(libctx, modulename, configfile);
+    oqsprov = load_oqs_provider(libctx, modulename, configfile);
 
     T(OSSL_PROVIDER_available(libctx, "default"));
+    T(OSSL_PROVIDER_available(libctx, modulename));
 
 #ifdef OSSL_CAPABILITY_TLS_SIGALG_NAME
     // crashes: EVP_SIGNATURE_do_all_provided(libctx, test_oqs_sigs, &errcnt);
@@ -177,6 +179,8 @@ int main(int argc, char *argv[])
 #endif
 
     OSSL_LIB_CTX_free(libctx);
+    if (OPENSSL_VERSION_PREREQ(3, 1))
+        OSSL_PROVIDER_unload(oqsprov); // avoid crash in 3.0.x
     TEST_ASSERT(errcnt == 0)
     return !test;
 }

--- a/test/test_common.c
+++ b/test/test_common.c
@@ -45,7 +45,7 @@ int alg_is_enabled(const char *algname)
 
 /* Loads the oqs-provider from a shared module (.so). */
 OSSL_PROVIDER *load_oqs_provider(OSSL_LIB_CTX *libctx, const char *modulename,
-                       const char *configfile)
+                                 const char *configfile)
 {
     T(OSSL_LIB_CTX_load_config(libctx, configfile));
     T(OSSL_PROVIDER_available(libctx, modulename));
@@ -58,7 +58,7 @@ extern OSSL_provider_init_fn OQS_PROVIDER_ENTRYPOINT_NAME;
 
 /* Loads the statically linked oqs-provider. */
 OSSL_PROVIDER *load_oqs_provider(OSSL_LIB_CTX *libctx, const char *modulename,
-                       const char *configfile)
+                                 const char *configfile)
 {
     (void)configfile;
     T(OSSL_PROVIDER_add_builtin(libctx, modulename,

--- a/test/test_common.c
+++ b/test/test_common.c
@@ -44,11 +44,12 @@ int alg_is_enabled(const char *algname)
 #ifndef OQS_PROVIDER_STATIC
 
 /* Loads the oqs-provider from a shared module (.so). */
-void load_oqs_provider(OSSL_LIB_CTX *libctx, const char *modulename,
+OSSL_PROVIDER *load_oqs_provider(OSSL_LIB_CTX *libctx, const char *modulename,
                        const char *configfile)
 {
     T(OSSL_LIB_CTX_load_config(libctx, configfile));
     T(OSSL_PROVIDER_available(libctx, modulename));
+    return OSSL_PROVIDER_load(libctx, modulename);
 }
 
 #else
@@ -56,13 +57,14 @@ void load_oqs_provider(OSSL_LIB_CTX *libctx, const char *modulename,
 extern OSSL_provider_init_fn OQS_PROVIDER_ENTRYPOINT_NAME;
 
 /* Loads the statically linked oqs-provider. */
-void load_oqs_provider(OSSL_LIB_CTX *libctx, const char *modulename,
+OSSL_PROVIDER *load_oqs_provider(OSSL_LIB_CTX *libctx, const char *modulename,
                        const char *configfile)
 {
     (void)configfile;
     T(OSSL_PROVIDER_add_builtin(libctx, modulename,
                                 OQS_PROVIDER_ENTRYPOINT_NAME));
     T(OSSL_PROVIDER_load(libctx, "default"));
+    return OSSL_PROVIDER_load(libctx, modulename);
 }
 
 #endif // ifndef OQS_PROVIDER_STATIC

--- a/test/test_common.h
+++ b/test/test_common.h
@@ -37,5 +37,5 @@ void hexdump(const void *ptr, size_t len);
 int alg_is_enabled(const char *algname);
 
 /* Loads the oqs-provider. */
-OSSL_PROVIDER* load_oqs_provider(OSSL_LIB_CTX *libctx, const char *modulename,
-                       const char *configfile);
+OSSL_PROVIDER *load_oqs_provider(OSSL_LIB_CTX *libctx, const char *modulename,
+                                 const char *configfile);

--- a/test/test_common.h
+++ b/test/test_common.h
@@ -37,5 +37,5 @@ void hexdump(const void *ptr, size_t len);
 int alg_is_enabled(const char *algname);
 
 /* Loads the oqs-provider. */
-void load_oqs_provider(OSSL_LIB_CTX *libctx, const char *modulename,
+OSSL_PROVIDER* load_oqs_provider(OSSL_LIB_CTX *libctx, const char *modulename,
                        const char *configfile);


### PR DESCRIPTION
As reported in https://github.com/open-quantum-safe/oqs-provider/discussions/365#discussioncomment-8680254 not all tests got executed for static builds. This PR fixes this.
