### PR TITLE
Fix #439: install the static library under `$PREFIX/lib`.

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -80,6 +80,12 @@ jobs:
         with:
           name: oqsprovider-x64
           path: _build/*.deb
+      - name: Verify that the static library is copied to the install directory.
+        run: |
+          OPENSSL_BRANCH=${{ matrix.ossl-branch }} OQSPROV_CMAKE_PARAMS="-DOQS_PROVIDER_BUILD_STATIC=ON" ./scripts/fullbuild.sh -f && \
+          mkdir -p _sysroot/ && \
+          cmake --install _build --prefix _sysroot/ && \
+          stat _sysroot/lib/liboqsprovider.a
 
   asan_linux_intel:
     name: "Security checks"

--- a/oqsprov/CMakeLists.txt
+++ b/oqsprov/CMakeLists.txt
@@ -79,6 +79,11 @@ if (NOT OQS_PROVIDER_BUILD_STATIC)
       SUFFIX ".dll"
     )
   endif()
+else()
+  set_target_properties(oqsprovider
+      PROPERTIES
+      PREFIX "lib"
+  )
 endif()
 
 target_link_libraries(oqsprovider PUBLIC OQS::oqs ${OPENSSL_CRYPTO_LIBRARY} ${OQS_ADDL_SOCKET_LIBS})
@@ -86,9 +91,11 @@ if (USE_ENCODING_LIB)
   target_link_libraries(oqsprovider PUBLIC qsc_key_encoder)
   target_include_directories(oqsprovider PRIVATE ${encoder_LIBRARY_INCLUDE})
 endif()
+
 install(TARGETS oqsprovider
-        CONFIGURATIONS Debug Release
         LIBRARY DESTINATION "${OPENSSL_MODULES_PATH}"
+        ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+        PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/oqs-provider/"
         RUNTIME DESTINATION "${OPENSSL_MODULES_PATH}")
 
 if ("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "aarch64")
@@ -104,6 +111,7 @@ install(TARGETS oqsprovider
         ARCHIVE DESTINATION lib/
         PUBLIC_HEADER DESTINATION include/oqs-provider/
         )
+
 set(CPACK_GENERATOR "DEB")
 set(CPACK_PACKAGE_VENDOR "www.openquantumsafe.org")
 set(CPACK_PACKAGE_VERSION ${OQSPROVIDER_VERSION_TEXT})


### PR DESCRIPTION
Fix #439: install the static library under `$PREFIX/lib`.

This commit fixes issue #439 by copying `oqsprovider.a` to the appropriate
`lib` directory (usually `${CMAKE_INSTALL_PREFIX}/lib`).


Signed-off-by: thb-sb <thomas.bailleux@sandboxquantum.com>
