### PR TITLE
Add composite signatures to sigalg list & add code points.

### DIFF
--- a/oqs-template/generate.yml
+++ b/oqs-template/generate.yml
@@ -399,7 +399,7 @@ kem_nid_end: '0x0250'
 kem_nid_hybrid_end: '0x2FFF'
 # need to edit ssl_local.h macros IS_OQS_KEM_CURVEID and IS_OQS_KEM_HYBRID_CURVEID with the above _end values
 
-# Next free signature ID: 0xfee1
+# Next free signature ID: 0xfeee
 sigs:
   # -
     # iso (1)
@@ -569,23 +569,28 @@ sigs:
         composite:  [{'name': 'pss2048',
                       'pretty_name': 'RSA PSS 2048',
                       'security': '112',
-                      'oid': '2.16.840.1.114027.80.8.1.1'},
+                      'oid': '2.16.840.1.114027.80.8.1.1',
+                      'code_point': '0xfee1'},
                      {'name': 'rsa2048',
                       'pretty_name': 'RSA2028',
                       'security': '112',
-                      'oid': '2.16.840.1.114027.80.8.1.2'},
+                      'oid': '2.16.840.1.114027.80.8.1.2',
+                      'code_point': '0xfee2'},
                      {'name': 'ed25519',
                       'pretty_name': 'ED25519',
                       'security': '128',
-                      'oid': '2.16.840.1.114027.80.8.1.3'},
+                      'oid': '2.16.840.1.114027.80.8.1.3',
+                      'code_point': '0xfee3'},
                      {'name': 'p256',
                       'pretty_name': 'ECDSA p256',
                       'security': '128',
-                      'oid': '2.16.840.1.114027.80.8.1.4'},
+                      'oid': '2.16.840.1.114027.80.8.1.4',
+                      'code_point': '0xfee4'},
                      {'name': 'bp256',
                       'pretty_name': 'ECDSA brainpoolP256r1',
                       'security': '256',
-                      'oid': '2.16.840.1.114027.80.8.1.5'}]
+                      'oid': '2.16.840.1.114027.80.8.1.5',
+                      'code_point': '0xfee5'}]
       -
         name: 'mldsa65'
         pretty_name: 'ML-DSA-65'
@@ -600,23 +605,28 @@ sigs:
         composite:  [{'name': 'pss3072',
                       'pretty_name': 'RSA PSS 3072',
                       'security': '128',
-                      'oid': '2.16.840.1.114027.80.8.1.6'},
+                      'oid': '2.16.840.1.114027.80.8.1.6',
+                      'code_point': '0xfee6'},
                      {'name': 'rsa3072',
                       'pretty_name': 'RSA 3072',
                       'security': '128',
-                      'oid': '2.16.840.1.114027.80.8.1.7'},
+                      'oid': '2.16.840.1.114027.80.8.1.7',
+                      'code_point': '0xfee7'},
                      {'name': 'p256',
                       'pretty_name': 'ECDSA p256',
                       'security': '128',
-                      'oid': '2.16.840.1.114027.80.8.1.8'},
+                      'oid': '2.16.840.1.114027.80.8.1.8',
+                      'code_point': '0xfee8'},
                      {'name': 'bp256',
                       'pretty_name': 'ECDSA brainpoolP256r1',
                       'security': '256',
-                      'oid': '2.16.840.1.114027.80.8.1.9'},
+                      'oid': '2.16.840.1.114027.80.8.1.9',
+                      'code_point': '0xfee9'},
                      {'name': 'ed25519',
                       'pretty_name': 'ED25519',
                       'security': '128',
-                      'oid': '2.16.840.1.114027.80.8.1.10'}]
+                      'oid': '2.16.840.1.114027.80.8.1.10',
+                      'code_point': '0xfeea'}]
       -
         name: 'mldsa87'
         pretty_name: 'ML-DSA-87'
