### PR TITLE
Remove macos-12 runner due to GitHub deprecation.

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -14,7 +14,6 @@ jobs:
       matrix:
         os:
           - macos-13
-          - macos-12
         libjade-build:
 # build with -DOQS_LIBJADE_BUILD=ON when building for algorithms with libjade implementations
           - "OFF"


### PR DESCRIPTION
See https://github.com/actions/runner-images/issues/10721, open-quantum-safe/liboqs#1976, open-quantum-safe/liboqs#1977.

<!-- Please give a brief explanation of the purpose of this pull request. -->

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->
