### PR TITLE
Remove `--repeat until-pass:5` workaround for ASan tests.

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -152,8 +152,7 @@ jobs:
         run: |
           ctest --test-dir build \
             --output-on-failure \
-            --extra-verbose \
-            --repeat until-pass:5
+            --extra-verbose
 
   linux_aarch64:
     name: "aarch64 cross-compilation"


### PR DESCRIPTION
Remove `--repeat until-pass:5` workaround for ASan tests.

Since [actions/runner-images#9491] is closed, we can now remove our workaround
for the ASAn tests.

[actions/runner-images#9491]: https://github.com/actions/runner-images/issues/9491

Signed-off-by: thb-sb <thomas.bailleux@sandboxquantum.com>