@@ -631,15 +641,18 @@ sigs:
         composite:  [{'name': 'p384',
                       'pretty_name': 'ECDSA p384',
                       'security': '192',
-                      'oid': '2.16.840.1.114027.80.8.1.11'},
+                      'oid': '2.16.840.1.114027.80.8.1.11',
+                      'code_point': '0xfeeb'},
                      {'name': 'bp384',
                       'pretty_name': 'ECDSA brainpoolP384r1',
                       'security': '384',
-                      'oid': '2.16.840.1.114027.80.8.1.12'},
+                      'oid': '2.16.840.1.114027.80.8.1.12',
+                      'code_point': '0xfeec'},
                      {'name': 'ed448',
                       'pretty_name': 'ED448',
                       'security': '192',
-                      'oid': '2.16.840.1.114027.80.8.1.13'}]
+                      'oid': '2.16.840.1.114027.80.8.1.13',
+                      'code_point': '0xfeed'}]
   -
     # iso (1)
     # identified-organization (3)

--- a/oqs-template/oqsprov/oqsprov_capabilities.c/codepoint_patching.fragment
+++ b/oqs-template/oqsprov/oqsprov_capabilities.c/codepoint_patching.fragment
@@ -16,6 +16,10 @@
    {%- set cnt.val = cnt.val + 1 %}
    if (getenv("OQS_CODEPOINT_{{ classical_alg['name']|upper }}_{{variant['name']|upper}}")) oqs_sigalg_list[{{ cnt.val }}].code_point = atoi(getenv("OQS_CODEPOINT_{{ classical_alg['name']|upper }}_{{variant['name']|upper}}")); 
       {%- endfor %}
+      {%- for classical_alg in variant['composite'] %}
+   {%- set cnt.val = cnt.val + 1 %}
+   if (getenv("OQS_CODEPOINT_{{variant['name']|upper}}_{{ classical_alg['name']|upper }}")) oqs_sigalg_list[{{ cnt.val }}].code_point = atoi(getenv("OQS_CODEPOINT_{{variant['name']|upper}}_{{ classical_alg['name']|upper }}")); 
+      {%- endfor %}
    {%- endfor %}
 {%- endfor %}
 

--- a/oqs-template/oqsprov/oqsprov_capabilities.c/sigalg_assignments.fragment
+++ b/oqs-template/oqsprov/oqsprov_capabilities.c/sigalg_assignments.fragment
@@ -4,6 +4,9 @@
         {%- for classical_alg in variant['mix_with'] %}
     { {{ classical_alg['code_point'] }}, {{ variant['security'] }}, TLS1_3_VERSION, 0 }, 
         {%- endfor %}
+        {%- for classical_alg in variant['composite'] %}
+    { {{ classical_alg['code_point'] }}, {{ variant['security'] }}, TLS1_3_VERSION, 0 }, 
+        {%- endfor %}
     {%- endfor %}
 {%- endfor %}
 

--- a/oqs-template/oqsprov/oqsprov_capabilities.c/sigalg_names.fragment
+++ b/oqs-template/oqsprov/oqsprov_capabilities.c/sigalg_names.fragment
@@ -8,6 +8,10 @@
     {%- set cnt.val = cnt.val + 1 %}
     OQS_SIGALG_ENTRY({{ classical_alg['name'] }}_{{variant['name']}}, {{ classical_alg['name'] }}_{{variant['name']}}, {{ classical_alg['name'] }}_{{variant['name']}}, "{{ classical_alg['oid'] }}", {{ cnt.val }}),
         {%- endfor %}
+        {%- for classical_alg in variant['composite'] %}
+    {%- set cnt.val = cnt.val + 1 %}
+    OQS_SIGALG_ENTRY({{variant['name']}}_{{ classical_alg['name'] }}, {{variant['name']}}_{{ classical_alg['name'] }}, {{variant['name']}}_{{ classical_alg['name'] }}, "{{ classical_alg['oid'] }}", {{ cnt.val }}),
+        {%- endfor %}
 #endif
     {%- endfor %}
 {%- endfor %}

