### PR TITLE
add support for the CMAKE_PARAMS environment variable

### DIFF
--- a/CONFIGURE.md
+++ b/CONFIGURE.md
@@ -30,14 +30,14 @@ activate further warning messages. In particular, when "Debug" has been set, dis
 [debugging capabilities](https://github.com/open-quantum-safe/oqs-provider/wiki/Debugging)
 are activated and additional setup warnings are output.
 
-### CMAKE_FLAGS
+### CMAKE_PARAMS
 
 This environment variable lets you specify additional flags to pass to `cmake` explicitly when using the `fullbuild.sh` script.
 
 For example, in order to point `cmake` to a specific library, you might run:
 
 ```
-$ env CMAKE_FLAGS="-DOPENSSL_CRYPTO_LIBRARY=/opt/lib64/libcrypto.so" bash scripts/fullbuild.sh
+$ env CMAKE_PARAMS="-DOPENSSL_CRYPTO_LIBRARY=/opt/lib64/libcrypto.so" bash scripts/fullbuild.sh
 ```
 
 ### liboqs_DIR

--- a/CONFIGURE.md
+++ b/CONFIGURE.md
@@ -30,6 +30,16 @@ activate further warning messages. In particular, when "Debug" has been set, dis
 [debugging capabilities](https://github.com/open-quantum-safe/oqs-provider/wiki/Debugging)
 are activated and additional setup warnings are output.
 
+### CMAKE_FLAGS
+
+This environment variable lets you specify additional flags to pass to `cmake` explicitly when using the `fullbuild.sh` script.
+
+For example, in order to point `cmake` to a specific library, you might run:
+
+```
+$ env CMAKE_FLAGS="-DOPENSSL_CRYPTO_LIBRARY=/opt/lib64/libcrypto.so" bash scripts/fullbuild.sh
+```
+
 ### liboqs_DIR
 
 This environment variable must be set to the location of the `liboqs` installation to be

--- a/scripts/fullbuild.sh
+++ b/scripts/fullbuild.sh
@@ -3,6 +3,7 @@
 # The following variables influence the operation of this build script:
 # Argument -f: Soft clean, ensuring re-build of oqs-provider binary
 # Argument -F: Hard clean, ensuring checkout and build of all dependencies
+# EnvVar CMAKE_FLAGS: passed to cmake
 # EnvVar MAKE_PARAMS: passed to invocations of make; sample value: "-j"
 # EnvVar OQSPROV_CMAKE_PARAMS: passed to invocations of oqsprovider cmake
 # EnvVar LIBOQS_BRANCH: Defines branch/release of liboqs; default value "main"
@@ -108,7 +109,7 @@ if [ -z $liboqs_DIR ]; then
   #    STD: only include NIST standardized algorithms
   #    NIST_R4: only include algorithms in round 4 of the NIST competition
   #    All: include all algorithms supported by liboqs (default)
-  cd liboqs && cmake -GNinja $DOQS_ALGS_ENABLED $CMAKE_OPENSSL_LOCATION -DCMAKE_INSTALL_PREFIX=$(pwd)/../.local -S . -B _build && cd _build && ninja && ninja install && cd ../..
+  cd liboqs && cmake -GNinja $CMAKE_FLAGS $DOQS_ALGS_ENABLED $CMAKE_OPENSSL_LOCATION -DCMAKE_INSTALL_PREFIX=$(pwd)/../.local -S . -B _build && cd _build && ninja && ninja install && cd ../..
   if [ $? -ne 0 ]; then
       echo "liboqs build failed. Exiting."
       exit -1
@@ -125,9 +126,9 @@ if [ ! -f "_build/lib/oqsprovider.$SHLIBEXT" ]; then
    BUILD_TYPE=""
    # for omitting public key in private keys add -DNOPUBKEY_IN_PRIVKEY=ON
    if [ -z "$OPENSSL_INSTALL" ]; then
-       cmake $CMAKE_OPENSSL_LOCATION $BUILD_TYPE $OQSPROV_CMAKE_PARAMS -S . -B _build && cmake --build _build
+       cmake $CMAKE_FLAGS $CMAKE_OPENSSL_LOCATION $BUILD_TYPE $OQSPROV_CMAKE_PARAMS -S . -B _build && cmake --build _build
    else
-       cmake -DOPENSSL_ROOT_DIR=$OPENSSL_INSTALL $BUILD_TYPE $OQSPROV_CMAKE_PARAMS -S . -B _build && cmake --build _build
+       cmake $CMAKE_FLAGS -DOPENSSL_ROOT_DIR=$OPENSSL_INSTALL $BUILD_TYPE $OQSPROV_CMAKE_PARAMS -S . -B _build && cmake --build _build
    fi
    if [ $? -ne 0 ]; then
      echo "provider build failed. Exiting."

--- a/scripts/fullbuild.sh
+++ b/scripts/fullbuild.sh
@@ -3,7 +3,7 @@
 # The following variables influence the operation of this build script:
 # Argument -f: Soft clean, ensuring re-build of oqs-provider binary
 # Argument -F: Hard clean, ensuring checkout and build of all dependencies
-# EnvVar CMAKE_FLAGS: passed to cmake
+# EnvVar CMAKE_PARAMS: passed to cmake
 # EnvVar MAKE_PARAMS: passed to invocations of make; sample value: "-j"
 # EnvVar OQSPROV_CMAKE_PARAMS: passed to invocations of oqsprovider cmake
 # EnvVar LIBOQS_BRANCH: Defines branch/release of liboqs; default value "main"
@@ -109,7 +109,7 @@ if [ -z $liboqs_DIR ]; then
   #    STD: only include NIST standardized algorithms
   #    NIST_R4: only include algorithms in round 4 of the NIST competition
   #    All: include all algorithms supported by liboqs (default)
-  cd liboqs && cmake -GNinja $CMAKE_FLAGS $DOQS_ALGS_ENABLED $CMAKE_OPENSSL_LOCATION -DCMAKE_INSTALL_PREFIX=$(pwd)/../.local -S . -B _build && cd _build && ninja && ninja install && cd ../..
+  cd liboqs && cmake -GNinja $CMAKE_PARAMS $DOQS_ALGS_ENABLED $CMAKE_OPENSSL_LOCATION -DCMAKE_INSTALL_PREFIX=$(pwd)/../.local -S . -B _build && cd _build && ninja && ninja install && cd ../..
   if [ $? -ne 0 ]; then
       echo "liboqs build failed. Exiting."
       exit -1
@@ -126,9 +126,9 @@ if [ ! -f "_build/lib/oqsprovider.$SHLIBEXT" ]; then
    BUILD_TYPE=""
    # for omitting public key in private keys add -DNOPUBKEY_IN_PRIVKEY=ON
    if [ -z "$OPENSSL_INSTALL" ]; then
-       cmake $CMAKE_FLAGS $CMAKE_OPENSSL_LOCATION $BUILD_TYPE $OQSPROV_CMAKE_PARAMS -S . -B _build && cmake --build _build
+       cmake $CMAKE_PARAMS $CMAKE_OPENSSL_LOCATION $BUILD_TYPE $OQSPROV_CMAKE_PARAMS -S . -B _build && cmake --build _build
    else
-       cmake $CMAKE_FLAGS -DOPENSSL_ROOT_DIR=$OPENSSL_INSTALL $BUILD_TYPE $OQSPROV_CMAKE_PARAMS -S . -B _build && cmake --build _build
+       cmake $CMAKE_PARAMS -DOPENSSL_ROOT_DIR=$OPENSSL_INSTALL $BUILD_TYPE $OQSPROV_CMAKE_PARAMS -S . -B _build && cmake --build _build
    fi
    if [ $? -ne 0 ]; then
      echo "provider build failed. Exiting."


### PR DESCRIPTION
I was unable to convince `fullbuild.sh` to use the right OpenSSL library from `/opt/lib64` by setting `OPENSSL_ROOT_DIR=/opt` nor by setting `OPENSSL_INSTALL=/opt` or other variations I tried.  It seemed I needed to invoke `cmake` with `-DOPENSSL_CRYPTO_LIBRARY="/opt/lib64/libcrypto.so"`, but there was no obvious way to get this flag passed into the script.

Adding a generic `CMAKE_FLAGS` environment variable allows me to pass this flag and would allow others to set additional flags they might need, and falls in line with common Unix practice of supporting e.g., `CFLAGS`, `LDFLAGS` etc.

Perhaps this is useful to somebody else.