### PR TITLE
Do not duplicate call to `getenv`.

### DIFF
--- a/oqs-template/oqsprov/oqsprov.c/encoding_patching.fragment
+++ b/oqs-template/oqsprov/oqsprov.c/encoding_patching.fragment
@@ -1,13 +1,14 @@
 {% set cnt = namespace(val=-2) %}
+{ const char* envval = NULL;
 {%- for sig in config['sigs'] %}
    {%- for variant in sig['variants'] %}
       {%- set cnt.val = cnt.val + 2 %}
-   if (getenv("OQS_ENCODING_{{variant['name']|upper}}")) oqs_alg_encoding_list[{{ cnt.val }}] = getenv("OQS_ENCODING_{{variant['name']|upper}}");
-   if (getenv("OQS_ENCODING_{{variant['name']|upper}}_ALGNAME")) oqs_alg_encoding_list[{{ cnt.val + 1 }}] = getenv("OQS_ENCODING_{{variant['name']|upper}}_ALGNAME");
+   if ((envval = getenv("OQS_ENCODING_{{variant['name']|upper}}"))) oqs_alg_encoding_list[{{ cnt.val }}] = envval;
+   if ((envval = getenv("OQS_ENCODING_{{variant['name']|upper}}_ALGNAME"))) oqs_alg_encoding_list[{{ cnt.val + 1 }}] = envval;
       {%- for classical_alg in variant['mix_with'] %}
          {%- set cnt.val = cnt.val + 2 %}
-   if (getenv("OQS_ENCODING_{{ classical_alg['name']|upper }}_{{variant['name']|upper}}")) oqs_alg_encoding_list[{{ cnt.val }}] = getenv("OQS_ENCODING_{{ classical_alg['name']|upper }}_{{variant['name']|upper}}");
-   if (getenv("OQS_ENCODING_{{ classical_alg['name']|upper }}_{{variant['name']|upper}}_ALGNAME")) oqs_alg_encoding_list[{{ cnt.val + 1 }}] = getenv("OQS_ENCODING_{{ classical_alg['name']|upper }}_{{variant['name']|upper}}_ALGNAME");
+   if ((envval = getenv("OQS_ENCODING_{{ classical_alg['name']|upper }}_{{variant['name']|upper}}"))) oqs_alg_encoding_list[{{ cnt.val }}] = envval;
+   if ((envval = getenv("OQS_ENCODING_{{ classical_alg['name']|upper }}_{{variant['name']|upper}}_ALGNAME"))) oqs_alg_encoding_list[{{ cnt.val + 1 }}] = envval;
       {%- endfor %}
       {%- for composite_alg in variant['composite'] %}
          {%- set cnt.val = cnt.val + 2 %}
@@ -16,4 +17,5 @@
       {%- endfor %}
    {%- endfor %}
 {%- endfor %}
+}
 

--- a/oqs-template/oqsprov/oqsprov.c/oid_patching.fragment
+++ b/oqs-template/oqsprov/oqsprov.c/oid_patching.fragment
@@ -1,14 +1,16 @@
 {% set cnt = namespace(val=-2) %}
+{
+  const char *envval = NULL;
 
 #ifdef OQS_KEM_ENCODERS
 
 {% set kemcount = namespace(val=-2) %}
 {% for kem in config['kems'] %}
 {% set kemcount.val = kemcount.val + 2 -%}
-   if (getenv("OQS_OID_{{kem['name_group']|upper}}")) oqs_oid_alg_list[{{ kemcount.val }}] = getenv("OQS_OID_{{kem['name_group']|upper}}");
+   if ((envval = getenv("OQS_OID_{{kem['name_group']|upper}}"))) oqs_oid_alg_list[{{ kemcount.val }}] = envval;
 {% for hybrid in kem['hybrids'] %}
 {% set kemcount.val = kemcount.val + 2 -%}
-   if (getenv("OQS_OID_{{ hybrid['hybrid_group']|upper }}_{{kem['name_group']|upper}}")) oqs_oid_alg_list[{{ kemcount.val }}] = getenv("OQS_OID_{{ hybrid['hybrid_group']|upper }}_{{kem['name_group']|upper}}");
+   if ((envval = getenv("OQS_OID_{{ hybrid['hybrid_group']|upper }}_{{kem['name_group']|upper}}"))) oqs_oid_alg_list[{{ kemcount.val }}] = envval;
 {%- endfor -%}
 {%- endfor %}
 
@@ -20,11 +22,11 @@
 {%- for sig in config['sigs'] %}
    {%- for variant in sig['variants'] %}
       {%- set cnt.val = cnt.val + 2 %}
-   if (getenv("OQS_OID_{{variant['name']|upper}}")) oqs_oid_alg_list[{{ cnt.val }}+OQS_KEMOID_CNT] = getenv("OQS_OID_{{variant['name']|upper}}");
+   if ((envval = getenv("OQS_OID_{{variant['name']|upper}}"))) oqs_oid_alg_list[{{ cnt.val }}+OQS_KEMOID_CNT] = envval;
       {%- for classical_alg in variant['mix_with'] %}
          {%- set cnt.val = cnt.val + 2 %}
-   if (getenv("OQS_OID_{{ classical_alg['name']|upper }}_{{variant['name']|upper}}")) oqs_oid_alg_list[{{ cnt.val }}+OQS_KEMOID_CNT] = getenv("OQS_OID_{{ classical_alg['name']|upper }}_{{variant['name']|upper}}");
+   if ((envval = getenv("OQS_OID_{{ classical_alg['name']|upper }}_{{variant['name']|upper}}"))) oqs_oid_alg_list[{{ cnt.val }}+OQS_KEMOID_CNT] = envval;
       {%- endfor %}
    {%- endfor %}
 {%- endfor %}
-
+}