--- a/oqsprov/oqsprov_capabilities.c
+++ b/oqsprov/oqsprov_capabilities.c
@@ -270,19 +270,25 @@ static OQS_SIGALG_CONSTANTS oqs_sigalg_list[] = {
     {0xfea4, 192, TLS1_3_VERSION, 0}, {0xfea5, 256, TLS1_3_VERSION, 0},
     {0xfea6, 256, TLS1_3_VERSION, 0}, {0xfed0, 128, TLS1_3_VERSION, 0},
     {0xfed3, 128, TLS1_3_VERSION, 0}, {0xfed4, 128, TLS1_3_VERSION, 0},
-    {0xfed1, 192, TLS1_3_VERSION, 0}, {0xfed5, 192, TLS1_3_VERSION, 0},
+    {0xfee1, 128, TLS1_3_VERSION, 0}, {0xfee2, 128, TLS1_3_VERSION, 0},
+    {0xfee3, 128, TLS1_3_VERSION, 0}, {0xfee4, 128, TLS1_3_VERSION, 0},
+    {0xfee5, 128, TLS1_3_VERSION, 0}, {0xfed1, 192, TLS1_3_VERSION, 0},
+    {0xfed5, 192, TLS1_3_VERSION, 0}, {0xfee6, 192, TLS1_3_VERSION, 0},
+    {0xfee7, 192, TLS1_3_VERSION, 0}, {0xfee8, 192, TLS1_3_VERSION, 0},
+    {0xfee9, 192, TLS1_3_VERSION, 0}, {0xfeea, 192, TLS1_3_VERSION, 0},
     {0xfed2, 256, TLS1_3_VERSION, 0}, {0xfed6, 256, TLS1_3_VERSION, 0},
-    {0xfed7, 128, TLS1_3_VERSION, 0}, {0xfed8, 128, TLS1_3_VERSION, 0},
-    {0xfed9, 128, TLS1_3_VERSION, 0}, {0xfedc, 128, TLS1_3_VERSION, 0},
-    {0xfedd, 128, TLS1_3_VERSION, 0}, {0xfede, 128, TLS1_3_VERSION, 0},
-    {0xfeda, 256, TLS1_3_VERSION, 0}, {0xfedb, 256, TLS1_3_VERSION, 0},
-    {0xfedf, 256, TLS1_3_VERSION, 0}, {0xfee0, 256, TLS1_3_VERSION, 0},
-    {0xfeb3, 128, TLS1_3_VERSION, 0}, {0xfeb4, 128, TLS1_3_VERSION, 0},
-    {0xfeb5, 128, TLS1_3_VERSION, 0}, {0xfeb6, 128, TLS1_3_VERSION, 0},
-    {0xfeb7, 128, TLS1_3_VERSION, 0}, {0xfeb8, 128, TLS1_3_VERSION, 0},
-    {0xfeb9, 192, TLS1_3_VERSION, 0}, {0xfeba, 192, TLS1_3_VERSION, 0},
-    {0xfec2, 128, TLS1_3_VERSION, 0}, {0xfec3, 128, TLS1_3_VERSION, 0},
-    {0xfec4, 128, TLS1_3_VERSION, 0},
+    {0xfeeb, 256, TLS1_3_VERSION, 0}, {0xfeec, 256, TLS1_3_VERSION, 0},
+    {0xfeed, 256, TLS1_3_VERSION, 0}, {0xfed7, 128, TLS1_3_VERSION, 0},
+    {0xfed8, 128, TLS1_3_VERSION, 0}, {0xfed9, 128, TLS1_3_VERSION, 0},
+    {0xfedc, 128, TLS1_3_VERSION, 0}, {0xfedd, 128, TLS1_3_VERSION, 0},
+    {0xfede, 128, TLS1_3_VERSION, 0}, {0xfeda, 256, TLS1_3_VERSION, 0},
+    {0xfedb, 256, TLS1_3_VERSION, 0}, {0xfedf, 256, TLS1_3_VERSION, 0},
+    {0xfee0, 256, TLS1_3_VERSION, 0}, {0xfeb3, 128, TLS1_3_VERSION, 0},
+    {0xfeb4, 128, TLS1_3_VERSION, 0}, {0xfeb5, 128, TLS1_3_VERSION, 0},
+    {0xfeb6, 128, TLS1_3_VERSION, 0}, {0xfeb7, 128, TLS1_3_VERSION, 0},
+    {0xfeb8, 128, TLS1_3_VERSION, 0}, {0xfeb9, 192, TLS1_3_VERSION, 0},
+    {0xfeba, 192, TLS1_3_VERSION, 0}, {0xfec2, 128, TLS1_3_VERSION, 0},
+    {0xfec3, 128, TLS1_3_VERSION, 0}, {0xfec4, 128, TLS1_3_VERSION, 0},
     ///// OQS_TEMPLATE_FRAGMENT_SIGALG_ASSIGNMENTS_END
 };
 
