### PR TITLE
add explicit usage warning [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,4 +268,8 @@ contributions to achieve this state.
 is completely dependent on the following package and accordingly
 cannot recommend any use beyond experimentation purposes:
 
+WE DO NOT CURRENTLY RECOMMEND RELYING ON THIS SOFTWARE IN A PRODUCTION ENVIRONMENT OR TO PROTECT ANY SENSITIVE DATA. This software is meant to help with research and prototyping. While we make a best-effort approach to avoid security bugs, this library has not received the level of auditing and analysis that would be necessary to rely on it for high security use.
+
+Further details and background available at:
+
 [liboqs disclaimer](https://github.com/open-quantum-safe/liboqs#limitations-and-security)

--- a/README.md
+++ b/README.md
@@ -249,6 +249,23 @@ THIS SOFTWARE IS PROVIDED WITH NO WARRANTIES, EXPRESS OR IMPLIED, AND
 ALL IMPLIED WARRANTIES ARE DISCLAIMED, INCLUDING ANY WARRANTY OF
 MERCHANTABILITY AND WARRANTY OF FITNESS FOR A PARTICULAR PURPOSE.
 
+## Standards compliance
+
+This project follows the [NIST PQC standardization process](https://csrc.nist.gov/projects/post-quantum-cryptography)
+and aims to support experimentation with the various PQC algorithms
+under evaluation and in different stages of standardization by NIST.
+`oqsprovider` at this time cannot claim or prove adherence to any
+standards documents published. For more details, review the file
+[STANDARDS.md](STANDARDS.md) carefully. Most notably, hybrid and
+composite implementations exclusively implemented in `oqsprovider`
+are at a pre-standard/draft stage only. Over time the project aims
+to provide standards compliance and solicits input by way of
+contributions to achieve this state.
+
 ## Component disclaimer
+
+`oqsprovider` for the implementation of all pure PQC functionality
+is completely dependent on the following package and accordingly
+cannot recommend any use beyond experimentation purposes:
 
 [liboqs disclaimer](https://github.com/open-quantum-safe/liboqs#limitations-and-security)

--- a/scripts/oqsprovider-externalinterop.sh
+++ b/scripts/oqsprovider-externalinterop.sh
@@ -28,6 +28,11 @@ fi
 
 # Ascertain algorithms are available:
 
+# skipping these tests for now as per https://mailarchive.ietf.org/arch/msg/tls/hli5ogDbUudAA4tZXskVbOqeor4
+# TBD replace with suitable ML-KEM hybrid tests as and when available XXX 
+
+exit 0
+
 echo " Cloudflare:"
 
 if ! ($OPENSSL_APP list -kem-algorithms | grep x25519_kyber768); then


### PR DESCRIPTION
The NIST standardization process seems to be moving faster than this project can follow. At the same time, more and more security concerns and actual bugs become visible that need resolution, e.g., #514, #483.

This PR therefore adds explicit language warning users of the current state of affairs, particularly in light of the upcoming [release cycle](https://github.com/open-quantum-safe/liboqs/milestone/25) it seems prudent to add language that winds up in the (to-be-)release(d) README.
