### PR TITLE
Fix #440: disable tests and examples using `BUILD_TESTING`.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,6 +87,7 @@ endfunction()
 add_subdirectory(oqsprov)
 
 # Testing
+include(CTest)
 enable_testing()
 add_subdirectory(test)
 

--- a/CONFIGURE.md
+++ b/CONFIGURE.md
@@ -97,6 +97,10 @@ void load_oqs_provider(OSSL_LIB_CTX *libctx) {
 See [`examples/static_oqsprovider.c`](examples/static_oqsprovider.c) for a complete
 example of how to load oqsprovider using `OSSL_PROVIDER_add_builtin`.
 
+### BUILD_TESTING
+
+By setting this to "OFF", no tests or examples will be compiled.
+
 ## Convenience build script options
 
 For anyone interested in building the complete software stack

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,3 +1,7 @@
+if(NOT BUILD_TESTING)
+  return()
+endif()
+
 if (OQS_PROVIDER_BUILD_STATIC)
   add_executable(example_static_oqsprovider static_oqsprovider.c)
   target_link_libraries(example_static_oqsprovider PRIVATE ${OPENSSL_CRYPTO_LIBRARY} oqsprovider)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,3 +1,7 @@
+if(NOT BUILD_TESTING)
+  return()
+endif()
+
 include(GNUInstallDirs)
 if (CMAKE_GENERATOR MATCHES "Visual Studio")
 set(OQS_PROV_BINARY_DIR ${CMAKE_BINARY_DIR}/lib/${CMAKE_BUILD_TYPE})


### PR DESCRIPTION
Fix #440: disable tests and examples using `BUILD_TESTING`.

By providing cmake with `BUILD_TESTING=OFF`, no test or example will be built.

`BUILD_TESTING` is `ON` by default, since we are using [`enable_testing`] along with `CTest`.


[`enable_testing`]: https://cmake.org/cmake/help/latest/command/enable_testing.html


Signed-off-by: thb-sb <thomas.bailleux@sandboxquantum.com>