@@ -457,78 +463,117 @@ int oqs_patch_codepoints()
     if (getenv("OQS_CODEPOINT_RSA3072_MLDSA44"))
         oqs_sigalg_list[9].code_point
             = atoi(getenv("OQS_CODEPOINT_RSA3072_MLDSA44"));
-    if (getenv("OQS_CODEPOINT_MLDSA65"))
-        oqs_sigalg_list[10].code_point = atoi(getenv("OQS_CODEPOINT_MLDSA65"));
-    if (getenv("OQS_CODEPOINT_P384_MLDSA65"))
+    if (getenv("OQS_CODEPOINT_MLDSA44_PSS2048"))
+        oqs_sigalg_list[10].code_point
+            = atoi(getenv("OQS_CODEPOINT_MLDSA44_PSS2048"));
+    if (getenv("OQS_CODEPOINT_MLDSA44_RSA2048"))
         oqs_sigalg_list[11].code_point
-            = atoi(getenv("OQS_CODEPOINT_P384_MLDSA65"));
-    if (getenv("OQS_CODEPOINT_MLDSA87"))
-        oqs_sigalg_list[12].code_point = atoi(getenv("OQS_CODEPOINT_MLDSA87"));
-    if (getenv("OQS_CODEPOINT_P521_MLDSA87"))
+            = atoi(getenv("OQS_CODEPOINT_MLDSA44_RSA2048"));
+    if (getenv("OQS_CODEPOINT_MLDSA44_ED25519"))
+        oqs_sigalg_list[12].code_point
+            = atoi(getenv("OQS_CODEPOINT_MLDSA44_ED25519"));
+    if (getenv("OQS_CODEPOINT_MLDSA44_P256"))
         oqs_sigalg_list[13].code_point
-            = atoi(getenv("OQS_CODEPOINT_P521_MLDSA87"));
-    if (getenv("OQS_CODEPOINT_FALCON512"))
+            = atoi(getenv("OQS_CODEPOINT_MLDSA44_P256"));
+    if (getenv("OQS_CODEPOINT_MLDSA44_BP256"))
         oqs_sigalg_list[14].code_point
+            = atoi(getenv("OQS_CODEPOINT_MLDSA44_BP256"));
+    if (getenv("OQS_CODEPOINT_MLDSA65"))
+        oqs_sigalg_list[15].code_point = atoi(getenv("OQS_CODEPOINT_MLDSA65"));
+    if (getenv("OQS_CODEPOINT_P384_MLDSA65"))
+        oqs_sigalg_list[16].code_point
+            = atoi(getenv("OQS_CODEPOINT_P384_MLDSA65"));
+    if (getenv("OQS_CODEPOINT_MLDSA65_PSS3072"))
+        oqs_sigalg_list[17].code_point
+            = atoi(getenv("OQS_CODEPOINT_MLDSA65_PSS3072"));
+    if (getenv("OQS_CODEPOINT_MLDSA65_RSA3072"))
+        oqs_sigalg_list[18].code_point
+            = atoi(getenv("OQS_CODEPOINT_MLDSA65_RSA3072"));
+    if (getenv("OQS_CODEPOINT_MLDSA65_P256"))
+        oqs_sigalg_list[19].code_point
+            = atoi(getenv("OQS_CODEPOINT_MLDSA65_P256"));
+    if (getenv("OQS_CODEPOINT_MLDSA65_BP256"))
+        oqs_sigalg_list[20].code_point
+            = atoi(getenv("OQS_CODEPOINT_MLDSA65_BP256"));
+    if (getenv("OQS_CODEPOINT_MLDSA65_ED25519"))
+        oqs_sigalg_list[21].code_point
+            = atoi(getenv("OQS_CODEPOINT_MLDSA65_ED25519"));
+    if (getenv("OQS_CODEPOINT_MLDSA87"))
+        oqs_sigalg_list[22].code_point = atoi(getenv("OQS_CODEPOINT_MLDSA87"));
+    if (getenv("OQS_CODEPOINT_P521_MLDSA87"))
+        oqs_sigalg_list[23].code_point
+            = atoi(getenv("OQS_CODEPOINT_P521_MLDSA87"));
+    if (getenv("OQS_CODEPOINT_MLDSA87_P384"))
+        oqs_sigalg_list[24].code_point
+            = atoi(getenv("OQS_CODEPOINT_MLDSA87_P384"));
+    if (getenv("OQS_CODEPOINT_MLDSA87_BP384"))
+        oqs_sigalg_list[25].code_point
+            = atoi(getenv("OQS_CODEPOINT_MLDSA87_BP384"));
+    if (getenv("OQS_CODEPOINT_MLDSA87_ED448"))
+        oqs_sigalg_list[26].code_point
+            = atoi(getenv("OQS_CODEPOINT_MLDSA87_ED448"));
+    if (getenv("OQS_CODEPOINT_FALCON512"))
+        oqs_sigalg_list[27].code_point
             = atoi(getenv("OQS_CODEPOINT_FALCON512"));
     if (getenv("OQS_CODEPOINT_P256_FALCON512"))
