### PR TITLE
Use more future-proof hash for signature

### DIFF
--- a/test/tlstest_helpers.c
+++ b/test/tlstest_helpers.c
@@ -27,7 +27,7 @@ int create_cert_key(OSSL_LIB_CTX *libctx, char *algname, char *certfilename,
         !X509_NAME_add_entry_by_txt(name, "CN", MBSTRING_ASC,
                                     (unsigned char *)"localhost", -1, -1, 0) ||
         !X509_set_issuer_name(x509, name) ||
-        !X509_sign(x509, pkey, EVP_sha1()) ||
+        !X509_sign(x509, pkey, EVP_sha256()) ||
         !(keybio = BIO_new_file(privkeyfilename, "wb")) ||
         !PEM_write_bio_PrivateKey(keybio, pkey, NULL, NULL, 0, NULL, NULL) ||
         !(certbio = BIO_new_file(certfilename, "wb")) ||


### PR DESCRIPTION
It doesn't make sense to use SHA1 even for tests nowadays. And also it makes tests failing on RHEL-based systems