### PR TITLE
Actionlint workflow checking

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,6 +5,6 @@
 /oqs-template/generate.yml @baentsch @bhess @feventura
 /CMakeLists.txt @baentsch @thb-sb
 /.circleci/config.yml @baentsch @thb-sb
-/.github/workflows @baentsch @thb-sb
+/.github/workflows @baentsch @thb-sb @jplomas
 /oqsprov/oqs_sig.c @baentsch @feventura
 /scripts/oqsprovider-pkcs12gen.sh @iyanmv

--- a/.github/workflows/check_workflows.yml
+++ b/.github/workflows/check_workflows.yml
@@ -1,0 +1,14 @@
+name: Check GitHub workflows
+
+on: [pull_request, push, workflow_call]
+
+jobs:
+  workflowcheck:
+    name: Check validity of GitHub workflows
+    runs-on: ubuntu-latest
+    container: openquantumsafe/ci-ubuntu-latest:latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # pin@v4
+      - name: Ensure GitHub actions are valid
+        run: actionlint -shellcheck "" # run *without* shellcheck

--- a/.github/workflows/coding_style.yml
+++ b/.github/workflows/coding_style.yml
@@ -14,7 +14,7 @@ jobs:
         run: apt-get update && apt-get install -y clang-format
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # pin@v4
 
       - name: Check coding style using clang-format
         run: ./scripts/do_code_format.sh

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -23,7 +23,7 @@ jobs:
       LIBOQS_BRANCH: "main"
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # pin@v4
       - name: Full build
         run: OQSPROV_CMAKE_PARAMS=${{ matrix.cmake-params}} ./scripts/fullbuild.sh
       - name: Enable sibling oqsprovider for testing
@@ -53,7 +53,7 @@ jobs:
       LIBOQS_BRANCH: "main"
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # pin@v4
       - name: Full build
         run: OPENSSL_BRANCH=${{ matrix.ossl-branch }} ./scripts/fullbuild.sh
       - name: Enable sibling oqsprovider for testing
@@ -103,7 +103,7 @@ jobs:
       OPENSSL_BRANCH: "openssl-3.1"
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # pin@v4
 
       - name: Install dependencies
         run: apt-get update && apt-get install -y clang llvm ninja-build git cmake libclang-14-dev libclang-common-14-dev
@@ -177,7 +177,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # pin@v4
 
       - name: Install dependencies
         run: apt-get update && apt-get install -y ninja-build git cmake nodejs gcc-aarch64-linux-gnu libc6-dev-arm64-cross qemu-user

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -25,15 +25,15 @@ jobs:
       MAKE_PARAMS: -j 4
     steps:
       - name: Checkout provider
-        uses: actions/checkout@v3
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # pin@v4
       - name: Checkout openssl
-        uses: actions/checkout@v3
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # pin@v4
         with:
           set-safe-directory: true
           repository: openssl/openssl
           path: openssl
       - name: checkout liboqs
-        uses: actions/checkout@v3
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # pin@v4
         with:
           set-safe-directory: true
           repository: open-quantum-safe/liboqs

--- a/.github/workflows/standalone.yml
+++ b/.github/workflows/standalone.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install prerequisites
         run: brew install liboqs
       - name: Checkout oqsprovider code
-        uses: actions/checkout@v2
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # pin@v4
       - name: Build and test oqsprovider
         # try this only if brew'd liboqs knows about ML-KEM:
         run: |
@@ -46,7 +46,7 @@ jobs:
       - name: Update container
         run: apt update && apt install -y cmake ninja-build gcc libssl-dev git
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # pin@v4
       - name: Full build
         run: LIBOQS_BRANCH=main ./scripts/fullbuild.sh
       - name: Test

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -18,6 +18,8 @@ jobs:
         platform:
           - arch: win64
             oqsconfig: -DOQS_ALGS_ENABLED=STD
+            # empty `config` property here to prevent actionlint error (property "config" is not defined in object type) on line 62 below
+            config:
 #          - arch: win32
 #            config: --strict-warnings no-fips enable-quic
     runs-on: ${{matrix.os}}
@@ -29,9 +31,9 @@ jobs:
       MAKE_PARAMS: -j 4
     steps:
       - name: Checkout provider
-        uses: actions/checkout@v3
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # pin@v4
       - name: Checkout openssl
-        uses: actions/checkout@v3
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # pin@v4
         with:
           set-safe-directory: true
           repository: openssl/openssl