-        oqs_sigalg_list[15].code_point
+        oqs_sigalg_list[28].code_point
             = atoi(getenv("OQS_CODEPOINT_P256_FALCON512"));
     if (getenv("OQS_CODEPOINT_RSA3072_FALCON512"))
-        oqs_sigalg_list[16].code_point
+        oqs_sigalg_list[29].code_point
             = atoi(getenv("OQS_CODEPOINT_RSA3072_FALCON512"));
     if (getenv("OQS_CODEPOINT_FALCONPADDED512"))
-        oqs_sigalg_list[17].code_point
+        oqs_sigalg_list[30].code_point
             = atoi(getenv("OQS_CODEPOINT_FALCONPADDED512"));
     if (getenv("OQS_CODEPOINT_P256_FALCONPADDED512"))
-        oqs_sigalg_list[18].code_point
+        oqs_sigalg_list[31].code_point
             = atoi(getenv("OQS_CODEPOINT_P256_FALCONPADDED512"));
     if (getenv("OQS_CODEPOINT_RSA3072_FALCONPADDED512"))
-        oqs_sigalg_list[19].code_point
+        oqs_sigalg_list[32].code_point
             = atoi(getenv("OQS_CODEPOINT_RSA3072_FALCONPADDED512"));
     if (getenv("OQS_CODEPOINT_FALCON1024"))
-        oqs_sigalg_list[20].code_point
+        oqs_sigalg_list[33].code_point
             = atoi(getenv("OQS_CODEPOINT_FALCON1024"));
     if (getenv("OQS_CODEPOINT_P521_FALCON1024"))
-        oqs_sigalg_list[21].code_point
+        oqs_sigalg_list[34].code_point
             = atoi(getenv("OQS_CODEPOINT_P521_FALCON1024"));
     if (getenv("OQS_CODEPOINT_FALCONPADDED1024"))
-        oqs_sigalg_list[22].code_point
+        oqs_sigalg_list[35].code_point
             = atoi(getenv("OQS_CODEPOINT_FALCONPADDED1024"));
     if (getenv("OQS_CODEPOINT_P521_FALCONPADDED1024"))
-        oqs_sigalg_list[23].code_point
+        oqs_sigalg_list[36].code_point
             = atoi(getenv("OQS_CODEPOINT_P521_FALCONPADDED1024"));
     if (getenv("OQS_CODEPOINT_SPHINCSSHA2128FSIMPLE"))
-        oqs_sigalg_list[24].code_point
+        oqs_sigalg_list[37].code_point
             = atoi(getenv("OQS_CODEPOINT_SPHINCSSHA2128FSIMPLE"));
     if (getenv("OQS_CODEPOINT_P256_SPHINCSSHA2128FSIMPLE"))
-        oqs_sigalg_list[25].code_point
+        oqs_sigalg_list[38].code_point
             = atoi(getenv("OQS_CODEPOINT_P256_SPHINCSSHA2128FSIMPLE"));
     if (getenv("OQS_CODEPOINT_RSA3072_SPHINCSSHA2128FSIMPLE"))
-        oqs_sigalg_list[26].code_point
+        oqs_sigalg_list[39].code_point
             = atoi(getenv("OQS_CODEPOINT_RSA3072_SPHINCSSHA2128FSIMPLE"));
     if (getenv("OQS_CODEPOINT_SPHINCSSHA2128SSIMPLE"))
-        oqs_sigalg_list[27].code_point
+        oqs_sigalg_list[40].code_point
             = atoi(getenv("OQS_CODEPOINT_SPHINCSSHA2128SSIMPLE"));
     if (getenv("OQS_CODEPOINT_P256_SPHINCSSHA2128SSIMPLE"))