--- a/oqsprov/oqsprov.c
+++ b/oqsprov/oqsprov.c
@@ -269,233 +269,211 @@ const char *oqs_oid_alg_list[OQS_OID_CNT] = {
 int oqs_patch_oids(void)
 {
     ///// OQS_TEMPLATE_FRAGMENT_OID_PATCHING_START
+    {
+        const char *envval = NULL;
 
 #ifdef OQS_KEM_ENCODERS
 
-    if (getenv("OQS_OID_FRODO640AES"))
-        oqs_oid_alg_list[0] = getenv("OQS_OID_FRODO640AES");
+        if ((envval = getenv("OQS_OID_FRODO640AES")))
+            oqs_oid_alg_list[0] = envval;
 
-    if (getenv("OQS_OID_P256_FRODO640AES"))
-        oqs_oid_alg_list[2] = getenv("OQS_OID_P256_FRODO640AES");
-    if (getenv("OQS_OID_X25519_FRODO640AES"))
-        oqs_oid_alg_list[4] = getenv("OQS_OID_X25519_FRODO640AES");
-    if (getenv("OQS_OID_FRODO640SHAKE"))
-        oqs_oid_alg_list[6] = getenv("OQS_OID_FRODO640SHAKE");
+        if ((envval = getenv("OQS_OID_P256_FRODO640AES")))
+            oqs_oid_alg_list[2] = envval;
+        if ((envval = getenv("OQS_OID_X25519_FRODO640AES")))
+            oqs_oid_alg_list[4] = envval;
+        if ((envval = getenv("OQS_OID_FRODO640SHAKE")))
+            oqs_oid_alg_list[6] = envval;
 
-    if (getenv("OQS_OID_P256_FRODO640SHAKE"))
-        oqs_oid_alg_list[8] = getenv("OQS_OID_P256_FRODO640SHAKE");
-    if (getenv("OQS_OID_X25519_FRODO640SHAKE"))
-        oqs_oid_alg_list[10] = getenv("OQS_OID_X25519_FRODO640SHAKE");
-    if (getenv("OQS_OID_FRODO976AES"))
-        oqs_oid_alg_list[12] = getenv("OQS_OID_FRODO976AES");
+        if ((envval = getenv("OQS_OID_P256_FRODO640SHAKE")))
+            oqs_oid_alg_list[8] = envval;
+        if ((envval = getenv("OQS_OID_X25519_FRODO640SHAKE")))
+            oqs_oid_alg_list[10] = envval;
+        if ((envval = getenv("OQS_OID_FRODO976AES")))
+            oqs_oid_alg_list[12] = envval;
 
-    if (getenv("OQS_OID_P384_FRODO976AES"))
-        oqs_oid_alg_list[14] = getenv("OQS_OID_P384_FRODO976AES");
-    if (getenv("OQS_OID_X448_FRODO976AES"))
-        oqs_oid_alg_list[16] = getenv("OQS_OID_X448_FRODO976AES");
-    if (getenv("OQS_OID_FRODO976SHAKE"))
-        oqs_oid_alg_list[18] = getenv("OQS_OID_FRODO976SHAKE");
+        if ((envval = getenv("OQS_OID_P384_FRODO976AES")))
+            oqs_oid_alg_list[14] = envval;
+        if ((envval = getenv("OQS_OID_X448_FRODO976AES")))
+            oqs_oid_alg_list[16] = envval;
+        if ((envval = getenv("OQS_OID_FRODO976SHAKE")))
+            oqs_oid_alg_list[18] = envval;
 
-    if (getenv("OQS_OID_P384_FRODO976SHAKE"))
-        oqs_oid_alg_list[20] = getenv("OQS_OID_P384_FRODO976SHAKE");
-    if (getenv("OQS_OID_X448_FRODO976SHAKE"))
-        oqs_oid_alg_list[22] = getenv("OQS_OID_X448_FRODO976SHAKE");
-    if (getenv("OQS_OID_FRODO1344AES"))
-        oqs_oid_alg_list[24] = getenv("OQS_OID_FRODO1344AES");
+        if ((envval = getenv("OQS_OID_P384_FRODO976SHAKE")))
+            oqs_oid_alg_list[20] = envval;
+        if ((envval = getenv("OQS_OID_X448_FRODO976SHAKE")))
+            oqs_oid_alg_list[22] = envval;
+        if ((envval = getenv("OQS_OID_FRODO1344AES")))
+            oqs_oid_alg_list[24] = envval;
 
-    if (getenv("OQS_OID_P521_FRODO1344AES"))
-        oqs_oid_alg_list[26] = getenv("OQS_OID_P521_FRODO1344AES");
-    if (getenv("OQS_OID_FRODO1344SHAKE"))
-        oqs_oid_alg_list[28] = getenv("OQS_OID_FRODO1344SHAKE");
+        if ((envval = getenv("OQS_OID_P521_FRODO1344AES")))
+            oqs_oid_alg_list[26] = envval;
+        if ((envval = getenv("OQS_OID_FRODO1344SHAKE")))
+            oqs_oid_alg_list[28] = envval;
 
-    if (getenv("OQS_OID_P521_FRODO1344SHAKE"))
-        oqs_oid_alg_list[30] = getenv("OQS_OID_P521_FRODO1344SHAKE");
-    if (getenv("OQS_OID_KYBER512"))
-        oqs_oid_alg_list[32] = getenv("OQS_OID_KYBER512");
+        if ((envval = getenv("OQS_OID_P521_FRODO1344SHAKE")))
+            oqs_oid_alg_list[30] = envval;
+        if ((envval = getenv("OQS_OID_KYBER512")))
+            oqs_oid_alg_list[32] = envval;
 
-    if (getenv("OQS_OID_P256_KYBER512"))
-        oqs_oid_alg_list[34] = getenv("OQS_OID_P256_KYBER512");
-    if (getenv("OQS_OID_X25519_KYBER512"))
-        oqs_oid_alg_list[36] = getenv("OQS_OID_X25519_KYBER512");
-    if (getenv("OQS_OID_KYBER768"))
-        oqs_oid_alg_list[38] = getenv("OQS_OID_KYBER768");
+        if ((envval = getenv("OQS_OID_P256_KYBER512")))
+            oqs_oid_alg_list[34] = envval;
+        if ((envval = getenv("OQS_OID_X25519_KYBER512")))
+            oqs_oid_alg_list[36] = envval;
+        if ((envval = getenv("OQS_OID_KYBER768")))
+            oqs_oid_alg_list[38] = envval;
 
-    if (getenv("OQS_OID_P384_KYBER768"))
-        oqs_oid_alg_list[40] = getenv("OQS_OID_P384_KYBER768");
-    if (getenv("OQS_OID_X448_KYBER768"))
-        oqs_oid_alg_list[42] = getenv("OQS_OID_X448_KYBER768");
-    if (getenv("OQS_OID_X25519_KYBER768"))
-        oqs_oid_alg_list[44] = getenv("OQS_OID_X25519_KYBER768");
-    if (getenv("OQS_OID_P256_KYBER768"))
-        oqs_oid_alg_list[46] = getenv("OQS_OID_P256_KYBER768");
-    if (getenv("OQS_OID_KYBER1024"))
-        oqs_oid_alg_list[48] = getenv("OQS_OID_KYBER1024");
+        if ((envval = getenv("OQS_OID_P384_KYBER768")))
+            oqs_oid_alg_list[40] = envval;
+        if ((envval = getenv("OQS_OID_X448_KYBER768")))
+            oqs_oid_alg_list[42] = envval;
+        if ((envval = getenv("OQS_OID_X25519_KYBER768")))
+            oqs_oid_alg_list[44] = envval;
+        if ((envval = getenv("OQS_OID_P256_KYBER768")))
+            oqs_oid_alg_list[46] = envval;
+        if ((envval = getenv("OQS_OID_KYBER1024")))
+            oqs_oid_alg_list[48] = envval;
 
-    if (getenv("OQS_OID_P521_KYBER1024"))
-        oqs_oid_alg_list[50] = getenv("OQS_OID_P521_KYBER1024");
-    if (getenv("OQS_OID_MLKEM512"))
-        oqs_oid_alg_list[52] = getenv("OQS_OID_MLKEM512");
+        if ((envval = getenv("OQS_OID_P521_KYBER1024")))
+            oqs_oid_alg_list[50] = envval;
+        if ((envval = getenv("OQS_OID_MLKEM512")))
+            oqs_oid_alg_list[52] = envval;
 
-    if (getenv("OQS_OID_P256_MLKEM512"))
-        oqs_oid_alg_list[54] = getenv("OQS_OID_P256_MLKEM512");
-    if (getenv("OQS_OID_X25519_MLKEM512"))
-        oqs_oid_alg_list[56] = getenv("OQS_OID_X25519_MLKEM512");
-    if (getenv("OQS_OID_MLKEM768"))
-        oqs_oid_alg_list[58] = getenv("OQS_OID_MLKEM768");
+        if ((envval = getenv("OQS_OID_P256_MLKEM512")))
+            oqs_oid_alg_list[54] = envval;
+        if ((envval = getenv("OQS_OID_X25519_MLKEM512")))
+            oqs_oid_alg_list[56] = envval;
+        if ((envval = getenv("OQS_OID_MLKEM768")))
+            oqs_oid_alg_list[58] = envval;
 
-    if (getenv("OQS_OID_P384_MLKEM768"))
-        oqs_oid_alg_list[60] = getenv("OQS_OID_P384_MLKEM768");
-    if (getenv("OQS_OID_X448_MLKEM768"))
-        oqs_oid_alg_list[62] = getenv("OQS_OID_X448_MLKEM768");
-    if (getenv("OQS_OID_X25519_MLKEM768"))
-        oqs_oid_alg_list[64] = getenv("OQS_OID_X25519_MLKEM768");
-    if (getenv("OQS_OID_P256_MLKEM768"))
-        oqs_oid_alg_list[66] = getenv("OQS_OID_P256_MLKEM768");
-    if (getenv("OQS_OID_MLKEM1024"))
-        oqs_oid_alg_list[68] = getenv("OQS_OID_MLKEM1024");
+        if ((envval = getenv("OQS_OID_P384_MLKEM768")))
+            oqs_oid_alg_list[60] = envval;
+        if ((envval = getenv("OQS_OID_X448_MLKEM768")))
+            oqs_oid_alg_list[62] = envval;
+        if ((envval = getenv("OQS_OID_X25519_MLKEM768")))
+            oqs_oid_alg_list[64] = envval;
+        if ((envval = getenv("OQS_OID_P256_MLKEM768")))
+            oqs_oid_alg_list[66] = envval;
+        if ((envval = getenv("OQS_OID_MLKEM1024")))
+            oqs_oid_alg_list[68] = envval;
 
-    if (getenv("OQS_OID_P521_MLKEM1024"))
-        oqs_oid_alg_list[70] = getenv("OQS_OID_P521_MLKEM1024");
-    if (getenv("OQS_OID_P384_MLKEM1024"))
-        oqs_oid_alg_list[72] = getenv("OQS_OID_P384_MLKEM1024");
-    if (getenv("OQS_OID_BIKEL1"))
-        oqs_oid_alg_list[74] = getenv("OQS_OID_BIKEL1");
+        if ((envval = getenv("OQS_OID_P521_MLKEM1024")))
+            oqs_oid_alg_list[70] = envval;
+        if ((envval = getenv("OQS_OID_P384_MLKEM1024")))
+            oqs_oid_alg_list[72] = envval;
+        if ((envval = getenv("OQS_OID_BIKEL1")))
+            oqs_oid_alg_list[74] = envval;
 
-    if (getenv("OQS_OID_P256_BIKEL1"))
-        oqs_oid_alg_list[76] = getenv("OQS_OID_P256_BIKEL1");
-    if (getenv("OQS_OID_X25519_BIKEL1"))
-        oqs_oid_alg_list[78] = getenv("OQS_OID_X25519_BIKEL1");
-    if (getenv("OQS_OID_BIKEL3"))
-        oqs_oid_alg_list[80] = getenv("OQS_OID_BIKEL3");
+        if ((envval = getenv("OQS_OID_P256_BIKEL1")))
+            oqs_oid_alg_list[76] = envval;
+        if ((envval = getenv("OQS_OID_X25519_BIKEL1")))
+            oqs_oid_alg_list[78] = envval;
+        if ((envval = getenv("OQS_OID_BIKEL3")))
+            oqs_oid_alg_list[80] = envval;
 
-    if (getenv("OQS_OID_P384_BIKEL3"))
-        oqs_oid_alg_list[82] = getenv("OQS_OID_P384_BIKEL3");
-    if (getenv("OQS_OID_X448_BIKEL3"))
-        oqs_oid_alg_list[84] = getenv("OQS_OID_X448_BIKEL3");
-    if (getenv("OQS_OID_BIKEL5"))
-        oqs_oid_alg_list[86] = getenv("OQS_OID_BIKEL5");
+        if ((envval = getenv("OQS_OID_P384_BIKEL3")))
+            oqs_oid_alg_list[82] = envval;
+        if ((envval = getenv("OQS_OID_X448_BIKEL3")))
+            oqs_oid_alg_list[84] = envval;
+        if ((envval = getenv("OQS_OID_BIKEL5")))
+            oqs_oid_alg_list[86] = envval;
 
-    if (getenv("OQS_OID_P521_BIKEL5"))
-        oqs_oid_alg_list[88] = getenv("OQS_OID_P521_BIKEL5");
-    if (getenv("OQS_OID_HQC128"))
-        oqs_oid_alg_list[90] = getenv("OQS_OID_HQC128");
+        if ((envval = getenv("OQS_OID_P521_BIKEL5")))
+            oqs_oid_alg_list[88] = envval;
+        if ((envval = getenv("OQS_OID_HQC128")))
+            oqs_oid_alg_list[90] = envval;
 
-    if (getenv("OQS_OID_P256_HQC128"))
-        oqs_oid_alg_list[92] = getenv("OQS_OID_P256_HQC128");
-    if (getenv("OQS_OID_X25519_HQC128"))
-        oqs_oid_alg_list[94] = getenv("OQS_OID_X25519_HQC128");
-    if (getenv("OQS_OID_HQC192"))
-        oqs_oid_alg_list[96] = getenv("OQS_OID_HQC192");
+        if ((envval = getenv("OQS_OID_P256_HQC128")))
+            oqs_oid_alg_list[92] = envval;
+        if ((envval = getenv("OQS_OID_X25519_HQC128")))
+            oqs_oid_alg_list[94] = envval;
+        if ((envval = getenv("OQS_OID_HQC192")))
+            oqs_oid_alg_list[96] = envval;
 
-    if (getenv("OQS_OID_P384_HQC192"))
-        oqs_oid_alg_list[98] = getenv("OQS_OID_P384_HQC192");
-    if (getenv("OQS_OID_X448_HQC192"))
-        oqs_oid_alg_list[100] = getenv("OQS_OID_X448_HQC192");
-    if (getenv("OQS_OID_HQC256"))
-        oqs_oid_alg_list[102] = getenv("OQS_OID_HQC256");
+        if ((envval = getenv("OQS_OID_P384_HQC192")))
+            oqs_oid_alg_list[98] = envval;
+        if ((envval = getenv("OQS_OID_X448_HQC192")))
+            oqs_oid_alg_list[100] = envval;
+        if ((envval = getenv("OQS_OID_HQC256")))
+            oqs_oid_alg_list[102] = envval;
 
-    if (getenv("OQS_OID_P521_HQC256"))
-        oqs_oid_alg_list[104] = getenv("OQS_OID_P521_HQC256");
+        if ((envval = getenv("OQS_OID_P521_HQC256")))
+            oqs_oid_alg_list[104] = envval;
 
 #    define OQS_KEMOID_CNT 104 + 2
 #else
 #    define OQS_KEMOID_CNT 0
 #endif /* OQS_KEM_ENCODERS */
-    if (getenv("OQS_OID_DILITHIUM2"))
-        oqs_oid_alg_list[0 + OQS_KEMOID_CNT] = getenv("OQS_OID_DILITHIUM2");
-    if (getenv("OQS_OID_P256_DILITHIUM2"))
-        oqs_oid_alg_list[2 + OQS_KEMOID_CNT]
-            = getenv("OQS_OID_P256_DILITHIUM2");
-    if (getenv("OQS_OID_RSA3072_DILITHIUM2"))
-        oqs_oid_alg_list[4 + OQS_KEMOID_CNT]
-            = getenv("OQS_OID_RSA3072_DILITHIUM2");
-    if (getenv("OQS_OID_DILITHIUM3"))
-        oqs_oid_alg_list[6 + OQS_KEMOID_CNT] = getenv("OQS_OID_DILITHIUM3");
-    if (getenv("OQS_OID_P384_DILITHIUM3"))
-        oqs_oid_alg_list[8 + OQS_KEMOID_CNT]
-            = getenv("OQS_OID_P384_DILITHIUM3");
-    if (getenv("OQS_OID_DILITHIUM5"))
-        oqs_oid_alg_list[10 + OQS_KEMOID_CNT] = getenv("OQS_OID_DILITHIUM5");
-    if (getenv("OQS_OID_P521_DILITHIUM5"))
-        oqs_oid_alg_list[12 + OQS_KEMOID_CNT]
-            = getenv("OQS_OID_P521_DILITHIUM5");
-    if (getenv("OQS_OID_MLDSA44"))
-        oqs_oid_alg_list[14 + OQS_KEMOID_CNT] = getenv("OQS_OID_MLDSA44");
-    if (getenv("OQS_OID_P256_MLDSA44"))
-        oqs_oid_alg_list[16 + OQS_KEMOID_CNT] = getenv("OQS_OID_P256_MLDSA44");
-    if (getenv("OQS_OID_RSA3072_MLDSA44"))
-        oqs_oid_alg_list[18 + OQS_KEMOID_CNT]
-            = getenv("OQS_OID_RSA3072_MLDSA44");
-    if (getenv("OQS_OID_MLDSA65"))
-        oqs_oid_alg_list[20 + OQS_KEMOID_CNT] = getenv("OQS_OID_MLDSA65");
-    if (getenv("OQS_OID_P384_MLDSA65"))
-        oqs_oid_alg_list[22 + OQS_KEMOID_CNT] = getenv("OQS_OID_P384_MLDSA65");
-    if (getenv("OQS_OID_MLDSA87"))
-        oqs_oid_alg_list[24 + OQS_KEMOID_CNT] = getenv("OQS_OID_MLDSA87");
-    if (getenv("OQS_OID_P521_MLDSA87"))
-        oqs_oid_alg_list[26 + OQS_KEMOID_CNT] = getenv("OQS_OID_P521_MLDSA87");
-    if (getenv("OQS_OID_FALCON512"))
-        oqs_oid_alg_list[28 + OQS_KEMOID_CNT] = getenv("OQS_OID_FALCON512");
-    if (getenv("OQS_OID_P256_FALCON512"))
-        oqs_oid_alg_list[30 + OQS_KEMOID_CNT]
-            = getenv("OQS_OID_P256_FALCON512");
-    if (getenv("OQS_OID_RSA3072_FALCON512"))
-        oqs_oid_alg_list[32 + OQS_KEMOID_CNT]
-            = getenv("OQS_OID_RSA3072_FALCON512");
-    if (getenv("OQS_OID_FALCONPADDED512"))
-        oqs_oid_alg_list[34 + OQS_KEMOID_CNT]
-            = getenv("OQS_OID_FALCONPADDED512");
-    if (getenv("OQS_OID_P256_FALCONPADDED512"))
-        oqs_oid_alg_list[36 + OQS_KEMOID_CNT]
-            = getenv("OQS_OID_P256_FALCONPADDED512");
-    if (getenv("OQS_OID_RSA3072_FALCONPADDED512"))
-        oqs_oid_alg_list[38 + OQS_KEMOID_CNT]
-            = getenv("OQS_OID_RSA3072_FALCONPADDED512");
-    if (getenv("OQS_OID_FALCON1024"))
-        oqs_oid_alg_list[40 + OQS_KEMOID_CNT] = getenv("OQS_OID_FALCON1024");
-    if (getenv("OQS_OID_P521_FALCON1024"))
-        oqs_oid_alg_list[42 + OQS_KEMOID_CNT]
-            = getenv("OQS_OID_P521_FALCON1024");
-    if (getenv("OQS_OID_FALCONPADDED1024"))
-        oqs_oid_alg_list[44 + OQS_KEMOID_CNT]
-            = getenv("OQS_OID_FALCONPADDED1024");
-    if (getenv("OQS_OID_P521_FALCONPADDED1024"))
-        oqs_oid_alg_list[46 + OQS_KEMOID_CNT]
-            = getenv("OQS_OID_P521_FALCONPADDED1024");
-    if (getenv("OQS_OID_SPHINCSSHA2128FSIMPLE"))
-        oqs_oid_alg_list[48 + OQS_KEMOID_CNT]
-            = getenv("OQS_OID_SPHINCSSHA2128FSIMPLE");
-    if (getenv("OQS_OID_P256_SPHINCSSHA2128FSIMPLE"))
-        oqs_oid_alg_list[50 + OQS_KEMOID_CNT]
-            = getenv("OQS_OID_P256_SPHINCSSHA2128FSIMPLE");
-    if (getenv("OQS_OID_RSA3072_SPHINCSSHA2128FSIMPLE"))
-        oqs_oid_alg_list[52 + OQS_KEMOID_CNT]
-            = getenv("OQS_OID_RSA3072_SPHINCSSHA2128FSIMPLE");
-    if (getenv("OQS_OID_SPHINCSSHA2128SSIMPLE"))
-        oqs_oid_alg_list[54 + OQS_KEMOID_CNT]
-            = getenv("OQS_OID_SPHINCSSHA2128SSIMPLE");
-    if (getenv("OQS_OID_P256_SPHINCSSHA2128SSIMPLE"))
-        oqs_oid_alg_list[56 + OQS_KEMOID_CNT]
-            = getenv("OQS_OID_P256_SPHINCSSHA2128SSIMPLE");
-    if (getenv("OQS_OID_RSA3072_SPHINCSSHA2128SSIMPLE"))
-        oqs_oid_alg_list[58 + OQS_KEMOID_CNT]
-            = getenv("OQS_OID_RSA3072_SPHINCSSHA2128SSIMPLE");
-    if (getenv("OQS_OID_SPHINCSSHA2192FSIMPLE"))
-        oqs_oid_alg_list[60 + OQS_KEMOID_CNT]
-            = getenv("OQS_OID_SPHINCSSHA2192FSIMPLE");
-    if (getenv("OQS_OID_P384_SPHINCSSHA2192FSIMPLE"))
-        oqs_oid_alg_list[62 + OQS_KEMOID_CNT]
-            = getenv("OQS_OID_P384_SPHINCSSHA2192FSIMPLE");
-    if (getenv("OQS_OID_SPHINCSSHAKE128FSIMPLE"))
-        oqs_oid_alg_list[64 + OQS_KEMOID_CNT]
-            = getenv("OQS_OID_SPHINCSSHAKE128FSIMPLE");
-    if (getenv("OQS_OID_P256_SPHINCSSHAKE128FSIMPLE"))
-        oqs_oid_alg_list[66 + OQS_KEMOID_CNT]
-            = getenv("OQS_OID_P256_SPHINCSSHAKE128FSIMPLE");
-    if (getenv("OQS_OID_RSA3072_SPHINCSSHAKE128FSIMPLE"))
-        oqs_oid_alg_list[68 + OQS_KEMOID_CNT]
-            = getenv("OQS_OID_RSA3072_SPHINCSSHAKE128FSIMPLE");
-    ///// OQS_TEMPLATE_FRAGMENT_OID_PATCHING_END
+        if ((envval = getenv("OQS_OID_DILITHIUM2")))
+            oqs_oid_alg_list[0 + OQS_KEMOID_CNT] = envval;
+        if ((envval = getenv("OQS_OID_P256_DILITHIUM2")))
+            oqs_oid_alg_list[2 + OQS_KEMOID_CNT] = envval;
+        if ((envval = getenv("OQS_OID_RSA3072_DILITHIUM2")))
+            oqs_oid_alg_list[4 + OQS_KEMOID_CNT] = envval;
+        if ((envval = getenv("OQS_OID_DILITHIUM3")))
+            oqs_oid_alg_list[6 + OQS_KEMOID_CNT] = envval;
+        if ((envval = getenv("OQS_OID_P384_DILITHIUM3")))
+            oqs_oid_alg_list[8 + OQS_KEMOID_CNT] = envval;
+        if ((envval = getenv("OQS_OID_DILITHIUM5")))
+            oqs_oid_alg_list[10 + OQS_KEMOID_CNT] = envval;
+        if ((envval = getenv("OQS_OID_P521_DILITHIUM5")))
+            oqs_oid_alg_list[12 + OQS_KEMOID_CNT] = envval;
+        if ((envval = getenv("OQS_OID_MLDSA44")))
+            oqs_oid_alg_list[14 + OQS_KEMOID_CNT] = envval;
+        if ((envval = getenv("OQS_OID_P256_MLDSA44")))
+            oqs_oid_alg_list[16 + OQS_KEMOID_CNT] = envval;
+        if ((envval = getenv("OQS_OID_RSA3072_MLDSA44")))
+            oqs_oid_alg_list[18 + OQS_KEMOID_CNT] = envval;
+        if ((envval = getenv("OQS_OID_MLDSA65")))
+            oqs_oid_alg_list[20 + OQS_KEMOID_CNT] = envval;
+        if ((envval = getenv("OQS_OID_P384_MLDSA65")))
+            oqs_oid_alg_list[22 + OQS_KEMOID_CNT] = envval;
+        if ((envval = getenv("OQS_OID_MLDSA87")))
+            oqs_oid_alg_list[24 + OQS_KEMOID_CNT] = envval;
+        if ((envval = getenv("OQS_OID_P521_MLDSA87")))
+            oqs_oid_alg_list[26 + OQS_KEMOID_CNT] = envval;
+        if ((envval = getenv("OQS_OID_FALCON512")))
+            oqs_oid_alg_list[28 + OQS_KEMOID_CNT] = envval;
+        if ((envval = getenv("OQS_OID_P256_FALCON512")))
+            oqs_oid_alg_list[30 + OQS_KEMOID_CNT] = envval;
+        if ((envval = getenv("OQS_OID_RSA3072_FALCON512")))
+            oqs_oid_alg_list[32 + OQS_KEMOID_CNT] = envval;
+        if ((envval = getenv("OQS_OID_FALCONPADDED512")))
+            oqs_oid_alg_list[34 + OQS_KEMOID_CNT] = envval;
+        if ((envval = getenv("OQS_OID_P256_FALCONPADDED512")))
+            oqs_oid_alg_list[36 + OQS_KEMOID_CNT] = envval;
+        if ((envval = getenv("OQS_OID_RSA3072_FALCONPADDED512")))
+            oqs_oid_alg_list[38 + OQS_KEMOID_CNT] = envval;
+        if ((envval = getenv("OQS_OID_FALCON1024")))
+            oqs_oid_alg_list[40 + OQS_KEMOID_CNT] = envval;
+        if ((envval = getenv("OQS_OID_P521_FALCON1024")))
+            oqs_oid_alg_list[42 + OQS_KEMOID_CNT] = envval;
+        if ((envval = getenv("OQS_OID_FALCONPADDED1024")))
+            oqs_oid_alg_list[44 + OQS_KEMOID_CNT] = envval;
+        if ((envval = getenv("OQS_OID_P521_FALCONPADDED1024")))
+            oqs_oid_alg_list[46 + OQS_KEMOID_CNT] = envval;
+        if ((envval = getenv("OQS_OID_SPHINCSSHA2128FSIMPLE")))
+            oqs_oid_alg_list[48 + OQS_KEMOID_CNT] = envval;
+        if ((envval = getenv("OQS_OID_P256_SPHINCSSHA2128FSIMPLE")))
+            oqs_oid_alg_list[50 + OQS_KEMOID_CNT] = envval;
+        if ((envval = getenv("OQS_OID_RSA3072_SPHINCSSHA2128FSIMPLE")))
+            oqs_oid_alg_list[52 + OQS_KEMOID_CNT] = envval;
+        if ((envval = getenv("OQS_OID_SPHINCSSHA2128SSIMPLE")))
+            oqs_oid_alg_list[54 + OQS_KEMOID_CNT] = envval;
+        if ((envval = getenv("OQS_OID_P256_SPHINCSSHA2128SSIMPLE")))
+            oqs_oid_alg_list[56 + OQS_KEMOID_CNT] = envval;
+        if ((envval = getenv("OQS_OID_RSA3072_SPHINCSSHA2128SSIMPLE")))
+            oqs_oid_alg_list[58 + OQS_KEMOID_CNT] = envval;
+        if ((envval = getenv("OQS_OID_SPHINCSSHA2192FSIMPLE")))
+            oqs_oid_alg_list[60 + OQS_KEMOID_CNT] = envval;
+        if ((envval = getenv("OQS_OID_P384_SPHINCSSHA2192FSIMPLE")))
+            oqs_oid_alg_list[62 + OQS_KEMOID_CNT] = envval;
+        if ((envval = getenv("OQS_OID_SPHINCSSHAKE128FSIMPLE")))
+            oqs_oid_alg_list[64 + OQS_KEMOID_CNT] = envval;
+        if ((envval = getenv("OQS_OID_P256_SPHINCSSHAKE128FSIMPLE")))
+            oqs_oid_alg_list[66 + OQS_KEMOID_CNT] = envval;
+        if ((envval = getenv("OQS_OID_RSA3072_SPHINCSSHAKE128FSIMPLE")))
+            oqs_oid_alg_list[68 + OQS_KEMOID_CNT] = envval;
+    } ///// OQS_TEMPLATE_FRAGMENT_OID_PATCHING_END
     return 1;
 }
 
@@ -505,245 +483,221 @@ const char *oqs_alg_encoding_list[OQS_OID_CNT] = {0};
 int oqs_patch_encodings(void)
 {
     ///// OQS_TEMPLATE_FRAGMENT_ENCODING_PATCHING_START
-    if (getenv("OQS_ENCODING_DILITHIUM2"))
-        oqs_alg_encoding_list[0] = getenv("OQS_ENCODING_DILITHIUM2");
-    if (getenv("OQS_ENCODING_DILITHIUM2_ALGNAME"))
-        oqs_alg_encoding_list[1] = getenv("OQS_ENCODING_DILITHIUM2_ALGNAME");
-    if (getenv("OQS_ENCODING_P256_DILITHIUM2"))
-        oqs_alg_encoding_list[2] = getenv("OQS_ENCODING_P256_DILITHIUM2");
-    if (getenv("OQS_ENCODING_P256_DILITHIUM2_ALGNAME"))
-        oqs_alg_encoding_list[3]
-            = getenv("OQS_ENCODING_P256_DILITHIUM2_ALGNAME");
-    if (getenv("OQS_ENCODING_RSA3072_DILITHIUM2"))
-        oqs_alg_encoding_list[4] = getenv("OQS_ENCODING_RSA3072_DILITHIUM2");
-    if (getenv("OQS_ENCODING_RSA3072_DILITHIUM2_ALGNAME"))
-        oqs_alg_encoding_list[5]
-            = getenv("OQS_ENCODING_RSA3072_DILITHIUM2_ALGNAME");
-    if (getenv("OQS_ENCODING_DILITHIUM3"))
-        oqs_alg_encoding_list[6] = getenv("OQS_ENCODING_DILITHIUM3");
-    if (getenv("OQS_ENCODING_DILITHIUM3_ALGNAME"))
-        oqs_alg_encoding_list[7] = getenv("OQS_ENCODING_DILITHIUM3_ALGNAME");
-    if (getenv("OQS_ENCODING_P384_DILITHIUM3"))
-        oqs_alg_encoding_list[8] = getenv("OQS_ENCODING_P384_DILITHIUM3");
-    if (getenv("OQS_ENCODING_P384_DILITHIUM3_ALGNAME"))
-        oqs_alg_encoding_list[9]
-            = getenv("OQS_ENCODING_P384_DILITHIUM3_ALGNAME");
-    if (getenv("OQS_ENCODING_DILITHIUM5"))
-        oqs_alg_encoding_list[10] = getenv("OQS_ENCODING_DILITHIUM5");
-    if (getenv("OQS_ENCODING_DILITHIUM5_ALGNAME"))
-        oqs_alg_encoding_list[11] = getenv("OQS_ENCODING_DILITHIUM5_ALGNAME");
-    if (getenv("OQS_ENCODING_P521_DILITHIUM5"))
-        oqs_alg_encoding_list[12] = getenv("OQS_ENCODING_P521_DILITHIUM5");
-    if (getenv("OQS_ENCODING_P521_DILITHIUM5_ALGNAME"))
-        oqs_alg_encoding_list[13]
-            = getenv("OQS_ENCODING_P521_DILITHIUM5_ALGNAME");
-    if (getenv("OQS_ENCODING_MLDSA44"))
-        oqs_alg_encoding_list[14] = getenv("OQS_ENCODING_MLDSA44");
-    if (getenv("OQS_ENCODING_MLDSA44_ALGNAME"))
-        oqs_alg_encoding_list[15] = getenv("OQS_ENCODING_MLDSA44_ALGNAME");
-    if (getenv("OQS_ENCODING_P256_MLDSA44"))
-        oqs_alg_encoding_list[16] = getenv("OQS_ENCODING_P256_MLDSA44");
-    if (getenv("OQS_ENCODING_P256_MLDSA44_ALGNAME"))
-        oqs_alg_encoding_list[17] = getenv("OQS_ENCODING_P256_MLDSA44_ALGNAME");
-    if (getenv("OQS_ENCODING_RSA3072_MLDSA44"))
-        oqs_alg_encoding_list[18] = getenv("OQS_ENCODING_RSA3072_MLDSA44");
-    if (getenv("OQS_ENCODING_RSA3072_MLDSA44_ALGNAME"))
-        oqs_alg_encoding_list[19]
-            = getenv("OQS_ENCODING_RSA3072_MLDSA44_ALGNAME");
-    if (getenv("OQS_ENCODING_MLDSA44_PSS2048"))
-        oqs_alg_encoding_list[20] = getenv("OQS_ENCODING_MLDSA44_PSS2048");
-    if (getenv("OQS_ENCODING_MLDSA44_PSS2048_ALGNAME"))
-        oqs_alg_encoding_list[21]
-            = getenv("OQS_ENCODING_MLDSA44_PSS2048_ALGNAME");
-    if (getenv("OQS_ENCODING_MLDSA44_RSA2048"))
-        oqs_alg_encoding_list[22] = getenv("OQS_ENCODING_MLDSA44_RSA2048");
-    if (getenv("OQS_ENCODING_MLDSA44_RSA2048_ALGNAME"))
-        oqs_alg_encoding_list[23]
-            = getenv("OQS_ENCODING_MLDSA44_RSA2048_ALGNAME");
-    if (getenv("OQS_ENCODING_MLDSA44_ED25519"))
-        oqs_alg_encoding_list[24] = getenv("OQS_ENCODING_MLDSA44_ED25519");
-    if (getenv("OQS_ENCODING_MLDSA44_ED25519_ALGNAME"))
-        oqs_alg_encoding_list[25]
-            = getenv("OQS_ENCODING_MLDSA44_ED25519_ALGNAME");
-    if (getenv("OQS_ENCODING_MLDSA44_P256"))
-        oqs_alg_encoding_list[26] = getenv("OQS_ENCODING_MLDSA44_P256");
-    if (getenv("OQS_ENCODING_MLDSA44_P256_ALGNAME"))
-        oqs_alg_encoding_list[27] = getenv("OQS_ENCODING_MLDSA44_P256_ALGNAME");
-    if (getenv("OQS_ENCODING_MLDSA44_BP256"))
-        oqs_alg_encoding_list[28] = getenv("OQS_ENCODING_MLDSA44_BP256");
-    if (getenv("OQS_ENCODING_MLDSA44_BP256_ALGNAME"))
-        oqs_alg_encoding_list[29]
-            = getenv("OQS_ENCODING_MLDSA44_BP256_ALGNAME");
-    if (getenv("OQS_ENCODING_MLDSA65"))
-        oqs_alg_encoding_list[30] = getenv("OQS_ENCODING_MLDSA65");
-    if (getenv("OQS_ENCODING_MLDSA65_ALGNAME"))
-        oqs_alg_encoding_list[31] = getenv("OQS_ENCODING_MLDSA65_ALGNAME");
-    if (getenv("OQS_ENCODING_P384_MLDSA65"))
-        oqs_alg_encoding_list[32] = getenv("OQS_ENCODING_P384_MLDSA65");
-    if (getenv("OQS_ENCODING_P384_MLDSA65_ALGNAME"))
-        oqs_alg_encoding_list[33] = getenv("OQS_ENCODING_P384_MLDSA65_ALGNAME");
-    if (getenv("OQS_ENCODING_MLDSA65_PSS3072"))
-        oqs_alg_encoding_list[34] = getenv("OQS_ENCODING_MLDSA65_PSS3072");
-    if (getenv("OQS_ENCODING_MLDSA65_PSS3072_ALGNAME"))
-        oqs_alg_encoding_list[35]
-            = getenv("OQS_ENCODING_MLDSA65_PSS3072_ALGNAME");
-    if (getenv("OQS_ENCODING_MLDSA65_RSA3072"))
-        oqs_alg_encoding_list[36] = getenv("OQS_ENCODING_MLDSA65_RSA3072");
-    if (getenv("OQS_ENCODING_MLDSA65_RSA3072_ALGNAME"))
-        oqs_alg_encoding_list[37]
-            = getenv("OQS_ENCODING_MLDSA65_RSA3072_ALGNAME");
-    if (getenv("OQS_ENCODING_MLDSA65_P256"))
-        oqs_alg_encoding_list[38] = getenv("OQS_ENCODING_MLDSA65_P256");
-    if (getenv("OQS_ENCODING_MLDSA65_P256_ALGNAME"))
-        oqs_alg_encoding_list[39] = getenv("OQS_ENCODING_MLDSA65_P256_ALGNAME");
-    if (getenv("OQS_ENCODING_MLDSA65_BP256"))
-        oqs_alg_encoding_list[40] = getenv("OQS_ENCODING_MLDSA65_BP256");
-    if (getenv("OQS_ENCODING_MLDSA65_BP256_ALGNAME"))
-        oqs_alg_encoding_list[41]
-            = getenv("OQS_ENCODING_MLDSA65_BP256_ALGNAME");
-    if (getenv("OQS_ENCODING_MLDSA65_ED25519"))
-        oqs_alg_encoding_list[42] = getenv("OQS_ENCODING_MLDSA65_ED25519");
-    if (getenv("OQS_ENCODING_MLDSA65_ED25519_ALGNAME"))
-        oqs_alg_encoding_list[43]
-            = getenv("OQS_ENCODING_MLDSA65_ED25519_ALGNAME");
-    if (getenv("OQS_ENCODING_MLDSA87"))
-        oqs_alg_encoding_list[44] = getenv("OQS_ENCODING_MLDSA87");
-    if (getenv("OQS_ENCODING_MLDSA87_ALGNAME"))
-        oqs_alg_encoding_list[45] = getenv("OQS_ENCODING_MLDSA87_ALGNAME");
-    if (getenv("OQS_ENCODING_P521_MLDSA87"))
-        oqs_alg_encoding_list[46] = getenv("OQS_ENCODING_P521_MLDSA87");
-    if (getenv("OQS_ENCODING_P521_MLDSA87_ALGNAME"))
-        oqs_alg_encoding_list[47] = getenv("OQS_ENCODING_P521_MLDSA87_ALGNAME");
-    if (getenv("OQS_ENCODING_MLDSA87_P384"))
-        oqs_alg_encoding_list[48] = getenv("OQS_ENCODING_MLDSA87_P384");
-    if (getenv("OQS_ENCODING_MLDSA87_P384_ALGNAME"))
-        oqs_alg_encoding_list[49] = getenv("OQS_ENCODING_MLDSA87_P384_ALGNAME");
-    if (getenv("OQS_ENCODING_MLDSA87_BP384"))
-        oqs_alg_encoding_list[50] = getenv("OQS_ENCODING_MLDSA87_BP384");
-    if (getenv("OQS_ENCODING_MLDSA87_BP384_ALGNAME"))
-        oqs_alg_encoding_list[51]
-            = getenv("OQS_ENCODING_MLDSA87_BP384_ALGNAME");
-    if (getenv("OQS_ENCODING_MLDSA87_ED448"))
-        oqs_alg_encoding_list[52] = getenv("OQS_ENCODING_MLDSA87_ED448");
-    if (getenv("OQS_ENCODING_MLDSA87_ED448_ALGNAME"))
-        oqs_alg_encoding_list[53]
-            = getenv("OQS_ENCODING_MLDSA87_ED448_ALGNAME");
-    if (getenv("OQS_ENCODING_FALCON512"))
-        oqs_alg_encoding_list[54] = getenv("OQS_ENCODING_FALCON512");
-    if (getenv("OQS_ENCODING_FALCON512_ALGNAME"))
-        oqs_alg_encoding_list[55] = getenv("OQS_ENCODING_FALCON512_ALGNAME");
-    if (getenv("OQS_ENCODING_P256_FALCON512"))
-        oqs_alg_encoding_list[56] = getenv("OQS_ENCODING_P256_FALCON512");
-    if (getenv("OQS_ENCODING_P256_FALCON512_ALGNAME"))
-        oqs_alg_encoding_list[57]
-            = getenv("OQS_ENCODING_P256_FALCON512_ALGNAME");
-    if (getenv("OQS_ENCODING_RSA3072_FALCON512"))
-        oqs_alg_encoding_list[58] = getenv("OQS_ENCODING_RSA3072_FALCON512");
-    if (getenv("OQS_ENCODING_RSA3072_FALCON512_ALGNAME"))
-        oqs_alg_encoding_list[59]
-            = getenv("OQS_ENCODING_RSA3072_FALCON512_ALGNAME");
-    if (getenv("OQS_ENCODING_FALCONPADDED512"))
-        oqs_alg_encoding_list[60] = getenv("OQS_ENCODING_FALCONPADDED512");
-    if (getenv("OQS_ENCODING_FALCONPADDED512_ALGNAME"))
-        oqs_alg_encoding_list[61]
-            = getenv("OQS_ENCODING_FALCONPADDED512_ALGNAME");
-    if (getenv("OQS_ENCODING_P256_FALCONPADDED512"))
-        oqs_alg_encoding_list[62] = getenv("OQS_ENCODING_P256_FALCONPADDED512");
-    if (getenv("OQS_ENCODING_P256_FALCONPADDED512_ALGNAME"))
-        oqs_alg_encoding_list[63]
-            = getenv("OQS_ENCODING_P256_FALCONPADDED512_ALGNAME");
-    if (getenv("OQS_ENCODING_RSA3072_FALCONPADDED512"))
-        oqs_alg_encoding_list[64]
-            = getenv("OQS_ENCODING_RSA3072_FALCONPADDED512");
-    if (getenv("OQS_ENCODING_RSA3072_FALCONPADDED512_ALGNAME"))
-        oqs_alg_encoding_list[65]
-            = getenv("OQS_ENCODING_RSA3072_FALCONPADDED512_ALGNAME");
-    if (getenv("OQS_ENCODING_FALCON1024"))
-        oqs_alg_encoding_list[66] = getenv("OQS_ENCODING_FALCON1024");
-    if (getenv("OQS_ENCODING_FALCON1024_ALGNAME"))
-        oqs_alg_encoding_list[67] = getenv("OQS_ENCODING_FALCON1024_ALGNAME");
-    if (getenv("OQS_ENCODING_P521_FALCON1024"))
-        oqs_alg_encoding_list[68] = getenv("OQS_ENCODING_P521_FALCON1024");
-    if (getenv("OQS_ENCODING_P521_FALCON1024_ALGNAME"))
-        oqs_alg_encoding_list[69]
-            = getenv("OQS_ENCODING_P521_FALCON1024_ALGNAME");
-    if (getenv("OQS_ENCODING_FALCONPADDED1024"))
-        oqs_alg_encoding_list[70] = getenv("OQS_ENCODING_FALCONPADDED1024");
-    if (getenv("OQS_ENCODING_FALCONPADDED1024_ALGNAME"))
-        oqs_alg_encoding_list[71]
-            = getenv("OQS_ENCODING_FALCONPADDED1024_ALGNAME");
-    if (getenv("OQS_ENCODING_P521_FALCONPADDED1024"))
-        oqs_alg_encoding_list[72]
-            = getenv("OQS_ENCODING_P521_FALCONPADDED1024");
-    if (getenv("OQS_ENCODING_P521_FALCONPADDED1024_ALGNAME"))
-        oqs_alg_encoding_list[73]
-            = getenv("OQS_ENCODING_P521_FALCONPADDED1024_ALGNAME");
-    if (getenv("OQS_ENCODING_SPHINCSSHA2128FSIMPLE"))
-        oqs_alg_encoding_list[74]
-            = getenv("OQS_ENCODING_SPHINCSSHA2128FSIMPLE");
-    if (getenv("OQS_ENCODING_SPHINCSSHA2128FSIMPLE_ALGNAME"))
-        oqs_alg_encoding_list[75]
-            = getenv("OQS_ENCODING_SPHINCSSHA2128FSIMPLE_ALGNAME");
-    if (getenv("OQS_ENCODING_P256_SPHINCSSHA2128FSIMPLE"))
-        oqs_alg_encoding_list[76]
-            = getenv("OQS_ENCODING_P256_SPHINCSSHA2128FSIMPLE");
-    if (getenv("OQS_ENCODING_P256_SPHINCSSHA2128FSIMPLE_ALGNAME"))
-        oqs_alg_encoding_list[77]
-            = getenv("OQS_ENCODING_P256_SPHINCSSHA2128FSIMPLE_ALGNAME");
-    if (getenv("OQS_ENCODING_RSA3072_SPHINCSSHA2128FSIMPLE"))
-        oqs_alg_encoding_list[78]
-            = getenv("OQS_ENCODING_RSA3072_SPHINCSSHA2128FSIMPLE");
-    if (getenv("OQS_ENCODING_RSA3072_SPHINCSSHA2128FSIMPLE_ALGNAME"))
-        oqs_alg_encoding_list[79]
-            = getenv("OQS_ENCODING_RSA3072_SPHINCSSHA2128FSIMPLE_ALGNAME");
-    if (getenv("OQS_ENCODING_SPHINCSSHA2128SSIMPLE"))
-        oqs_alg_encoding_list[80]
-            = getenv("OQS_ENCODING_SPHINCSSHA2128SSIMPLE");
-    if (getenv("OQS_ENCODING_SPHINCSSHA2128SSIMPLE_ALGNAME"))
-        oqs_alg_encoding_list[81]
-            = getenv("OQS_ENCODING_SPHINCSSHA2128SSIMPLE_ALGNAME");
-    if (getenv("OQS_ENCODING_P256_SPHINCSSHA2128SSIMPLE"))
-        oqs_alg_encoding_list[82]
-            = getenv("OQS_ENCODING_P256_SPHINCSSHA2128SSIMPLE");
-    if (getenv("OQS_ENCODING_P256_SPHINCSSHA2128SSIMPLE_ALGNAME"))
-        oqs_alg_encoding_list[83]
-            = getenv("OQS_ENCODING_P256_SPHINCSSHA2128SSIMPLE_ALGNAME");
-    if (getenv("OQS_ENCODING_RSA3072_SPHINCSSHA2128SSIMPLE"))
-        oqs_alg_encoding_list[84]
-            = getenv("OQS_ENCODING_RSA3072_SPHINCSSHA2128SSIMPLE");
-    if (getenv("OQS_ENCODING_RSA3072_SPHINCSSHA2128SSIMPLE_ALGNAME"))
-        oqs_alg_encoding_list[85]
-            = getenv("OQS_ENCODING_RSA3072_SPHINCSSHA2128SSIMPLE_ALGNAME");
-    if (getenv("OQS_ENCODING_SPHINCSSHA2192FSIMPLE"))
-        oqs_alg_encoding_list[86]
-            = getenv("OQS_ENCODING_SPHINCSSHA2192FSIMPLE");
-    if (getenv("OQS_ENCODING_SPHINCSSHA2192FSIMPLE_ALGNAME"))
-        oqs_alg_encoding_list[87]
-            = getenv("OQS_ENCODING_SPHINCSSHA2192FSIMPLE_ALGNAME");
-    if (getenv("OQS_ENCODING_P384_SPHINCSSHA2192FSIMPLE"))
-        oqs_alg_encoding_list[88]
-            = getenv("OQS_ENCODING_P384_SPHINCSSHA2192FSIMPLE");
-    if (getenv("OQS_ENCODING_P384_SPHINCSSHA2192FSIMPLE_ALGNAME"))
-        oqs_alg_encoding_list[89]
-            = getenv("OQS_ENCODING_P384_SPHINCSSHA2192FSIMPLE_ALGNAME");
-    if (getenv("OQS_ENCODING_SPHINCSSHAKE128FSIMPLE"))
-        oqs_alg_encoding_list[90]
-            = getenv("OQS_ENCODING_SPHINCSSHAKE128FSIMPLE");
-    if (getenv("OQS_ENCODING_SPHINCSSHAKE128FSIMPLE_ALGNAME"))
-        oqs_alg_encoding_list[91]
-            = getenv("OQS_ENCODING_SPHINCSSHAKE128FSIMPLE_ALGNAME");
-    if (getenv("OQS_ENCODING_P256_SPHINCSSHAKE128FSIMPLE"))
-        oqs_alg_encoding_list[92]
-            = getenv("OQS_ENCODING_P256_SPHINCSSHAKE128FSIMPLE");
-    if (getenv("OQS_ENCODING_P256_SPHINCSSHAKE128FSIMPLE_ALGNAME"))
-        oqs_alg_encoding_list[93]
-            = getenv("OQS_ENCODING_P256_SPHINCSSHAKE128FSIMPLE_ALGNAME");
-    if (getenv("OQS_ENCODING_RSA3072_SPHINCSSHAKE128FSIMPLE"))
-        oqs_alg_encoding_list[94]
-            = getenv("OQS_ENCODING_RSA3072_SPHINCSSHAKE128FSIMPLE");
-    if (getenv("OQS_ENCODING_RSA3072_SPHINCSSHAKE128FSIMPLE_ALGNAME"))
-        oqs_alg_encoding_list[95]
-            = getenv("OQS_ENCODING_RSA3072_SPHINCSSHAKE128FSIMPLE_ALGNAME");
+    {
+        const char *envval = NULL;
+        if ((envval = getenv("OQS_ENCODING_DILITHIUM2")))
+            oqs_alg_encoding_list[0] = envval;
+        if ((envval = getenv("OQS_ENCODING_DILITHIUM2_ALGNAME")))
+            oqs_alg_encoding_list[1] = envval;
+        if ((envval = getenv("OQS_ENCODING_P256_DILITHIUM2")))
+            oqs_alg_encoding_list[2] = envval;
+        if ((envval = getenv("OQS_ENCODING_P256_DILITHIUM2_ALGNAME")))
+            oqs_alg_encoding_list[3] = envval;
+        if ((envval = getenv("OQS_ENCODING_RSA3072_DILITHIUM2")))
+            oqs_alg_encoding_list[4] = envval;
+        if ((envval = getenv("OQS_ENCODING_RSA3072_DILITHIUM2_ALGNAME")))
+            oqs_alg_encoding_list[5] = envval;
+        if ((envval = getenv("OQS_ENCODING_DILITHIUM3")))
+            oqs_alg_encoding_list[6] = envval;
+        if ((envval = getenv("OQS_ENCODING_DILITHIUM3_ALGNAME")))
+            oqs_alg_encoding_list[7] = envval;
+        if ((envval = getenv("OQS_ENCODING_P384_DILITHIUM3")))
+            oqs_alg_encoding_list[8] = envval;
+        if ((envval = getenv("OQS_ENCODING_P384_DILITHIUM3_ALGNAME")))
+            oqs_alg_encoding_list[9] = envval;
+        if ((envval = getenv("OQS_ENCODING_DILITHIUM5")))
+            oqs_alg_encoding_list[10] = envval;
+        if ((envval = getenv("OQS_ENCODING_DILITHIUM5_ALGNAME")))
+            oqs_alg_encoding_list[11] = envval;
+        if ((envval = getenv("OQS_ENCODING_P521_DILITHIUM5")))
+            oqs_alg_encoding_list[12] = envval;
+        if ((envval = getenv("OQS_ENCODING_P521_DILITHIUM5_ALGNAME")))
+            oqs_alg_encoding_list[13] = envval;
+        if ((envval = getenv("OQS_ENCODING_MLDSA44")))
+            oqs_alg_encoding_list[14] = envval;
+        if ((envval = getenv("OQS_ENCODING_MLDSA44_ALGNAME")))
+            oqs_alg_encoding_list[15] = envval;
+        if ((envval = getenv("OQS_ENCODING_P256_MLDSA44")))
+            oqs_alg_encoding_list[16] = envval;
+        if ((envval = getenv("OQS_ENCODING_P256_MLDSA44_ALGNAME")))
+            oqs_alg_encoding_list[17] = envval;
+        if ((envval = getenv("OQS_ENCODING_RSA3072_MLDSA44")))
+            oqs_alg_encoding_list[18] = envval;
+        if ((envval = getenv("OQS_ENCODING_RSA3072_MLDSA44_ALGNAME")))
+            oqs_alg_encoding_list[19] = envval;
+        if (getenv("OQS_ENCODING_MLDSA44_PSS2048"))
+            oqs_alg_encoding_list[20] = getenv("OQS_ENCODING_MLDSA44_PSS2048");
+        if (getenv("OQS_ENCODING_MLDSA44_PSS2048_ALGNAME"))
+            oqs_alg_encoding_list[21]
+                = getenv("OQS_ENCODING_MLDSA44_PSS2048_ALGNAME");
+        if (getenv("OQS_ENCODING_MLDSA44_RSA2048"))
+            oqs_alg_encoding_list[22] = getenv("OQS_ENCODING_MLDSA44_RSA2048");
+        if (getenv("OQS_ENCODING_MLDSA44_RSA2048_ALGNAME"))
+            oqs_alg_encoding_list[23]
+                = getenv("OQS_ENCODING_MLDSA44_RSA2048_ALGNAME");
+        if (getenv("OQS_ENCODING_MLDSA44_ED25519"))
+            oqs_alg_encoding_list[24] = getenv("OQS_ENCODING_MLDSA44_ED25519");
+        if (getenv("OQS_ENCODING_MLDSA44_ED25519_ALGNAME"))
+            oqs_alg_encoding_list[25]
+                = getenv("OQS_ENCODING_MLDSA44_ED25519_ALGNAME");
+        if (getenv("OQS_ENCODING_MLDSA44_P256"))
+            oqs_alg_encoding_list[26] = getenv("OQS_ENCODING_MLDSA44_P256");
+        if (getenv("OQS_ENCODING_MLDSA44_P256_ALGNAME"))
+            oqs_alg_encoding_list[27]
+                = getenv("OQS_ENCODING_MLDSA44_P256_ALGNAME");
+        if (getenv("OQS_ENCODING_MLDSA44_BP256"))
+            oqs_alg_encoding_list[28] = getenv("OQS_ENCODING_MLDSA44_BP256");
+        if (getenv("OQS_ENCODING_MLDSA44_BP256_ALGNAME"))
+            oqs_alg_encoding_list[29]
+                = getenv("OQS_ENCODING_MLDSA44_BP256_ALGNAME");
+        if ((envval = getenv("OQS_ENCODING_MLDSA65")))
+            oqs_alg_encoding_list[30] = envval;
+        if ((envval = getenv("OQS_ENCODING_MLDSA65_ALGNAME")))
+            oqs_alg_encoding_list[31] = envval;
+        if ((envval = getenv("OQS_ENCODING_P384_MLDSA65")))
+            oqs_alg_encoding_list[32] = envval;
+        if ((envval = getenv("OQS_ENCODING_P384_MLDSA65_ALGNAME")))
+            oqs_alg_encoding_list[33] = envval;
+        if (getenv("OQS_ENCODING_MLDSA65_PSS3072"))
+            oqs_alg_encoding_list[34] = getenv("OQS_ENCODING_MLDSA65_PSS3072");
+        if (getenv("OQS_ENCODING_MLDSA65_PSS3072_ALGNAME"))
+            oqs_alg_encoding_list[35]
+                = getenv("OQS_ENCODING_MLDSA65_PSS3072_ALGNAME");
+        if (getenv("OQS_ENCODING_MLDSA65_RSA3072"))
+            oqs_alg_encoding_list[36] = getenv("OQS_ENCODING_MLDSA65_RSA3072");
+        if (getenv("OQS_ENCODING_MLDSA65_RSA3072_ALGNAME"))
+            oqs_alg_encoding_list[37]
+                = getenv("OQS_ENCODING_MLDSA65_RSA3072_ALGNAME");
+        if (getenv("OQS_ENCODING_MLDSA65_P256"))
+            oqs_alg_encoding_list[38] = getenv("OQS_ENCODING_MLDSA65_P256");
+        if (getenv("OQS_ENCODING_MLDSA65_P256_ALGNAME"))
+            oqs_alg_encoding_list[39]
+                = getenv("OQS_ENCODING_MLDSA65_P256_ALGNAME");
+        if (getenv("OQS_ENCODING_MLDSA65_BP256"))
+            oqs_alg_encoding_list[40] = getenv("OQS_ENCODING_MLDSA65_BP256");
+        if (getenv("OQS_ENCODING_MLDSA65_BP256_ALGNAME"))
+            oqs_alg_encoding_list[41]
+                = getenv("OQS_ENCODING_MLDSA65_BP256_ALGNAME");
+        if (getenv("OQS_ENCODING_MLDSA65_ED25519"))
+            oqs_alg_encoding_list[42] = getenv("OQS_ENCODING_MLDSA65_ED25519");
+        if (getenv("OQS_ENCODING_MLDSA65_ED25519_ALGNAME"))
+            oqs_alg_encoding_list[43]
+                = getenv("OQS_ENCODING_MLDSA65_ED25519_ALGNAME");
+        if ((envval = getenv("OQS_ENCODING_MLDSA87")))
+            oqs_alg_encoding_list[44] = envval;
+        if ((envval = getenv("OQS_ENCODING_MLDSA87_ALGNAME")))
+            oqs_alg_encoding_list[45] = envval;
+        if ((envval = getenv("OQS_ENCODING_P521_MLDSA87")))
+            oqs_alg_encoding_list[46] = envval;
+        if ((envval = getenv("OQS_ENCODING_P521_MLDSA87_ALGNAME")))
+            oqs_alg_encoding_list[47] = envval;
+        if (getenv("OQS_ENCODING_MLDSA87_P384"))
+            oqs_alg_encoding_list[48] = getenv("OQS_ENCODING_MLDSA87_P384");
+        if (getenv("OQS_ENCODING_MLDSA87_P384_ALGNAME"))
+            oqs_alg_encoding_list[49]
+                = getenv("OQS_ENCODING_MLDSA87_P384_ALGNAME");
+        if (getenv("OQS_ENCODING_MLDSA87_BP384"))
+            oqs_alg_encoding_list[50] = getenv("OQS_ENCODING_MLDSA87_BP384");
+        if (getenv("OQS_ENCODING_MLDSA87_BP384_ALGNAME"))
+            oqs_alg_encoding_list[51]
+                = getenv("OQS_ENCODING_MLDSA87_BP384_ALGNAME");
+        if (getenv("OQS_ENCODING_MLDSA87_ED448"))
+            oqs_alg_encoding_list[52] = getenv("OQS_ENCODING_MLDSA87_ED448");
+        if (getenv("OQS_ENCODING_MLDSA87_ED448_ALGNAME"))
+            oqs_alg_encoding_list[53]
+                = getenv("OQS_ENCODING_MLDSA87_ED448_ALGNAME");
+        if ((envval = getenv("OQS_ENCODING_FALCON512")))
+            oqs_alg_encoding_list[54] = envval;
+        if ((envval = getenv("OQS_ENCODING_FALCON512_ALGNAME")))
+            oqs_alg_encoding_list[55] = envval;
+        if ((envval = getenv("OQS_ENCODING_P256_FALCON512")))
+            oqs_alg_encoding_list[56] = envval;
+        if ((envval = getenv("OQS_ENCODING_P256_FALCON512_ALGNAME")))
+            oqs_alg_encoding_list[57] = envval;
+        if ((envval = getenv("OQS_ENCODING_RSA3072_FALCON512")))
+            oqs_alg_encoding_list[58] = envval;
+        if ((envval = getenv("OQS_ENCODING_RSA3072_FALCON512_ALGNAME")))
+            oqs_alg_encoding_list[59] = envval;
+        if ((envval = getenv("OQS_ENCODING_FALCONPADDED512")))
+            oqs_alg_encoding_list[60] = envval;
+        if ((envval = getenv("OQS_ENCODING_FALCONPADDED512_ALGNAME")))
+            oqs_alg_encoding_list[61] = envval;
+        if ((envval = getenv("OQS_ENCODING_P256_FALCONPADDED512")))
+            oqs_alg_encoding_list[62] = envval;
+        if ((envval = getenv("OQS_ENCODING_P256_FALCONPADDED512_ALGNAME")))
+            oqs_alg_encoding_list[63] = envval;
+        if ((envval = getenv("OQS_ENCODING_RSA3072_FALCONPADDED512")))
+            oqs_alg_encoding_list[64] = envval;
+        if ((envval = getenv("OQS_ENCODING_RSA3072_FALCONPADDED512_ALGNAME")))
+            oqs_alg_encoding_list[65] = envval;
+        if ((envval = getenv("OQS_ENCODING_FALCON1024")))
+            oqs_alg_encoding_list[66] = envval;
+        if ((envval = getenv("OQS_ENCODING_FALCON1024_ALGNAME")))
+            oqs_alg_encoding_list[67] = envval;
+        if ((envval = getenv("OQS_ENCODING_P521_FALCON1024")))
+            oqs_alg_encoding_list[68] = envval;
+        if ((envval = getenv("OQS_ENCODING_P521_FALCON1024_ALGNAME")))
+            oqs_alg_encoding_list[69] = envval;
+        if ((envval = getenv("OQS_ENCODING_FALCONPADDED1024")))
+            oqs_alg_encoding_list[70] = envval;
+        if ((envval = getenv("OQS_ENCODING_FALCONPADDED1024_ALGNAME")))
+            oqs_alg_encoding_list[71] = envval;
+        if ((envval = getenv("OQS_ENCODING_P521_FALCONPADDED1024")))
+            oqs_alg_encoding_list[72] = envval;
+        if ((envval = getenv("OQS_ENCODING_P521_FALCONPADDED1024_ALGNAME")))
+            oqs_alg_encoding_list[73] = envval;
+        if ((envval = getenv("OQS_ENCODING_SPHINCSSHA2128FSIMPLE")))
+            oqs_alg_encoding_list[74] = envval;
+        if ((envval = getenv("OQS_ENCODING_SPHINCSSHA2128FSIMPLE_ALGNAME")))
+            oqs_alg_encoding_list[75] = envval;
+        if ((envval = getenv("OQS_ENCODING_P256_SPHINCSSHA2128FSIMPLE")))
+            oqs_alg_encoding_list[76] = envval;
+        if ((envval
+             = getenv("OQS_ENCODING_P256_SPHINCSSHA2128FSIMPLE_ALGNAME")))
+            oqs_alg_encoding_list[77] = envval;
+        if ((envval = getenv("OQS_ENCODING_RSA3072_SPHINCSSHA2128FSIMPLE")))
+            oqs_alg_encoding_list[78] = envval;
+        if ((envval
+             = getenv("OQS_ENCODING_RSA3072_SPHINCSSHA2128FSIMPLE_ALGNAME")))
+            oqs_alg_encoding_list[79] = envval;
+        if ((envval = getenv("OQS_ENCODING_SPHINCSSHA2128SSIMPLE")))
+            oqs_alg_encoding_list[80] = envval;
+        if ((envval = getenv("OQS_ENCODING_SPHINCSSHA2128SSIMPLE_ALGNAME")))
+            oqs_alg_encoding_list[81] = envval;
+        if ((envval = getenv("OQS_ENCODING_P256_SPHINCSSHA2128SSIMPLE")))
+            oqs_alg_encoding_list[82] = envval;
+        if ((envval
+             = getenv("OQS_ENCODING_P256_SPHINCSSHA2128SSIMPLE_ALGNAME")))
+            oqs_alg_encoding_list[83] = envval;
+        if ((envval = getenv("OQS_ENCODING_RSA3072_SPHINCSSHA2128SSIMPLE")))
+            oqs_alg_encoding_list[84] = envval;
+        if ((envval
+             = getenv("OQS_ENCODING_RSA3072_SPHINCSSHA2128SSIMPLE_ALGNAME")))
+            oqs_alg_encoding_list[85] = envval;
+        if ((envval = getenv("OQS_ENCODING_SPHINCSSHA2192FSIMPLE")))
+            oqs_alg_encoding_list[86] = envval;
+        if ((envval = getenv("OQS_ENCODING_SPHINCSSHA2192FSIMPLE_ALGNAME")))
+            oqs_alg_encoding_list[87] = envval;
+        if ((envval = getenv("OQS_ENCODING_P384_SPHINCSSHA2192FSIMPLE")))
+            oqs_alg_encoding_list[88] = envval;
+        if ((envval
+             = getenv("OQS_ENCODING_P384_SPHINCSSHA2192FSIMPLE_ALGNAME")))
+            oqs_alg_encoding_list[89] = envval;
+        if ((envval = getenv("OQS_ENCODING_SPHINCSSHAKE128FSIMPLE")))
+            oqs_alg_encoding_list[90] = envval;
+        if ((envval = getenv("OQS_ENCODING_SPHINCSSHAKE128FSIMPLE_ALGNAME")))
+            oqs_alg_encoding_list[91] = envval;
+        if ((envval = getenv("OQS_ENCODING_P256_SPHINCSSHAKE128FSIMPLE")))
+            oqs_alg_encoding_list[92] = envval;
+        if ((envval
+             = getenv("OQS_ENCODING_P256_SPHINCSSHAKE128FSIMPLE_ALGNAME")))
+            oqs_alg_encoding_list[93] = envval;
+        if ((envval = getenv("OQS_ENCODING_RSA3072_SPHINCSSHAKE128FSIMPLE")))
+            oqs_alg_encoding_list[94] = envval;
+        if ((envval
+             = getenv("OQS_ENCODING_RSA3072_SPHINCSSHAKE128FSIMPLE_ALGNAME")))
+            oqs_alg_encoding_list[95] = envval;
+    }
     ///// OQS_TEMPLATE_FRAGMENT_ENCODING_PATCHING_END
     return 1;
 }


### PR DESCRIPTION
Do not duplicate call to `getenv`.

As described here: https://github.com/open-quantum-safe/oqs-provider/pull/317#discussion_r1516489169
we shouldn't call `getenv` twice.

This commit uses a `envval` variable to store the value of `getenv`.

Signed-off-by: thb-sb <thomas.bailleux@sandboxquantum.com>