@@ -39,7 +41,7 @@ jobs:
           # TODO: Revert ref tag once openssl master doesn't crash any more
           ref: openssl-3.3.0
       - name: checkout liboqs
-        uses: actions/checkout@v3
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # pin@v4
         with:
           set-safe-directory: true
           repository: open-quantum-safe/liboqs
@@ -126,15 +128,15 @@ jobs:
         with:
           path: c:\openssl32
           key: ${{ runner.os }}-msvcopenssl32
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # pin@v4
       - name: Checkout OpenSSL master
         if: steps.cache-openssl32.outputs.cache-hit != 'true'
-        uses: actions/checkout@v3
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # pin@v4
         with:
           set-safe-directory: true
           repository: openssl/openssl
           path: openssl
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # pin@v4
         with:
           set-safe-directory: true
           repository: open-quantum-safe/liboqs
@@ -240,15 +242,15 @@ jobs:
           with:
             path: c:\openssl32n
             key: ${{ runner.os }}-msvcopenssl32n
-        - uses: actions/checkout@v3
+        - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # pin@v4
         - name: Checkout OpenSSL master
           if: steps.cache-openssl32n.outputs.cache-hit != 'true'
-          uses: actions/checkout@v3
+          uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # pin@v4
           with:
             set-safe-directory: true
             repository: openssl/openssl
             path: openssl
-        - uses: actions/checkout@v3
+        - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # pin@v4
           with:
             set-safe-directory: true
             repository: open-quantum-safe/liboqs


### PR DESCRIPTION
Based on https://github.com/open-quantum-safe/liboqs/pull/1916, this integrates Actionlint checking of GitHub workflows for errors as part of CI. This also fixes issues highlighted in other workflows, primarily the `checkout` version and missing property.

For completeness, the actionlint output for the workflows _before_ the fixes applied in this PR:

```
| .github/workflows/coding_style.yml:17:15: the runner of "actions/checkout@v2" action is too old to run on GitHub Actions. update the action's version to fix this issue [action]
|    |
| 17 |         uses: actions/checkout@v2
|    |               ^~~~~~~~~~~~~~~~~~~
| .github/workflows/linux.yml:26:15: the runner of "actions/checkout@v2" action is too old to run on GitHub Actions. update the action's version to fix this issue [action]
|    |
| 26 |         uses: actions/checkout@v2
|    |               ^~~~~~~~~~~~~~~~~~~
| .github/workflows/linux.yml:56:15: the runner of "actions/checkout@v2" action is too old to run on GitHub Actions. update the action's version to fix this issue [action]
|    |
| 56 |         uses: actions/checkout@v2
|    |               ^~~~~~~~~~~~~~~~~~~
| .github/workflows/linux.yml:106:15: the runner of "actions/checkout@v2" action is too old to run on GitHub Actions. update the action's version to fix this issue [action]
|     |
| 106 |         uses: actions/checkout@v2
|     |               ^~~~~~~~~~~~~~~~~~~
| .github/workflows/linux.yml:180:15: the runner of "actions/checkout@v2" action is too old to run on GitHub Actions. update the action's version to fix this issue [action]
|     |
| 180 |         uses: actions/checkout@v2
|     |               ^~~~~~~~~~~~~~~~~~~
| .github/workflows/standalone.yml:21:15: the runner of "actions/checkout@v2" action is too old to run on GitHub Actions. update the action's version to fix this issue [action]
|    |
| 21 |         uses: actions/checkout@v2
|    |               ^~~~~~~~~~~~~~~~~~~
| .github/workflows/standalone.yml:49:15: the runner of "actions/checkout@v2" action is too old to run on GitHub Actions. update the action's version to fix this issue [action]
|    |
| 49 |         uses: actions/checkout@v2
|    |               ^~~~~~~~~~~~~~~~~~~
| .github/workflows/windows.yml:60:60: property "config" is not defined in object type {arch: string; oqsconfig: string} [expression]
|    |
| 60 |         run: bash -c "./config --prefix=/opt/openssl32 ${{ matrix.platform.config }} && perl configdata.pm --dump && make $MAKE_PARAMS && make install_sw"
|    |                                                            ^~~~~~~~~~~~~~~~~~~~~~
[Check GitHub workflows/Check validity of GitHub workflows]   ❌  Failure - Main Ensure GitHub actions are valid
```