-        oqs_sigalg_list[28].code_point
+        oqs_sigalg_list[41].code_point
             = atoi(getenv("OQS_CODEPOINT_P256_SPHINCSSHA2128SSIMPLE"));
     if (getenv("OQS_CODEPOINT_RSA3072_SPHINCSSHA2128SSIMPLE"))
-        oqs_sigalg_list[29].code_point
+        oqs_sigalg_list[42].code_point
             = atoi(getenv("OQS_CODEPOINT_RSA3072_SPHINCSSHA2128SSIMPLE"));
     if (getenv("OQS_CODEPOINT_SPHINCSSHA2192FSIMPLE"))
-        oqs_sigalg_list[30].code_point
+        oqs_sigalg_list[43].code_point
             = atoi(getenv("OQS_CODEPOINT_SPHINCSSHA2192FSIMPLE"));
     if (getenv("OQS_CODEPOINT_P384_SPHINCSSHA2192FSIMPLE"))
-        oqs_sigalg_list[31].code_point
+        oqs_sigalg_list[44].code_point
             = atoi(getenv("OQS_CODEPOINT_P384_SPHINCSSHA2192FSIMPLE"));
     if (getenv("OQS_CODEPOINT_SPHINCSSHAKE128FSIMPLE"))
-        oqs_sigalg_list[32].code_point
+        oqs_sigalg_list[45].code_point
             = atoi(getenv("OQS_CODEPOINT_SPHINCSSHAKE128FSIMPLE"));
     if (getenv("OQS_CODEPOINT_P256_SPHINCSSHAKE128FSIMPLE"))
-        oqs_sigalg_list[33].code_point
+        oqs_sigalg_list[46].code_point
             = atoi(getenv("OQS_CODEPOINT_P256_SPHINCSSHAKE128FSIMPLE"));
     if (getenv("OQS_CODEPOINT_RSA3072_SPHINCSSHAKE128FSIMPLE"))
-        oqs_sigalg_list[34].code_point
+        oqs_sigalg_list[47].code_point
             = atoi(getenv("OQS_CODEPOINT_RSA3072_SPHINCSSHAKE128FSIMPLE"));
     ///// OQS_TEMPLATE_FRAGMENT_CODEPOINT_PATCHING_END
     return 1;
@@ -596,75 +641,101 @@ static const OSSL_PARAM oqs_param_sigalg_list[][12] = {
                      8),
     OQS_SIGALG_ENTRY(rsa3072_mldsa44, rsa3072_mldsa44, rsa3072_mldsa44,
                      "1.3.9999.7.2", 9),
+    OQS_SIGALG_ENTRY(mldsa44_pss2048, mldsa44_pss2048, mldsa44_pss2048,
+                     "2.16.840.1.114027.80.8.1.1", 10),
+    OQS_SIGALG_ENTRY(mldsa44_rsa2048, mldsa44_rsa2048, mldsa44_rsa2048,
+                     "2.16.840.1.114027.80.8.1.2", 11),
+    OQS_SIGALG_ENTRY(mldsa44_ed25519, mldsa44_ed25519, mldsa44_ed25519,
+                     "2.16.840.1.114027.80.8.1.3", 12),
+    OQS_SIGALG_ENTRY(mldsa44_p256, mldsa44_p256, mldsa44_p256,
+                     "2.16.840.1.114027.80.8.1.4", 13),
+    OQS_SIGALG_ENTRY(mldsa44_bp256, mldsa44_bp256, mldsa44_bp256,
+                     "2.16.840.1.114027.80.8.1.5", 14),
 #    endif
 #    ifdef OQS_ENABLE_SIG_ml_dsa_65
