### PR TITLE
Fix CI (Add Ubuntu 24 support)

### DIFF
--- a/.github/workflows/standalone.yml
+++ b/.github/workflows/standalone.yml
@@ -36,7 +36,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: jammy
+          - name: ubuntu-latest
             container: ubuntu:latest
     container:
       image: ${{ matrix.container }}

--- a/USAGE.md
+++ b/USAGE.md
@@ -17,6 +17,18 @@ this, e.g., as follows:
 OpenSSL 3.2.0-dev  (Library: OpenSSL 3.2.0-dev )
 ```
 
+### Note on OpenSSL installation
+
+If one does not have an OpenSSL version installed in a suitable version, care
+is advised installing such version such as not to damage a pre-installed/system-wide
+`openssl` installation.
+
+In order to experiment with a local `openssl` version, we have made available
+[a shell script](scripts/fullbuild.sh) creating a local, non-system wide installed
+`openssl` binary. By default, the current "master" branch is built by this script
+but it can be configured to build any release/tag by setting the [OPENSSL_BRANCH](CONFIGURE.md#openssl_branch)
+environment variable.
+
 ## Activation
 
 Every OpenSSL provider needs to be activated for use. There are three main ways

--- a/scripts/fullbuild.sh
+++ b/scripts/fullbuild.sh
@@ -100,7 +100,8 @@ if [ -z $liboqs_DIR ]; then
   if [ ! -z $OPENSSL_INSTALL ]; then
     export CMAKE_OPENSSL_LOCATION="-DOPENSSL_ROOT_DIR=$OPENSSL_INSTALL"
   else
-    export CMAKE_OPENSSL_LOCATION=""
+    # work around for cmake 3.23.3 regression not finding OpenSSL:
+    export CMAKE_OPENSSL_LOCATION="-DOPENSSL_ROOT_DIR="
   fi
   # for full debug build add: -DCMAKE_BUILD_TYPE=Debug
   # to optimize for size add -DOQS_ALGS_ENABLED= suitably to one of these values:
@@ -124,7 +125,7 @@ if [ ! -f "_build/lib/oqsprovider.$SHLIBEXT" ]; then
    BUILD_TYPE=""
    # for omitting public key in private keys add -DNOPUBKEY_IN_PRIVKEY=ON
    if [ -z "$OPENSSL_INSTALL" ]; then
-       cmake -DOPENSSL_ROOT_DIR=$(pwd)/.local $BUILD_TYPE $OQSPROV_CMAKE_PARAMS -S . -B _build && cmake --build _build
+       cmake $CMAKE_OPENSSL_LOCATION $BUILD_TYPE $OQSPROV_CMAKE_PARAMS -S . -B _build && cmake --build _build
    else
        cmake -DOPENSSL_ROOT_DIR=$OPENSSL_INSTALL $BUILD_TYPE $OQSPROV_CMAKE_PARAMS -S . -B _build && cmake --build _build
    fi


### PR DESCRIPTION
- Provides fix for [Ubuntu 24 LTS CI cmake regression](https://github.com/open-quantum-safe/oqs-provider/actions/runs/8858042266/job/24326224274) (see also https://github.com/open-quantum-safe/liboqs/issues/1748)
- Corrects consequent logic build script flaw for case where OpenSSL has not been locally built
