### PR TITLE
Force liboqs as a debian package dependency requirement only if it is not a static linked library.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,7 +63,8 @@ endif()
 # Add required include for liboqs
 find_package(liboqs REQUIRED)
 get_target_property(LIBOQS_INCLUDE_DIR OQS::oqs INTERFACE_INCLUDE_DIRECTORIES)
-message(STATUS "liboqs found: Include dir at ${LIBOQS_INCLUDE_DIR}")
+get_target_property(LIBOQS_LIBRARY_TYPE OQS::oqs TYPE)
+message(STATUS "liboqs found: Include dir at ${LIBOQS_INCLUDE_DIR} (${LIBOQS_LIBRARY_TYPE})")
 include_directories(${LIBOQS_INCLUDE_DIR})
 
 # Hints the compiler on the fact that the provider is being compiled into a static library.

--- a/oqsprov/CMakeLists.txt
+++ b/oqsprov/CMakeLists.txt
@@ -94,7 +94,11 @@ install(TARGETS oqsprovider
 set(CPACK_GENERATOR "DEB")
 set(CPACK_PACKAGE_VENDOR "www.openquantumsafe.org")
 set(CPACK_PACKAGE_VERSION ${OQSPROVIDER_VERSION_TEXT})
-set(CPACK_DEBIAN_PACKAGE_DEPENDS "libc6, openssl (>= 3.0.0), liboqs (>= 0.8.0)")
+set(CPACK_DEBIAN_PACKAGE_DEPENDS "libc6, openssl (>= 3.0.0)")
+if (NOT "${LIBOQS_LIBRARY_TYPE}" STREQUAL "STATIC_LIBRARY")
+  message("Adding liboqs as dynamic dependency for the debian package")
+  string(APPEND CPACK_DEBIAN_PACKAGE_DEPENDS ", liboqs (>= 0.8.0)")
+endif ()
 set(CPACK_DEBIAN_PACKAGE_MAINTAINER "www.openquantumsafe.org")
 include(CPack)
 


### PR DESCRIPTION
Fixes #491 