-    OQS_SIGALG_ENTRY(mldsa65, mldsa65, mldsa65, "1.3.6.1.4.1.2.267.12.6.5", 10),
+    OQS_SIGALG_ENTRY(mldsa65, mldsa65, mldsa65, "1.3.6.1.4.1.2.267.12.6.5", 15),
     OQS_SIGALG_ENTRY(p384_mldsa65, p384_mldsa65, p384_mldsa65, "1.3.9999.7.3",
-                     11),
+                     16),
+    OQS_SIGALG_ENTRY(mldsa65_pss3072, mldsa65_pss3072, mldsa65_pss3072,
+                     "2.16.840.1.114027.80.8.1.6", 17),
+    OQS_SIGALG_ENTRY(mldsa65_rsa3072, mldsa65_rsa3072, mldsa65_rsa3072,
+                     "2.16.840.1.114027.80.8.1.7", 18),
+    OQS_SIGALG_ENTRY(mldsa65_p256, mldsa65_p256, mldsa65_p256,
+                     "2.16.840.1.114027.80.8.1.8", 19),
+    OQS_SIGALG_ENTRY(mldsa65_bp256, mldsa65_bp256, mldsa65_bp256,
+                     "2.16.840.1.114027.80.8.1.9", 20),
+    OQS_SIGALG_ENTRY(mldsa65_ed25519, mldsa65_ed25519, mldsa65_ed25519,
+                     "2.16.840.1.114027.80.8.1.10", 21),
 #    endif
 #    ifdef OQS_ENABLE_SIG_ml_dsa_87
-    OQS_SIGALG_ENTRY(mldsa87, mldsa87, mldsa87, "1.3.6.1.4.1.2.267.12.8.7", 12),
+    OQS_SIGALG_ENTRY(mldsa87, mldsa87, mldsa87, "1.3.6.1.4.1.2.267.12.8.7", 22),
     OQS_SIGALG_ENTRY(p521_mldsa87, p521_mldsa87, p521_mldsa87, "1.3.9999.7.4",
-                     13),
+                     23),
+    OQS_SIGALG_ENTRY(mldsa87_p384, mldsa87_p384, mldsa87_p384,
+                     "2.16.840.1.114027.80.8.1.11", 24),
+    OQS_SIGALG_ENTRY(mldsa87_bp384, mldsa87_bp384, mldsa87_bp384,
+                     "2.16.840.1.114027.80.8.1.12", 25),
+    OQS_SIGALG_ENTRY(mldsa87_ed448, mldsa87_ed448, mldsa87_ed448,
+                     "2.16.840.1.114027.80.8.1.13", 26),
 #    endif
 #    ifdef OQS_ENABLE_SIG_falcon_512
-    OQS_SIGALG_ENTRY(falcon512, falcon512, falcon512, "1.3.9999.3.11", 14),
+    OQS_SIGALG_ENTRY(falcon512, falcon512, falcon512, "1.3.9999.3.11", 27),
     OQS_SIGALG_ENTRY(p256_falcon512, p256_falcon512, p256_falcon512,
-                     "1.3.9999.3.12", 15),
+                     "1.3.9999.3.12", 28),
     OQS_SIGALG_ENTRY(rsa3072_falcon512, rsa3072_falcon512, rsa3072_falcon512,
-                     "1.3.9999.3.13", 16),
+                     "1.3.9999.3.13", 29),
 #    endif
 #    ifdef OQS_ENABLE_SIG_falcon_padded_512
     OQS_SIGALG_ENTRY(falconpadded512, falconpadded512, falconpadded512,
-                     "1.3.9999.3.16", 17),
+                     "1.3.9999.3.16", 30),
     OQS_SIGALG_ENTRY(p256_falconpadded512, p256_falconpadded512,
-                     p256_falconpadded512, "1.3.9999.3.17", 18),
+                     p256_falconpadded512, "1.3.9999.3.17", 31),
     OQS_SIGALG_ENTRY(rsa3072_falconpadded512, rsa3072_falconpadded512,
-                     rsa3072_falconpadded512, "1.3.9999.3.18", 19),
+                     rsa3072_falconpadded512, "1.3.9999.3.18", 32),
 #    endif
 #    ifdef OQS_ENABLE_SIG_falcon_1024
-    OQS_SIGALG_ENTRY(falcon1024, falcon1024, falcon1024, "1.3.9999.3.14", 20),
+    OQS_SIGALG_ENTRY(falcon1024, falcon1024, falcon1024, "1.3.9999.3.14", 33),
     OQS_SIGALG_ENTRY(p521_falcon1024, p521_falcon1024, p521_falcon1024,
-                     "1.3.9999.3.15", 21),
+                     "1.3.9999.3.15", 34),
 #    endif
 #    ifdef OQS_ENABLE_SIG_falcon_padded_1024
     OQS_SIGALG_ENTRY(falconpadded1024, falconpadded1024, falconpadded1024,
-                     "1.3.9999.3.19", 22),
+                     "1.3.9999.3.19", 35),
     OQS_SIGALG_ENTRY(p521_falconpadded1024, p521_falconpadded1024,
-                     p521_falconpadded1024, "1.3.9999.3.20", 23),
+                     p521_falconpadded1024, "1.3.9999.3.20", 36),
 #    endif
 #    ifdef OQS_ENABLE_SIG_sphincs_sha2_128f_simple
     OQS_SIGALG_ENTRY(sphincssha2128fsimple, sphincssha2128fsimple,
-                     sphincssha2128fsimple, "1.3.9999.6.4.13", 24),
+                     sphincssha2128fsimple, "1.3.9999.6.4.13", 37),
     OQS_SIGALG_ENTRY(p256_sphincssha2128fsimple, p256_sphincssha2128fsimple,
-                     p256_sphincssha2128fsimple, "1.3.9999.6.4.14", 25),
+                     p256_sphincssha2128fsimple, "1.3.9999.6.4.14", 38),
     OQS_SIGALG_ENTRY(rsa3072_sphincssha2128fsimple,
                      rsa3072_sphincssha2128fsimple,
-                     rsa3072_sphincssha2128fsimple, "1.3.9999.6.4.15", 26),
+                     rsa3072_sphincssha2128fsimple, "1.3.9999.6.4.15", 39),
 #    endif
 #    ifdef OQS_ENABLE_SIG_sphincs_sha2_128s_simple
     OQS_SIGALG_ENTRY(sphincssha2128ssimple, sphincssha2128ssimple,
-                     sphincssha2128ssimple, "1.3.9999.6.4.16", 27),
+                     sphincssha2128ssimple, "1.3.9999.6.4.16", 40),
     OQS_SIGALG_ENTRY(p256_sphincssha2128ssimple, p256_sphincssha2128ssimple,
-                     p256_sphincssha2128ssimple, "1.3.9999.6.4.17", 28),
+                     p256_sphincssha2128ssimple, "1.3.9999.6.4.17", 41),
     OQS_SIGALG_ENTRY(rsa3072_sphincssha2128ssimple,
                      rsa3072_sphincssha2128ssimple,
-                     rsa3072_sphincssha2128ssimple, "1.3.9999.6.4.18", 29),
+                     rsa3072_sphincssha2128ssimple, "1.3.9999.6.4.18", 42),
 #    endif
 #    ifdef OQS_ENABLE_SIG_sphincs_sha2_192f_simple
     OQS_SIGALG_ENTRY(sphincssha2192fsimple, sphincssha2192fsimple,
-                     sphincssha2192fsimple, "1.3.9999.6.5.10", 30),
+                     sphincssha2192fsimple, "1.3.9999.6.5.10", 43),
     OQS_SIGALG_ENTRY(p384_sphincssha2192fsimple, p384_sphincssha2192fsimple,
-                     p384_sphincssha2192fsimple, "1.3.9999.6.5.11", 31),
+                     p384_sphincssha2192fsimple, "1.3.9999.6.5.11", 44),
 #    endif
 #    ifdef OQS_ENABLE_SIG_sphincs_shake_128f_simple
     OQS_SIGALG_ENTRY(sphincsshake128fsimple, sphincsshake128fsimple,
-                     sphincsshake128fsimple, "1.3.9999.6.7.13", 32),
+                     sphincsshake128fsimple, "1.3.9999.6.7.13", 45),
     OQS_SIGALG_ENTRY(p256_sphincsshake128fsimple, p256_sphincsshake128fsimple,
-                     p256_sphincsshake128fsimple, "1.3.9999.6.7.14", 33),
+                     p256_sphincsshake128fsimple, "1.3.9999.6.7.14", 46),
     OQS_SIGALG_ENTRY(rsa3072_sphincsshake128fsimple,
                      rsa3072_sphincsshake128fsimple,
-                     rsa3072_sphincsshake128fsimple, "1.3.9999.6.7.15", 34),
+                     rsa3072_sphincsshake128fsimple, "1.3.9999.6.7.15", 47),
 #    endif
     ///// OQS_TEMPLATE_FRAGMENT_SIGALG_NAMES_END
 };


### PR DESCRIPTION
Adds templates to generate oqs_sigalg_list entries and code points for composite signatures.

The failed TLS tests with composite signatures reported in #381 pass after this fix.

Fixes #381.