### PR TITLE
update IANA code points for ML-KEM

### DIFF
--- a/ALGORITHMS.md
+++ b/ALGORITHMS.md
@@ -12,13 +12,13 @@ As standardization for these algorithms within TLS is not done, all TLS code poi
 <!--- OQS_TEMPLATE_FRAGMENT_IDS_START -->
 |Algorithm name | default ID | enabled | environment variable |
 |---------------|:----------:|:-------:|----------------------|
-| frodo640aes | 0x0200 | Yes | OQS_CODEPOINT_FRODO640AES |
+| frodo640aes | 65024 | Yes | OQS_CODEPOINT_FRODO640AES |
 | p256_frodo640aes | 0x2F00 | Yes | OQS_CODEPOINT_P256_FRODO640AES |
 | x25519_frodo640aes | 0x2F80 | Yes | OQS_CODEPOINT_X25519_FRODO640AES |
-| frodo640shake | 0x0201 | Yes | OQS_CODEPOINT_FRODO640SHAKE |
+| frodo640shake | 65025 | Yes | OQS_CODEPOINT_FRODO640SHAKE |
 | p256_frodo640shake | 0x2F01 | Yes | OQS_CODEPOINT_P256_FRODO640SHAKE |
 | x25519_frodo640shake | 0x2F81 | Yes | OQS_CODEPOINT_X25519_FRODO640SHAKE |
-| frodo976aes | 0x0202 | Yes | OQS_CODEPOINT_FRODO976AES |
+| frodo976aes | 65026 | Yes | OQS_CODEPOINT_FRODO976AES |
 | p384_frodo976aes | 0x2F02 | Yes | OQS_CODEPOINT_P384_FRODO976AES |
 | x448_frodo976aes | 0x2F82 | Yes | OQS_CODEPOINT_X448_FRODO976AES |
 | frodo976shake | 0x0203 | Yes | OQS_CODEPOINT_FRODO976SHAKE |
@@ -38,15 +38,15 @@ As standardization for these algorithms within TLS is not done, all TLS code poi
 | p256_kyber768 | 0x639A | Yes | OQS_CODEPOINT_P256_KYBER768 |
 | kyber1024 | 0x023D | Yes | OQS_CODEPOINT_KYBER1024 |
 | p521_kyber1024 | 0x2F3D | Yes | OQS_CODEPOINT_P521_KYBER1024 |
-| mlkem512 | 261 | Yes | OQS_CODEPOINT_MLKEM512 |
+| mlkem512 | 512 | Yes | OQS_CODEPOINT_MLKEM512 |
 | p256_mlkem512 | 0x2F4B | Yes | OQS_CODEPOINT_P256_MLKEM512 |
 | x25519_mlkem512 | 0x2FB6 | Yes | OQS_CODEPOINT_X25519_MLKEM512 |
-| mlkem768 | 262 | Yes | OQS_CODEPOINT_MLKEM768 |
+| mlkem768 | 513 | Yes | OQS_CODEPOINT_MLKEM768 |
 | p384_mlkem768 | 0x2F4C | Yes | OQS_CODEPOINT_P384_MLKEM768 |
 | x448_mlkem768 | 0x2FB7 | Yes | OQS_CODEPOINT_X448_MLKEM768 |
 | X25519MLKEM768 | 0x11ec | Yes | OQS_CODEPOINT_X25519MLKEM768 |
 | SecP256r1MLKEM768 | 0x11eb | Yes | OQS_CODEPOINT_SECP256R1MLKEM768 |
-| mlkem1024 | 263 | Yes | OQS_CODEPOINT_MLKEM1024 |
+| mlkem1024 | 514 | Yes | OQS_CODEPOINT_MLKEM1024 |
 | p521_mlkem1024 | 0x2F4D | Yes | OQS_CODEPOINT_P521_MLKEM1024 |
 | p384_mlkem1024 | 0x2F4E | Yes | OQS_CODEPOINT_P384_MLKEM1024 |
 | bikel1 | 0x0241 | Yes | OQS_CODEPOINT_BIKEL1 |

--- a/oqs-template/generate.yml
+++ b/oqs-template/generate.yml
@@ -1,10 +1,12 @@
 # This is the master document for ID interoperability for KEM IDs, p-hybrid KEM IDs, SIG (O)IDs
 # Next free plain KEM ID: 0x024D, p-hybrid: 0x2F4F, X-hybrid: 0x2FB9
+# Switch to using unassigned code points as per https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-8:
+# Next free: 65027 (see https://github.com/open-quantum-safe/oqs-provider/issues/561)
 kems:
   -
     family: 'FrodoKEM'
     name_group: 'frodo640aes'
-    nid: '0x0200'
+    nid: '65024'
     nid_hybrid: '0x2F00'
     oqs_alg: 'OQS_KEM_alg_frodokem_640_aes'
     extra_nids:
@@ -14,7 +16,7 @@ kems:
   -
     family: 'FrodoKEM'
     name_group: 'frodo640shake'
-    nid: '0x0201'
+    nid: '65025'
     nid_hybrid: '0x2F01'
     oqs_alg: 'OQS_KEM_alg_frodokem_640_shake'
     extra_nids:
@@ -24,7 +26,7 @@ kems:
   -
     family: 'FrodoKEM'
     name_group: 'frodo976aes'
-    nid: '0x0202'
+    nid: '65026'
     nid_hybrid: '0x2F02'
     oqs_alg: 'OQS_KEM_alg_frodokem_976_aes'
     extra_nids:
@@ -151,7 +153,7 @@ kems:
     fips_standard: 1
     name_group: 'mlkem512'
 # https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-8
-    nid: '261'
+    nid: '512'
 # NIST kem 1
     oid: '2.16.840.1.101.3.4.4.1'
 # code point not standardized: Why? XXX
@@ -171,7 +173,7 @@ kems:
     fips_standard: 1
     name_group: 'mlkem768'
 # https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-8
-    nid: '262'
+    nid: '513'
 # NIST kem 2
     oid: '2.16.840.1.101.3.4.4.2'
 # code point not standardized: Why? XXX
@@ -195,7 +197,7 @@ kems:
     fips_standard: 1
     name_group: 'mlkem1024'
 # https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-8
-    nid: '263'
+    nid: '514'
 # NIST kem 3
     oid: '2.16.840.1.101.3.4.4.3'
 # code point not standardized: Why? XXX

--- a/oqs-template/oqs-kem-info.md
+++ b/oqs-template/oqs-kem-info.md
@@ -57,15 +57,15 @@
 | FrodoKEM       | NIST Round 3 submission  | frodo1344aes   | 3            |                    5 | 0x2F04       | secp521_r1                       |
 | FrodoKEM       | NIST Round 3 submission  | frodo1344shake | 3            |                    5 | 0x0205       |                                  |
 | FrodoKEM       | NIST Round 3 submission  | frodo1344shake | 3            |                    5 | 0x2F05       | secp521_r1                       |
-| FrodoKEM       | NIST Round 3 submission  | frodo640aes    | 3            |                    1 | 0x0200       |                                  |
 | FrodoKEM       | NIST Round 3 submission  | frodo640aes    | 3            |                    1 | 0x2F00       | secp256_r1                       |
 | FrodoKEM       | NIST Round 3 submission  | frodo640aes    | 3            |                    1 | 0x2F80       | x25519                           |
-| FrodoKEM       | NIST Round 3 submission  | frodo640shake  | 3            |                    1 | 0x0201       |                                  |
+| FrodoKEM       | NIST Round 3 submission  | frodo640aes    | 3            |                    1 | 65024        |                                  |
 | FrodoKEM       | NIST Round 3 submission  | frodo640shake  | 3            |                    1 | 0x2F01       | secp256_r1                       |
 | FrodoKEM       | NIST Round 3 submission  | frodo640shake  | 3            |                    1 | 0x2F81       | x25519                           |
-| FrodoKEM       | NIST Round 3 submission  | frodo976aes    | 3            |                    3 | 0x0202       |                                  |
+| FrodoKEM       | NIST Round 3 submission  | frodo640shake  | 3            |                    1 | 65025        |                                  |
 | FrodoKEM       | NIST Round 3 submission  | frodo976aes    | 3            |                    3 | 0x2F02       | secp384_r1                       |
 | FrodoKEM       | NIST Round 3 submission  | frodo976aes    | 3            |                    3 | 0x2F82       | x448                             |
+| FrodoKEM       | NIST Round 3 submission  | frodo976aes    | 3            |                    3 | 65026        |                                  |
 | FrodoKEM       | NIST Round 3 submission  | frodo976shake  | 3            |                    3 | 0x0203       |                                  |
 | FrodoKEM       | NIST Round 3 submission  | frodo976shake  | 3            |                    3 | 0x2F03       | secp384_r1                       |
 | FrodoKEM       | NIST Round 3 submission  | frodo976shake  | 3            |                    3 | 0x2F83       | x448                             |
@@ -87,12 +87,12 @@
 | HQC            | 2023-04-30               | hqc256         | 4            |                    5 | 0x2F46       | secp521_r1                       |
 | ML-KEM         | ML-KEM                   | mlkem1024      | FIPS203      |                    5 | 0x2F4D       | secp521_r1                       |
 | ML-KEM         | ML-KEM                   | mlkem1024      | FIPS203      |                    5 | 0x2F4E       | p384                             |
-| ML-KEM         | ML-KEM                   | mlkem1024      | FIPS203      |                    5 | 263          |                                  |
+| ML-KEM         | ML-KEM                   | mlkem1024      | FIPS203      |                    5 | 514          |                                  |
 | ML-KEM         | ML-KEM                   | mlkem512       | FIPS203      |                    1 | 0x2F4B       | secp256_r1                       |
 | ML-KEM         | ML-KEM                   | mlkem512       | FIPS203      |                    1 | 0x2FB6       | x25519                           |
-| ML-KEM         | ML-KEM                   | mlkem512       | FIPS203      |                    1 | 261          |                                  |
+| ML-KEM         | ML-KEM                   | mlkem512       | FIPS203      |                    1 | 512          |                                  |
 | ML-KEM         | ML-KEM                   | mlkem768       | FIPS203      |                    3 | 0x11eb       | p256                             |
 | ML-KEM         | ML-KEM                   | mlkem768       | FIPS203      |                    3 | 0x11ec       | x25519                           |
 | ML-KEM         | ML-KEM                   | mlkem768       | FIPS203      |                    3 | 0x2F4C       | secp384_r1                       |
 | ML-KEM         | ML-KEM                   | mlkem768       | FIPS203      |                    3 | 0x2FB7       | x448                             |
-| ML-KEM         | ML-KEM                   | mlkem768       | FIPS203      |                    3 | 262          |                                  |
+| ML-KEM         | ML-KEM                   | mlkem768       | FIPS203      |                    3 | 513          |                                  |

--- a/oqs-template/oqs-sig-info.md
+++ b/oqs-template/oqs-sig-info.md
@@ -1,192 +1,192 @@
-| Algorithm                                         | Implementation Version                          | NIST round   |   Claimed NIST Level | Code Point   | OID                         |
-|:--------------------------------------------------|:------------------------------------------------|:-------------|---------------------:|:-------------|:----------------------------|
-| CROSSrsdp128balanced                              | 1.2 + Keccak_x4 + PQClean fixes                 | 1            |                    1 | 0xfef6       | 1.3.6.1.4.1.62245.2.1.1     |
-| CROSSrsdp128fast                                  | 1.2 + Keccak_x4 + PQClean fixes                 | 1            |                    1 | 0xfef7       | 1.3.6.1.4.1.62245.2.1.2     |
-| CROSSrsdp128small                                 | 1.2 + Keccak_x4 + PQClean fixes                 | 1            |                    1 | 0xfef8       | 1.3.6.1.4.1.62245.2.1.3     |
-| CROSSrsdp192balanced                              | 1.2 + Keccak_x4 + PQClean fixes                 | 1            |                    3 | 0xfef9       | 1.3.6.1.4.1.62245.2.1.4     |
-| CROSSrsdp192fast                                  | 1.2 + Keccak_x4 + PQClean fixes                 | 1            |                    3 | 0xfefa       | 1.3.6.1.4.1.62245.2.1.5     |
-| CROSSrsdp192small                                 | 1.2 + Keccak_x4 + PQClean fixes                 | 1            |                    3 | 0xfefb       | 1.3.6.1.4.1.62245.2.1.6     |
-| CROSSrsdp256small                                 | 1.2 + Keccak_x4 + PQClean fixes                 | 1            |                    5 | 0xfefc       | 1.3.6.1.4.1.62245.2.1.9     |
-| CROSSrsdpg128balanced                             | 1.2 + Keccak_x4 + PQClean fixes                 | 1            |                    1 | 0xfefd       | 1.3.6.1.4.1.62245.2.1.10    |
-| CROSSrsdpg128fast                                 | 1.2 + Keccak_x4 + PQClean fixes                 | 1            |                    1 | 0xfefe       | 1.3.6.1.4.1.62245.2.1.11    |
-| CROSSrsdpg128small                                | 1.2 + Keccak_x4 + PQClean fixes                 | 1            |                    1 | 0xfeff       | 1.3.6.1.4.1.62245.2.1.12    |
-| CROSSrsdpg192balanced                             | 1.2 + Keccak_x4 + PQClean fixes                 | 1            |                    3 | 0xff00       | 1.3.6.1.4.1.62245.2.1.13    |
-| CROSSrsdpg192fast                                 | 1.2 + Keccak_x4 + PQClean fixes                 | 1            |                    3 | 0xff01       | 1.3.6.1.4.1.62245.2.1.14    |
-| CROSSrsdpg192small                                | 1.2 + Keccak_x4 + PQClean fixes                 | 1            |                    3 | 0xff02       | 1.3.6.1.4.1.62245.2.1.15    |
-| CROSSrsdpg256balanced                             | 1.2 + Keccak_x4 + PQClean fixes                 | 1            |                    5 | 0xff03       | 1.3.6.1.4.1.62245.2.1.16    |
-| CROSSrsdpg256fast                                 | 1.2 + Keccak_x4 + PQClean fixes                 | 1            |                    5 | 0xff04       | 1.3.6.1.4.1.62245.2.1.17    |
-| CROSSrsdpg256small                                | 1.2 + Keccak_x4 + PQClean fixes                 | 1            |                    5 | 0xff05       | 1.3.6.1.4.1.62245.2.1.18    |
-| dilithium2                                        | 3.1                                             | 3            |                    2 | 0xfea0       | 1.3.6.1.4.1.2.267.7.4.4     |
-| dilithium2 **hybrid with** p256                   | 3.1                                             | 3            |                    2 | 0xfea1       | 1.3.9999.2.7.1              |
-| dilithium2 **hybrid with** rsa3072                | 3.1                                             | 3            |                    2 | 0xfea2       | 1.3.9999.2.7.2              |
-| dilithium3                                        | 3.1                                             | 3            |                    3 | 0xfea3       | 1.3.6.1.4.1.2.267.7.6.5     |
-| dilithium3 **hybrid with** p384                   | 3.1                                             | 3            |                    3 | 0xfea4       | 1.3.9999.2.7.3              |
-| dilithium5                                        | 3.1                                             | 3            |                    5 | 0xfea5       | 1.3.6.1.4.1.2.267.7.8.7     |
-| dilithium5 **hybrid with** p521                   | 3.1                                             | 3            |                    5 | 0xfea6       | 1.3.9999.2.7.4              |
-| dilithium2_aes                                    | NIST Round 3 submission                         | 3            |                    2 | 0xfea7       | 1.3.6.1.4.1.2.267.11.4.4    |
-| dilithium2_aes **hybrid with** p256               | NIST Round 3 submission                         | 3            |                    2 | 0xfea8       | 1.3.9999.2.11.1             |
-| dilithium2_aes **hybrid with** rsa3072            | NIST Round 3 submission                         | 3            |                    2 | 0xfea9       | 1.3.9999.2.11.2             |
-| dilithium3_aes                                    | NIST Round 3 submission                         | 3            |                    3 | 0xfeaa       | 1.3.6.1.4.1.2.267.11.6.5    |
-| dilithium3_aes **hybrid with** p384               | NIST Round 3 submission                         | 3            |                    3 | 0xfeab       | 1.3.9999.2.11.3             |
-| dilithium5_aes                                    | NIST Round 3 submission                         | 3            |                    5 | 0xfeac       | 1.3.6.1.4.1.2.267.11.8.7    |
-| dilithium5_aes **hybrid with** p521               | NIST Round 3 submission                         | 3            |                    5 | 0xfead       | 1.3.9999.2.11.4             |
-| falcon512                                         | 20211101                                        | 3            |                    1 | 0xfed7       | 1.3.9999.3.11               |
-| falcon512 **hybrid with** p256                    | 20211101                                        | 3            |                    1 | 0xfed8       | 1.3.9999.3.12               |
-| falcon512 **hybrid with** rsa3072                 | 20211101                                        | 3            |                    1 | 0xfed9       | 1.3.9999.3.13               |
-| falcon512                                         | PQClean Round 3 version labelled 20211101       | 3            |                    1 | 0xfeae       | 1.3.9999.3.6                |
-| falcon512 **hybrid with** p256                    | PQClean Round 3 version labelled 20211101       | 3            |                    1 | 0xfeaf       | 1.3.9999.3.7                |
-| falcon512 **hybrid with** rsa3072                 | PQClean Round 3 version labelled 20211101       | 3            |                    1 | 0xfeb0       | 1.3.9999.3.8                |
-| falcon512                                         | NIST Round 3 submission                         | 3            |                    1 | 0xfe0b       | 1.3.9999.3.1                |
-| falcon512 **hybrid with** p256                    | NIST Round 3 submission                         | 3            |                    1 | 0xfe0c       | 1.3.9999.3.2                |
-| falcon512 **hybrid with** rsa3072                 | NIST Round 3 submission                         | 3            |                    1 | 0xfe0d       | 1.3.9999.3.3                |
-| falconpadded512                                   | 20211101                                        | 3            |                    1 | 0xfedc       | 1.3.9999.3.16               |
-| falconpadded512 **hybrid with** p256              | 20211101                                        | 3            |                    1 | 0xfedd       | 1.3.9999.3.17               |
-| falconpadded512 **hybrid with** rsa3072           | 20211101                                        | 3            |                    1 | 0xfede       | 1.3.9999.3.18               |
-| falcon1024                                        | 20211101                                        | 3            |                    5 | 0xfeda       | 1.3.9999.3.14               |
-| falcon1024 **hybrid with** p521                   | 20211101                                        | 3            |                    5 | 0xfedb       | 1.3.9999.3.15               |
-| falcon1024                                        | PQClean Round 3 version labelled 20211101       | 3            |                    5 | 0xfeb1       | 1.3.9999.3.9                |
-| falcon1024 **hybrid with** p521                   | PQClean Round 3 version labelled 20211101       | 3            |                    5 | 0xfeb2       | 1.3.9999.3.10               |
-| falcon1024                                        | NIST Round 3 submission                         | 3            |                    5 | 0xfe0e       | 1.3.9999.3.4                |
-| falcon1024 **hybrid with** p521                   | NIST Round 3 submission                         | 3            |                    5 | 0xfe0f       | 1.3.9999.3.5                |
-| falconpadded1024                                  | 20211101                                        | 3            |                    5 | 0xfedf       | 1.3.9999.3.19               |
-| falconpadded1024 **hybrid with** p521             | 20211101                                        | 3            |                    5 | 0xfee0       | 1.3.9999.3.20               |
-| mayo1                                             | https://doi.org/10.46586/tches.v2024.i2.252-275 | 1            |                    1 | 0xfeee       | 1.3.9999.8.1.1              |
-| mayo1 **hybrid with** p256                        | https://doi.org/10.46586/tches.v2024.i2.252-275 | 1            |                    1 | 0xfef2       | 1.3.9999.8.1.2              |
-| mayo2                                             | https://doi.org/10.46586/tches.v2024.i2.252-275 | 1            |                    1 | 0xfeef       | 1.3.9999.8.2.1              |
-| mayo2 **hybrid with** p256                        | https://doi.org/10.46586/tches.v2024.i2.252-275 | 1            |                    1 | 0xfef3       | 1.3.9999.8.2.2              |
-| mayo3                                             | https://doi.org/10.46586/tches.v2024.i2.252-275 | 1            |                    3 | 0xfef0       | 1.3.9999.8.3.1              |
-| mayo3 **hybrid with** p384                        | https://doi.org/10.46586/tches.v2024.i2.252-275 | 1            |                    3 | 0xfef4       | 1.3.9999.8.3.2              |
-| mayo5                                             | https://doi.org/10.46586/tches.v2024.i2.252-275 | 1            |                    5 | 0xfef1       | 1.3.9999.8.5.1              |
-| mayo5 **hybrid with** p521                        | https://doi.org/10.46586/tches.v2024.i2.252-275 | 1            |                    5 | 0xfef5       | 1.3.9999.8.5.2              |
-| mldsa44                                           | ML-DSA-ipd                                      | ipd          |                    1 | 0xfed0       | 1.3.6.1.4.1.2.267.12.4.4    |
-| mldsa44 **hybrid with** p256                      | ML-DSA-ipd                                      | ipd          |                    1 | 0xfed3       | 1.3.9999.7.1                |
-| mldsa44 **hybrid with** rsa3072                   | ML-DSA-ipd                                      | ipd          |                    1 | 0xfed4       | 1.3.9999.7.2                |
-| mldsa44 **composite with** pss2048                | ML-DSA-ipd                                      | ipd          |                    1 | 0xfee1       | 2.16.840.1.114027.80.8.1.1  |
-| mldsa44 **composite with** rsa2048                | ML-DSA-ipd                                      | ipd          |                    1 | 0xfee2       | 2.16.840.1.114027.80.8.1.2  |
-| mldsa44 **composite with** ed25519                | ML-DSA-ipd                                      | ipd          |                    1 | 0xfee3       | 2.16.840.1.114027.80.8.1.3  |
-| mldsa44 **composite with** p256                   | ML-DSA-ipd                                      | ipd          |                    1 | 0xfee4       | 2.16.840.1.114027.80.8.1.4  |
-| mldsa44 **composite with** bp256                  | ML-DSA-ipd                                      | ipd          |                    1 | 0xfee5       | 2.16.840.1.114027.80.8.1.5  |
-| mldsa65                                           | ML-DSA-ipd                                      | ipd          |                    3 | 0xfed1       | 1.3.6.1.4.1.2.267.12.6.5    |
-| mldsa65 **hybrid with** p384                      | ML-DSA-ipd                                      | ipd          |                    3 | 0xfed5       | 1.3.9999.7.3                |
-| mldsa65 **composite with** pss3072                | ML-DSA-ipd                                      | ipd          |                    3 | 0xfee6       | 2.16.840.1.114027.80.8.1.6  |
-| mldsa65 **composite with** rsa3072                | ML-DSA-ipd                                      | ipd          |                    3 | 0xfee7       | 2.16.840.1.114027.80.8.1.7  |
-| mldsa65 **composite with** p256                   | ML-DSA-ipd                                      | ipd          |                    3 | 0xfee8       | 2.16.840.1.114027.80.8.1.8  |
-| mldsa65 **composite with** bp256                  | ML-DSA-ipd                                      | ipd          |                    3 | 0xfee9       | 2.16.840.1.114027.80.8.1.9  |
-| mldsa65 **composite with** ed25519                | ML-DSA-ipd                                      | ipd          |                    3 | 0xfeea       | 2.16.840.1.114027.80.8.1.10 |
-| mldsa87                                           | ML-DSA-ipd                                      | ipd          |                    5 | 0xfed2       | 1.3.6.1.4.1.2.267.12.8.7    |
-| mldsa87 **hybrid with** p521                      | ML-DSA-ipd                                      | ipd          |                    5 | 0xfed6       | 1.3.9999.7.4                |
-| mldsa87 **composite with** p384                   | ML-DSA-ipd                                      | ipd          |                    5 | 0xfeeb       | 2.16.840.1.114027.80.8.1.11 |
-| mldsa87 **composite with** bp384                  | ML-DSA-ipd                                      | ipd          |                    5 | 0xfeec       | 2.16.840.1.114027.80.8.1.12 |
-| mldsa87 **composite with** ed448                  | ML-DSA-ipd                                      | ipd          |                    5 | 0xfeed       | 2.16.840.1.114027.80.8.1.13 |
-| sphincsharaka128frobust                           | NIST Round 3 submission                         | 3            |                    1 | 0xfe42       | 1.3.9999.6.1.1              |
-| sphincsharaka128frobust **hybrid with** p256      | NIST Round 3 submission                         | 3            |                    1 | 0xfe43       | 1.3.9999.6.1.2              |
-| sphincsharaka128frobust **hybrid with** rsa3072   | NIST Round 3 submission                         | 3            |                    1 | 0xfe44       | 1.3.9999.6.1.3              |
-| sphincsharaka128fsimple                           | NIST Round 3 submission                         | 3            |                    1 | 0xfe45       | 1.3.9999.6.1.4              |
-| sphincsharaka128fsimple **hybrid with** p256      | NIST Round 3 submission                         | 3            |                    1 | 0xfe46       | 1.3.9999.6.1.5              |
-| sphincsharaka128fsimple **hybrid with** rsa3072   | NIST Round 3 submission                         | 3            |                    1 | 0xfe47       | 1.3.9999.6.1.6              |
-| sphincsharaka128srobust                           | NIST Round 3 submission                         | 3            |                    1 | 0xfe48       | 1.3.9999.6.1.7              |
-| sphincsharaka128srobust **hybrid with** p256      | NIST Round 3 submission                         | 3            |                    1 | 0xfe49       | 1.3.9999.6.1.8              |
-| sphincsharaka128srobust **hybrid with** rsa3072   | NIST Round 3 submission                         | 3            |                    1 | 0xfe4a       | 1.3.9999.6.1.9              |
-| sphincsharaka128ssimple                           | NIST Round 3 submission                         | 3            |                    1 | 0xfe4b       | 1.3.9999.6.1.10             |
-| sphincsharaka128ssimple **hybrid with** p256      | NIST Round 3 submission                         | 3            |                    1 | 0xfe4c       | 1.3.9999.6.1.11             |
-| sphincsharaka128ssimple **hybrid with** rsa3072   | NIST Round 3 submission                         | 3            |                    1 | 0xfe4d       | 1.3.9999.6.1.12             |
-| sphincsharaka192frobust                           | NIST Round 3 submission                         | 3            |                    3 | 0xfe4e       | 1.3.9999.6.2.1              |
-| sphincsharaka192frobust **hybrid with** p384      | NIST Round 3 submission                         | 3            |                    3 | 0xfe4f       | 1.3.9999.6.2.2              |
-| sphincsharaka192fsimple                           | NIST Round 3 submission                         | 3            |                    3 | 0xfe50       | 1.3.9999.6.2.3              |
-| sphincsharaka192fsimple **hybrid with** p384      | NIST Round 3 submission                         | 3            |                    3 | 0xfe51       | 1.3.9999.6.2.4              |
-| sphincsharaka192srobust                           | NIST Round 3 submission                         | 3            |                    3 | 0xfe52       | 1.3.9999.6.2.5              |
-| sphincsharaka192srobust **hybrid with** p384      | NIST Round 3 submission                         | 3            |                    3 | 0xfe53       | 1.3.9999.6.2.6              |
-| sphincsharaka192ssimple                           | NIST Round 3 submission                         | 3            |                    3 | 0xfe54       | 1.3.9999.6.2.7              |
-| sphincsharaka192ssimple **hybrid with** p384      | NIST Round 3 submission                         | 3            |                    3 | 0xfe55       | 1.3.9999.6.2.8              |
-| sphincsharaka256frobust                           | NIST Round 3 submission                         | 3            |                    3 | 0xfe56       | 1.3.9999.6.3.1              |
-| sphincsharaka256frobust **hybrid with** p521      | NIST Round 3 submission                         | 3            |                    3 | 0xfe57       | 1.3.9999.6.3.2              |
-| sphincsharaka256fsimple                           | NIST Round 3 submission                         | 3            |                    5 | 0xfe58       | 1.3.9999.6.3.3              |
-| sphincsharaka256fsimple **hybrid with** p521      | NIST Round 3 submission                         | 3            |                    5 | 0xfe59       | 1.3.9999.6.3.4              |
-| sphincsharaka256srobust                           | NIST Round 3 submission                         | 3            |                    5 | 0xfe5a       | 1.3.9999.6.3.5              |
-| sphincsharaka256srobust **hybrid with** p521      | NIST Round 3 submission                         | 3            |                    5 | 0xfe5b       | 1.3.9999.6.3.6              |
-| sphincsharaka256ssimple                           | NIST Round 3 submission                         | 3            |                    5 | 0xfe5c       | 1.3.9999.6.3.7              |
-| sphincsharaka256ssimple **hybrid with** p521      | NIST Round 3 submission                         | 3            |                    5 | 0xfe5d       | 1.3.9999.6.3.8              |
-| sphincssha26128frobust                            | NIST Round 3 submission                         | 3            |                    5 | 0xfe5e       | 1.3.9999.6.4.1              |
-| sphincssha26128frobust **hybrid with** p256       | NIST Round 3 submission                         | 3            |                    5 | 0xfe5f       | 1.3.9999.6.4.2              |
-| sphincssha26128frobust **hybrid with** rsa3072    | NIST Round 3 submission                         | 3            |                    5 | 0xfe60       | 1.3.9999.6.4.3              |
-| sphincssha2128fsimple                             | NIST Round 3 submission, v3.1 (June 10, 2022)   | 3            |                    1 | 0xfeb3       | 1.3.9999.6.4.13             |
-| sphincssha2128fsimple **hybrid with** p256        | NIST Round 3 submission, v3.1 (June 10, 2022)   | 3            |                    1 | 0xfeb4       | 1.3.9999.6.4.14             |
-| sphincssha2128fsimple **hybrid with** rsa3072     | NIST Round 3 submission, v3.1 (June 10, 2022)   | 3            |                    1 | 0xfeb5       | 1.3.9999.6.4.15             |
-| sphincssha2128fsimple                             | NIST Round 3 submission                         | 3            |                    1 | 0xfe61       | 1.3.9999.6.4.4              |
-| sphincssha2128fsimple **hybrid with** p256        | NIST Round 3 submission                         | 3            |                    1 | 0xfe62       | 1.3.9999.6.4.5              |
-| sphincssha2128fsimple **hybrid with** rsa3072     | NIST Round 3 submission                         | 3            |                    1 | 0xfe63       | 1.3.9999.6.4.6              |
-| sphincssha256128srobust                           | NIST Round 3 submission                         | 3            |                    5 | 0xfe64       | 1.3.9999.6.4.7              |
-| sphincssha256128srobust **hybrid with** p256      | NIST Round 3 submission                         | 3            |                    5 | 0xfe65       | 1.3.9999.6.4.8              |
-| sphincssha256128srobust **hybrid with** rsa3072   | NIST Round 3 submission                         | 3            |                    5 | 0xfe66       | 1.3.9999.6.4.9              |
-| sphincssha2128ssimple                             | NIST Round 3 submission, v3.1 (June 10, 2022)   | 3            |                    1 | 0xfeb6       | 1.3.9999.6.4.16             |
-| sphincssha2128ssimple **hybrid with** p256        | NIST Round 3 submission, v3.1 (June 10, 2022)   | 3            |                    1 | 0xfeb7       | 1.3.9999.6.4.17             |
-| sphincssha2128ssimple **hybrid with** rsa3072     | NIST Round 3 submission, v3.1 (June 10, 2022)   | 3            |                    1 | 0xfeb8       | 1.3.9999.6.4.18             |
-| sphincssha2128ssimple                             | NIST Round 3 submission                         | 3            |                    1 | 0xfe67       | 1.3.9999.6.4.10             |
-| sphincssha2128ssimple **hybrid with** p256        | NIST Round 3 submission                         | 3            |                    1 | 0xfe68       | 1.3.9999.6.4.11             |
-| sphincssha2128ssimple **hybrid with** rsa3072     | NIST Round 3 submission                         | 3            |                    1 | 0xfe69       | 1.3.9999.6.4.12             |
-| sphincssha256192frobust                           | NIST Round 3 submission                         | 3            |                    5 | 0xfe6a       | 1.3.9999.6.5.1              |
-| sphincssha256192frobust **hybrid with** p384      | NIST Round 3 submission                         | 3            |                    5 | 0xfe6b       | 1.3.9999.6.5.2              |
-| sphincssha2192fsimple                             | NIST Round 3 submission, v3.1 (June 10, 2022)   | 3            |                    3 | 0xfeb9       | 1.3.9999.6.5.10             |
-| sphincssha2192fsimple **hybrid with** p384        | NIST Round 3 submission, v3.1 (June 10, 2022)   | 3            |                    3 | 0xfeba       | 1.3.9999.6.5.11             |
-| sphincssha2192fsimple                             | NIST Round 3 submission                         | 3            |                    3 | 0xfe6c       | 1.3.9999.6.5.3              |
-| sphincssha2192fsimple **hybrid with** p384        | NIST Round 3 submission                         | 3            |                    3 | 0xfe6d       | 1.3.9999.6.5.4              |
-| sphincssha256192srobust                           | NIST Round 3 submission                         | 3            |                    5 | 0xfe6e       | 1.3.9999.6.5.5              |
-| sphincssha256192srobust **hybrid with** p384      | NIST Round 3 submission                         | 3            |                    5 | 0xfe6f       | 1.3.9999.6.5.6              |
-| sphincssha2192ssimple                             | NIST Round 3 submission, v3.1 (June 10, 2022)   | 3            |                    3 | 0xfebb       | 1.3.9999.6.5.12             |
-| sphincssha2192ssimple **hybrid with** p384        | NIST Round 3 submission, v3.1 (June 10, 2022)   | 3            |                    3 | 0xfebc       | 1.3.9999.6.5.13             |
-| sphincssha2192ssimple                             | NIST Round 3 submission                         | 3            |                    3 | 0xfe70       | 1.3.9999.6.5.7              |
-| sphincssha2192ssimple **hybrid with** p384        | NIST Round 3 submission                         | 3            |                    3 | 0xfe71       | 1.3.9999.6.5.8              |
-| sphincssha256256frobust                           | NIST Round 3 submission                         | 3            |                    5 | 0xfe72       | 1.3.9999.6.6.1              |
-| sphincssha256256frobust **hybrid with** p521      | NIST Round 3 submission                         | 3            |                    5 | 0xfe73       | 1.3.9999.6.6.2              |
-| sphincssha2256fsimple                             | NIST Round 3 submission, v3.1 (June 10, 2022)   | 3            |                    5 | 0xfebd       | 1.3.9999.6.6.10             |
-| sphincssha2256fsimple **hybrid with** p521        | NIST Round 3 submission, v3.1 (June 10, 2022)   | 3            |                    5 | 0xfebe       | 1.3.9999.6.6.11             |
-| sphincssha2256fsimple                             | NIST Round 3 submission                         | 3            |                    5 | 0xfe74       | 1.3.9999.6.6.3              |
-| sphincssha2256fsimple **hybrid with** p521        | NIST Round 3 submission                         | 3            |                    5 | 0xfe75       | 1.3.9999.6.6.4              |
-| sphincssha256256srobust                           | NIST Round 3 submission                         | 3            |                    5 | 0xfe76       | 1.3.9999.6.6.5              |
-| sphincssha256256srobust **hybrid with** p521      | NIST Round 3 submission                         | 3            |                    5 | 0xfe77       | 1.3.9999.6.6.6              |
-| sphincssha2256ssimple                             | NIST Round 3 submission, v3.1 (June 10, 2022)   | 3            |                    5 | 0xfec0       | 1.3.9999.6.6.12             |
-| sphincssha2256ssimple **hybrid with** p521        | NIST Round 3 submission, v3.1 (June 10, 2022)   | 3            |                    5 | 0xfec1       | 1.3.9999.6.6.13             |
-| sphincssha2256ssimple                             | NIST Round 3 submission                         | 3            |                    5 | 0xfe78       | 1.3.9999.6.6.7              |
-| sphincssha2256ssimple **hybrid with** p521        | NIST Round 3 submission                         | 3            |                    5 | 0xfe79       | 1.3.9999.6.6.8              |
-| sphincsshake256128frobust                         | NIST Round 3 submission                         | 3            |                    1 | 0xfe7a       | 1.3.9999.6.7.1              |
-| sphincsshake256128frobust **hybrid with** p256    | NIST Round 3 submission                         | 3            |                    1 | 0xfe7b       | 1.3.9999.6.7.2              |
-| sphincsshake256128frobust **hybrid with** rsa3072 | NIST Round 3 submission                         | 3            |                    1 | 0xfe7c       | 1.3.9999.6.7.3              |
-| sphincsshake128fsimple                            | NIST Round 3 submission, v3.1 (June 10, 2022)   | 3            |                    1 | 0xfec2       | 1.3.9999.6.7.13             |
-| sphincsshake128fsimple **hybrid with** p256       | NIST Round 3 submission, v3.1 (June 10, 2022)   | 3            |                    1 | 0xfec3       | 1.3.9999.6.7.14             |
-| sphincsshake128fsimple **hybrid with** rsa3072    | NIST Round 3 submission, v3.1 (June 10, 2022)   | 3            |                    1 | 0xfec4       | 1.3.9999.6.7.15             |
-| sphincsshake128fsimple                            | NIST Round 3 submission                         | 3            |                    1 | 0xfe7d       | 1.3.9999.6.7.4              |
-| sphincsshake128fsimple **hybrid with** p256       | NIST Round 3 submission                         | 3            |                    1 | 0xfe7e       | 1.3.9999.6.7.5              |
-| sphincsshake128fsimple **hybrid with** rsa3072    | NIST Round 3 submission                         | 3            |                    1 | 0xfe7f       | 1.3.9999.6.7.6              |
-| sphincsshake256128srobust                         | NIST Round 3 submission                         | 3            |                    1 | 0xfe80       | 1.3.9999.6.7.7              |
-| sphincsshake256128srobust **hybrid with** p256    | NIST Round 3 submission                         | 3            |                    1 | 0xfe81       | 1.3.9999.6.7.8              |
-| sphincsshake256128srobust **hybrid with** rsa3072 | NIST Round 3 submission                         | 3            |                    1 | 0xfe82       | 1.3.9999.6.7.9              |
-| sphincsshake128ssimple                            | NIST Round 3 submission, v3.1 (June 10, 2022)   | 3            |                    1 | 0xfec5       | 1.3.9999.6.7.16             |
-| sphincsshake128ssimple **hybrid with** p256       | NIST Round 3 submission, v3.1 (June 10, 2022)   | 3            |                    1 | 0xfec6       | 1.3.9999.6.7.17             |
-| sphincsshake128ssimple **hybrid with** rsa3072    | NIST Round 3 submission, v3.1 (June 10, 2022)   | 3            |                    1 | 0xfec7       | 1.3.9999.6.7.18             |
-| sphincsshake128ssimple                            | NIST Round 3 submission                         | 3            |                    1 | 0xfe83       | 1.3.9999.6.7.10             |
-| sphincsshake128ssimple **hybrid with** p256       | NIST Round 3 submission                         | 3            |                    1 | 0xfe84       | 1.3.9999.6.7.11             |
-| sphincsshake128ssimple **hybrid with** rsa3072    | NIST Round 3 submission                         | 3            |                    1 | 0xfe85       | 1.3.9999.6.7.12             |
-| sphincsshake256192frobust                         | NIST Round 3 submission                         | 3            |                    3 | 0xfe86       | 1.3.9999.6.8.1              |
-| sphincsshake256192frobust **hybrid with** p384    | NIST Round 3 submission                         | 3            |                    3 | 0xfe87       | 1.3.9999.6.8.2              |
-| sphincsshake192fsimple                            | NIST Round 3 submission, v3.1 (June 10, 2022)   | 3            |                    3 | 0xfec8       | 1.3.9999.6.8.10             |
-| sphincsshake192fsimple **hybrid with** p384       | NIST Round 3 submission, v3.1 (June 10, 2022)   | 3            |                    3 | 0xfec9       | 1.3.9999.6.8.11             |
-| sphincsshake192fsimple                            | NIST Round 3 submission                         | 3            |                    3 | 0xfe88       | 1.3.9999.6.8.3              |
-| sphincsshake192fsimple **hybrid with** p384       | NIST Round 3 submission                         | 3            |                    3 | 0xfe89       | 1.3.9999.6.8.4              |
-| sphincsshake256192srobust                         | NIST Round 3 submission                         | 3            |                    3 | 0xfe8a       | 1.3.9999.6.8.5              |
-| sphincsshake256192srobust **hybrid with** p384    | NIST Round 3 submission                         | 3            |                    3 | 0xfe8b       | 1.3.9999.6.8.6              |
-| sphincsshake192ssimple                            | NIST Round 3 submission, v3.1 (June 10, 2022)   | 3            |                    3 | 0xfeca       | 1.3.9999.6.8.12             |
-| sphincsshake192ssimple **hybrid with** p384       | NIST Round 3 submission, v3.1 (June 10, 2022)   | 3            |                    3 | 0xfecb       | 1.3.9999.6.8.13             |
-| sphincsshake192ssimple                            | NIST Round 3 submission                         | 3            |                    3 | 0xfe8c       | 1.3.9999.6.8.7              |
-| sphincsshake192ssimple **hybrid with** p384       | NIST Round 3 submission                         | 3            |                    3 | 0xfe8d       | 1.3.9999.6.8.8              |
-| sphincsshake256256frobust                         | NIST Round 3 submission                         | 3            |                    5 | 0xfe8e       | 1.3.9999.6.9.1              |
-| sphincsshake256256frobust **hybrid with** p521    | NIST Round 3 submission                         | 3            |                    5 | 0xfe8f       | 1.3.9999.6.9.2              |
-| sphincsshake256fsimple                            | NIST Round 3 submission, v3.1 (June 10, 2022)   | 3            |                    5 | 0xfecc       | 1.3.9999.6.9.10             |
-| sphincsshake256fsimple **hybrid with** p521       | NIST Round 3 submission, v3.1 (June 10, 2022)   | 3            |                    5 | 0xfecd       | 1.3.9999.6.9.11             |
-| sphincsshake256fsimple                            | NIST Round 3 submission                         | 3            |                    5 | 0xfe90       | 1.3.9999.6.9.3              |
-| sphincsshake256fsimple **hybrid with** p521       | NIST Round 3 submission                         | 3            |                    5 | 0xfe91       | 1.3.9999.6.9.4              |
-| sphincsshake256256srobust                         | NIST Round 3 submission                         | 3            |                    5 | 0xfe92       | 1.3.9999.6.9.5              |
-| sphincsshake256256srobust **hybrid with** p521    | NIST Round 3 submission                         | 3            |                    5 | 0xfe93       | 1.3.9999.6.9.6              |
-| sphincsshake256ssimple                            | NIST Round 3 submission, v3.1 (June 10, 2022)   | 3            |                    5 | 0xfece       | 1.3.9999.6.9.12             |
-| sphincsshake256ssimple **hybrid with** p521       | NIST Round 3 submission, v3.1 (June 10, 2022)   | 3            |                    5 | 0xfecf       | 1.3.9999.6.9.13             |
-| sphincsshake256ssimple                            | NIST Round 3 submission                         | 3            |                    5 | 0xfe94       | 1.3.9999.6.9.7              |
-| sphincsshake256ssimple **hybrid with** p521       | NIST Round 3 submission                         | 3            |                    5 | 0xfe95       | 1.3.9999.6.9.8              |
+| Algorithm                                         | Implementation Version                           | NIST round   |   Claimed NIST Level | Code Point   | OID                         |
+|:--------------------------------------------------|:-------------------------------------------------|:-------------|---------------------:|:-------------|:----------------------------|
+| CROSSrsdp128balanced                              | 1.2 + Keccak_x4 + PQClean fixes + endianness fix | 1            |                    1 | 0xfef6       | 1.3.6.1.4.1.62245.2.1.1     |
+| CROSSrsdp128fast                                  | 1.2 + Keccak_x4 + PQClean fixes + endianness fix | 1            |                    1 | 0xfef7       | 1.3.6.1.4.1.62245.2.1.2     |
+| CROSSrsdp128small                                 | 1.2 + Keccak_x4 + PQClean fixes + endianness fix | 1            |                    1 | 0xfef8       | 1.3.6.1.4.1.62245.2.1.3     |
+| CROSSrsdp192balanced                              | 1.2 + Keccak_x4 + PQClean fixes + endianness fix | 1            |                    3 | 0xfef9       | 1.3.6.1.4.1.62245.2.1.4     |
+| CROSSrsdp192fast                                  | 1.2 + Keccak_x4 + PQClean fixes + endianness fix | 1            |                    3 | 0xfefa       | 1.3.6.1.4.1.62245.2.1.5     |
+| CROSSrsdp192small                                 | 1.2 + Keccak_x4 + PQClean fixes + endianness fix | 1            |                    3 | 0xfefb       | 1.3.6.1.4.1.62245.2.1.6     |
+| CROSSrsdp256small                                 | 1.2 + Keccak_x4 + PQClean fixes + endianness fix | 1            |                    5 | 0xfefc       | 1.3.6.1.4.1.62245.2.1.9     |
+| CROSSrsdpg128balanced                             | 1.2 + Keccak_x4 + PQClean fixes + endianness fix | 1            |                    1 | 0xfefd       | 1.3.6.1.4.1.62245.2.1.10    |
+| CROSSrsdpg128fast                                 | 1.2 + Keccak_x4 + PQClean fixes + endianness fix | 1            |                    1 | 0xfefe       | 1.3.6.1.4.1.62245.2.1.11    |
+| CROSSrsdpg128small                                | 1.2 + Keccak_x4 + PQClean fixes + endianness fix | 1            |                    1 | 0xfeff       | 1.3.6.1.4.1.62245.2.1.12    |
+| CROSSrsdpg192balanced                             | 1.2 + Keccak_x4 + PQClean fixes + endianness fix | 1            |                    3 | 0xff00       | 1.3.6.1.4.1.62245.2.1.13    |
+| CROSSrsdpg192fast                                 | 1.2 + Keccak_x4 + PQClean fixes + endianness fix | 1            |                    3 | 0xff01       | 1.3.6.1.4.1.62245.2.1.14    |
+| CROSSrsdpg192small                                | 1.2 + Keccak_x4 + PQClean fixes + endianness fix | 1            |                    3 | 0xff02       | 1.3.6.1.4.1.62245.2.1.15    |
+| CROSSrsdpg256balanced                             | 1.2 + Keccak_x4 + PQClean fixes + endianness fix | 1            |                    5 | 0xff03       | 1.3.6.1.4.1.62245.2.1.16    |
+| CROSSrsdpg256fast                                 | 1.2 + Keccak_x4 + PQClean fixes + endianness fix | 1            |                    5 | 0xff04       | 1.3.6.1.4.1.62245.2.1.17    |
+| CROSSrsdpg256small                                | 1.2 + Keccak_x4 + PQClean fixes + endianness fix | 1            |                    5 | 0xff05       | 1.3.6.1.4.1.62245.2.1.18    |
+| dilithium2                                        | 3.1                                              | 3            |                    2 | 0xfea0       | 1.3.6.1.4.1.2.267.7.4.4     |
+| dilithium2 **hybrid with** p256                   | 3.1                                              | 3            |                    2 | 0xfea1       | 1.3.9999.2.7.1              |
+| dilithium2 **hybrid with** rsa3072                | 3.1                                              | 3            |                    2 | 0xfea2       | 1.3.9999.2.7.2              |
+| dilithium3                                        | 3.1                                              | 3            |                    3 | 0xfea3       | 1.3.6.1.4.1.2.267.7.6.5     |
+| dilithium3 **hybrid with** p384                   | 3.1                                              | 3            |                    3 | 0xfea4       | 1.3.9999.2.7.3              |
+| dilithium5                                        | 3.1                                              | 3            |                    5 | 0xfea5       | 1.3.6.1.4.1.2.267.7.8.7     |
+| dilithium5 **hybrid with** p521                   | 3.1                                              | 3            |                    5 | 0xfea6       | 1.3.9999.2.7.4              |
+| dilithium2_aes                                    | NIST Round 3 submission                          | 3            |                    2 | 0xfea7       | 1.3.6.1.4.1.2.267.11.4.4    |
+| dilithium2_aes **hybrid with** p256               | NIST Round 3 submission                          | 3            |                    2 | 0xfea8       | 1.3.9999.2.11.1             |
+| dilithium2_aes **hybrid with** rsa3072            | NIST Round 3 submission                          | 3            |                    2 | 0xfea9       | 1.3.9999.2.11.2             |
+| dilithium3_aes                                    | NIST Round 3 submission                          | 3            |                    3 | 0xfeaa       | 1.3.6.1.4.1.2.267.11.6.5    |
+| dilithium3_aes **hybrid with** p384               | NIST Round 3 submission                          | 3            |                    3 | 0xfeab       | 1.3.9999.2.11.3             |
+| dilithium5_aes                                    | NIST Round 3 submission                          | 3            |                    5 | 0xfeac       | 1.3.6.1.4.1.2.267.11.8.7    |
+| dilithium5_aes **hybrid with** p521               | NIST Round 3 submission                          | 3            |                    5 | 0xfead       | 1.3.9999.2.11.4             |
+| falcon512                                         | 20211101                                         | 3            |                    1 | 0xfed7       | 1.3.9999.3.11               |
+| falcon512 **hybrid with** p256                    | 20211101                                         | 3            |                    1 | 0xfed8       | 1.3.9999.3.12               |
+| falcon512 **hybrid with** rsa3072                 | 20211101                                         | 3            |                    1 | 0xfed9       | 1.3.9999.3.13               |
+| falcon512                                         | PQClean Round 3 version labelled 20211101        | 3            |                    1 | 0xfeae       | 1.3.9999.3.6                |
+| falcon512 **hybrid with** p256                    | PQClean Round 3 version labelled 20211101        | 3            |                    1 | 0xfeaf       | 1.3.9999.3.7                |
+| falcon512 **hybrid with** rsa3072                 | PQClean Round 3 version labelled 20211101        | 3            |                    1 | 0xfeb0       | 1.3.9999.3.8                |
+| falcon512                                         | NIST Round 3 submission                          | 3            |                    1 | 0xfe0b       | 1.3.9999.3.1                |
+| falcon512 **hybrid with** p256                    | NIST Round 3 submission                          | 3            |                    1 | 0xfe0c       | 1.3.9999.3.2                |
+| falcon512 **hybrid with** rsa3072                 | NIST Round 3 submission                          | 3            |                    1 | 0xfe0d       | 1.3.9999.3.3                |
+| falconpadded512                                   | 20211101                                         | 3            |                    1 | 0xfedc       | 1.3.9999.3.16               |
+| falconpadded512 **hybrid with** p256              | 20211101                                         | 3            |                    1 | 0xfedd       | 1.3.9999.3.17               |
+| falconpadded512 **hybrid with** rsa3072           | 20211101                                         | 3            |                    1 | 0xfede       | 1.3.9999.3.18               |
+| falcon1024                                        | 20211101                                         | 3            |                    5 | 0xfeda       | 1.3.9999.3.14               |
+| falcon1024 **hybrid with** p521                   | 20211101                                         | 3            |                    5 | 0xfedb       | 1.3.9999.3.15               |
+| falcon1024                                        | PQClean Round 3 version labelled 20211101        | 3            |                    5 | 0xfeb1       | 1.3.9999.3.9                |
+| falcon1024 **hybrid with** p521                   | PQClean Round 3 version labelled 20211101        | 3            |                    5 | 0xfeb2       | 1.3.9999.3.10               |
+| falcon1024                                        | NIST Round 3 submission                          | 3            |                    5 | 0xfe0e       | 1.3.9999.3.4                |
+| falcon1024 **hybrid with** p521                   | NIST Round 3 submission                          | 3            |                    5 | 0xfe0f       | 1.3.9999.3.5                |
+| falconpadded1024                                  | 20211101                                         | 3            |                    5 | 0xfedf       | 1.3.9999.3.19               |
+| falconpadded1024 **hybrid with** p521             | 20211101                                         | 3            |                    5 | 0xfee0       | 1.3.9999.3.20               |
+| mayo1                                             | https://doi.org/10.46586/tches.v2024.i2.252-275  | 1            |                    1 | 0xfeee       | 1.3.9999.8.1.1              |
+| mayo1 **hybrid with** p256                        | https://doi.org/10.46586/tches.v2024.i2.252-275  | 1            |                    1 | 0xfef2       | 1.3.9999.8.1.2              |
+| mayo2                                             | https://doi.org/10.46586/tches.v2024.i2.252-275  | 1            |                    1 | 0xfeef       | 1.3.9999.8.2.1              |
+| mayo2 **hybrid with** p256                        | https://doi.org/10.46586/tches.v2024.i2.252-275  | 1            |                    1 | 0xfef3       | 1.3.9999.8.2.2              |
+| mayo3                                             | https://doi.org/10.46586/tches.v2024.i2.252-275  | 1            |                    3 | 0xfef0       | 1.3.9999.8.3.1              |
+| mayo3 **hybrid with** p384                        | https://doi.org/10.46586/tches.v2024.i2.252-275  | 1            |                    3 | 0xfef4       | 1.3.9999.8.3.2              |
+| mayo5                                             | https://doi.org/10.46586/tches.v2024.i2.252-275  | 1            |                    5 | 0xfef1       | 1.3.9999.8.5.1              |
+| mayo5 **hybrid with** p521                        | https://doi.org/10.46586/tches.v2024.i2.252-275  | 1            |                    5 | 0xfef5       | 1.3.9999.8.5.2              |
+| mldsa44                                           | ML-DSA                                           | FIPS204      |                    1 | 0xfed0       | 1.3.6.1.4.1.2.267.12.4.4    |
+| mldsa44 **hybrid with** p256                      | ML-DSA                                           | FIPS204      |                    1 | 0xfed3       | 1.3.9999.7.1                |
+| mldsa44 **hybrid with** rsa3072                   | ML-DSA                                           | FIPS204      |                    1 | 0xfed4       | 1.3.9999.7.2                |
+| mldsa44 **composite with** pss2048                | ML-DSA                                           | FIPS204      |                    1 | 0xfee1       | 2.16.840.1.114027.80.8.1.1  |
+| mldsa44 **composite with** rsa2048                | ML-DSA                                           | FIPS204      |                    1 | 0xfee2       | 2.16.840.1.114027.80.8.1.2  |
+| mldsa44 **composite with** ed25519                | ML-DSA                                           | FIPS204      |                    1 | 0xfee3       | 2.16.840.1.114027.80.8.1.3  |
+| mldsa44 **composite with** p256                   | ML-DSA                                           | FIPS204      |                    1 | 0xfee4       | 2.16.840.1.114027.80.8.1.4  |
+| mldsa44 **composite with** bp256                  | ML-DSA                                           | FIPS204      |                    1 | 0xfee5       | 2.16.840.1.114027.80.8.1.5  |
+| mldsa65                                           | ML-DSA                                           | FIPS204      |                    3 | 0xfed1       | 1.3.6.1.4.1.2.267.12.6.5    |
+| mldsa65 **hybrid with** p384                      | ML-DSA                                           | FIPS204      |                    3 | 0xfed5       | 1.3.9999.7.3                |
+| mldsa65 **composite with** pss3072                | ML-DSA                                           | FIPS204      |                    3 | 0xfee6       | 2.16.840.1.114027.80.8.1.6  |
+| mldsa65 **composite with** rsa3072                | ML-DSA                                           | FIPS204      |                    3 | 0xfee7       | 2.16.840.1.114027.80.8.1.7  |
+| mldsa65 **composite with** p256                   | ML-DSA                                           | FIPS204      |                    3 | 0xfee8       | 2.16.840.1.114027.80.8.1.8  |
+| mldsa65 **composite with** bp256                  | ML-DSA                                           | FIPS204      |                    3 | 0xfee9       | 2.16.840.1.114027.80.8.1.9  |
+| mldsa65 **composite with** ed25519                | ML-DSA                                           | FIPS204      |                    3 | 0xfeea       | 2.16.840.1.114027.80.8.1.10 |
+| mldsa87                                           | ML-DSA                                           | FIPS204      |                    5 | 0xfed2       | 1.3.6.1.4.1.2.267.12.8.7    |
+| mldsa87 **hybrid with** p521                      | ML-DSA                                           | FIPS204      |                    5 | 0xfed6       | 1.3.9999.7.4                |
+| mldsa87 **composite with** p384                   | ML-DSA                                           | FIPS204      |                    5 | 0xfeeb       | 2.16.840.1.114027.80.8.1.11 |
+| mldsa87 **composite with** bp384                  | ML-DSA                                           | FIPS204      |                    5 | 0xfeec       | 2.16.840.1.114027.80.8.1.12 |
+| mldsa87 **composite with** ed448                  | ML-DSA                                           | FIPS204      |                    5 | 0xfeed       | 2.16.840.1.114027.80.8.1.13 |
+| sphincsharaka128frobust                           | NIST Round 3 submission                          | 3            |                    1 | 0xfe42       | 1.3.9999.6.1.1              |
+| sphincsharaka128frobust **hybrid with** p256      | NIST Round 3 submission                          | 3            |                    1 | 0xfe43       | 1.3.9999.6.1.2              |
+| sphincsharaka128frobust **hybrid with** rsa3072   | NIST Round 3 submission                          | 3            |                    1 | 0xfe44       | 1.3.9999.6.1.3              |
+| sphincsharaka128fsimple                           | NIST Round 3 submission                          | 3            |                    1 | 0xfe45       | 1.3.9999.6.1.4              |
+| sphincsharaka128fsimple **hybrid with** p256      | NIST Round 3 submission                          | 3            |                    1 | 0xfe46       | 1.3.9999.6.1.5              |
+| sphincsharaka128fsimple **hybrid with** rsa3072   | NIST Round 3 submission                          | 3            |                    1 | 0xfe47       | 1.3.9999.6.1.6              |
+| sphincsharaka128srobust                           | NIST Round 3 submission                          | 3            |                    1 | 0xfe48       | 1.3.9999.6.1.7              |
+| sphincsharaka128srobust **hybrid with** p256      | NIST Round 3 submission                          | 3            |                    1 | 0xfe49       | 1.3.9999.6.1.8              |
+| sphincsharaka128srobust **hybrid with** rsa3072   | NIST Round 3 submission                          | 3            |                    1 | 0xfe4a       | 1.3.9999.6.1.9              |
+| sphincsharaka128ssimple                           | NIST Round 3 submission                          | 3            |                    1 | 0xfe4b       | 1.3.9999.6.1.10             |
+| sphincsharaka128ssimple **hybrid with** p256      | NIST Round 3 submission                          | 3            |                    1 | 0xfe4c       | 1.3.9999.6.1.11             |
+| sphincsharaka128ssimple **hybrid with** rsa3072   | NIST Round 3 submission                          | 3            |                    1 | 0xfe4d       | 1.3.9999.6.1.12             |
+| sphincsharaka192frobust                           | NIST Round 3 submission                          | 3            |                    3 | 0xfe4e       | 1.3.9999.6.2.1              |
+| sphincsharaka192frobust **hybrid with** p384      | NIST Round 3 submission                          | 3            |                    3 | 0xfe4f       | 1.3.9999.6.2.2              |
+| sphincsharaka192fsimple                           | NIST Round 3 submission                          | 3            |                    3 | 0xfe50       | 1.3.9999.6.2.3              |
+| sphincsharaka192fsimple **hybrid with** p384      | NIST Round 3 submission                          | 3            |                    3 | 0xfe51       | 1.3.9999.6.2.4              |
+| sphincsharaka192srobust                           | NIST Round 3 submission                          | 3            |                    3 | 0xfe52       | 1.3.9999.6.2.5              |
+| sphincsharaka192srobust **hybrid with** p384      | NIST Round 3 submission                          | 3            |                    3 | 0xfe53       | 1.3.9999.6.2.6              |
+| sphincsharaka192ssimple                           | NIST Round 3 submission                          | 3            |                    3 | 0xfe54       | 1.3.9999.6.2.7              |
+| sphincsharaka192ssimple **hybrid with** p384      | NIST Round 3 submission                          | 3            |                    3 | 0xfe55       | 1.3.9999.6.2.8              |
+| sphincsharaka256frobust                           | NIST Round 3 submission                          | 3            |                    3 | 0xfe56       | 1.3.9999.6.3.1              |
+| sphincsharaka256frobust **hybrid with** p521      | NIST Round 3 submission                          | 3            |                    3 | 0xfe57       | 1.3.9999.6.3.2              |
+| sphincsharaka256fsimple                           | NIST Round 3 submission                          | 3            |                    5 | 0xfe58       | 1.3.9999.6.3.3              |
+| sphincsharaka256fsimple **hybrid with** p521      | NIST Round 3 submission                          | 3            |                    5 | 0xfe59       | 1.3.9999.6.3.4              |
+| sphincsharaka256srobust                           | NIST Round 3 submission                          | 3            |                    5 | 0xfe5a       | 1.3.9999.6.3.5              |
+| sphincsharaka256srobust **hybrid with** p521      | NIST Round 3 submission                          | 3            |                    5 | 0xfe5b       | 1.3.9999.6.3.6              |
+| sphincsharaka256ssimple                           | NIST Round 3 submission                          | 3            |                    5 | 0xfe5c       | 1.3.9999.6.3.7              |
+| sphincsharaka256ssimple **hybrid with** p521      | NIST Round 3 submission                          | 3            |                    5 | 0xfe5d       | 1.3.9999.6.3.8              |
+| sphincssha26128frobust                            | NIST Round 3 submission                          | 3            |                    5 | 0xfe5e       | 1.3.9999.6.4.1              |
+| sphincssha26128frobust **hybrid with** p256       | NIST Round 3 submission                          | 3            |                    5 | 0xfe5f       | 1.3.9999.6.4.2              |
+| sphincssha26128frobust **hybrid with** rsa3072    | NIST Round 3 submission                          | 3            |                    5 | 0xfe60       | 1.3.9999.6.4.3              |
+| sphincssha2128fsimple                             | NIST Round 3 submission, v3.1 (June 10, 2022)    | 3            |                    1 | 0xfeb3       | 1.3.9999.6.4.13             |
+| sphincssha2128fsimple **hybrid with** p256        | NIST Round 3 submission, v3.1 (June 10, 2022)    | 3            |                    1 | 0xfeb4       | 1.3.9999.6.4.14             |
+| sphincssha2128fsimple **hybrid with** rsa3072     | NIST Round 3 submission, v3.1 (June 10, 2022)    | 3            |                    1 | 0xfeb5       | 1.3.9999.6.4.15             |
+| sphincssha2128fsimple                             | NIST Round 3 submission                          | 3            |                    1 | 0xfe61       | 1.3.9999.6.4.4              |
+| sphincssha2128fsimple **hybrid with** p256        | NIST Round 3 submission                          | 3            |                    1 | 0xfe62       | 1.3.9999.6.4.5              |
+| sphincssha2128fsimple **hybrid with** rsa3072     | NIST Round 3 submission                          | 3            |                    1 | 0xfe63       | 1.3.9999.6.4.6              |
+| sphincssha256128srobust                           | NIST Round 3 submission                          | 3            |                    5 | 0xfe64       | 1.3.9999.6.4.7              |
+| sphincssha256128srobust **hybrid with** p256      | NIST Round 3 submission                          | 3            |                    5 | 0xfe65       | 1.3.9999.6.4.8              |
+| sphincssha256128srobust **hybrid with** rsa3072   | NIST Round 3 submission                          | 3            |                    5 | 0xfe66       | 1.3.9999.6.4.9              |
+| sphincssha2128ssimple                             | NIST Round 3 submission, v3.1 (June 10, 2022)    | 3            |                    1 | 0xfeb6       | 1.3.9999.6.4.16             |
+| sphincssha2128ssimple **hybrid with** p256        | NIST Round 3 submission, v3.1 (June 10, 2022)    | 3            |                    1 | 0xfeb7       | 1.3.9999.6.4.17             |
+| sphincssha2128ssimple **hybrid with** rsa3072     | NIST Round 3 submission, v3.1 (June 10, 2022)    | 3            |                    1 | 0xfeb8       | 1.3.9999.6.4.18             |
+| sphincssha2128ssimple                             | NIST Round 3 submission                          | 3            |                    1 | 0xfe67       | 1.3.9999.6.4.10             |
+| sphincssha2128ssimple **hybrid with** p256        | NIST Round 3 submission                          | 3            |                    1 | 0xfe68       | 1.3.9999.6.4.11             |
+| sphincssha2128ssimple **hybrid with** rsa3072     | NIST Round 3 submission                          | 3            |                    1 | 0xfe69       | 1.3.9999.6.4.12             |
+| sphincssha256192frobust                           | NIST Round 3 submission                          | 3            |                    5 | 0xfe6a       | 1.3.9999.6.5.1              |
+| sphincssha256192frobust **hybrid with** p384      | NIST Round 3 submission                          | 3            |                    5 | 0xfe6b       | 1.3.9999.6.5.2              |
+| sphincssha2192fsimple                             | NIST Round 3 submission, v3.1 (June 10, 2022)    | 3            |                    3 | 0xfeb9       | 1.3.9999.6.5.10             |
+| sphincssha2192fsimple **hybrid with** p384        | NIST Round 3 submission, v3.1 (June 10, 2022)    | 3            |                    3 | 0xfeba       | 1.3.9999.6.5.11             |
+| sphincssha2192fsimple                             | NIST Round 3 submission                          | 3            |                    3 | 0xfe6c       | 1.3.9999.6.5.3              |
+| sphincssha2192fsimple **hybrid with** p384        | NIST Round 3 submission                          | 3            |                    3 | 0xfe6d       | 1.3.9999.6.5.4              |
+| sphincssha256192srobust                           | NIST Round 3 submission                          | 3            |                    5 | 0xfe6e       | 1.3.9999.6.5.5              |
+| sphincssha256192srobust **hybrid with** p384      | NIST Round 3 submission                          | 3            |                    5 | 0xfe6f       | 1.3.9999.6.5.6              |
+| sphincssha2192ssimple                             | NIST Round 3 submission, v3.1 (June 10, 2022)    | 3            |                    3 | 0xfebb       | 1.3.9999.6.5.12             |
+| sphincssha2192ssimple **hybrid with** p384        | NIST Round 3 submission, v3.1 (June 10, 2022)    | 3            |                    3 | 0xfebc       | 1.3.9999.6.5.13             |
+| sphincssha2192ssimple                             | NIST Round 3 submission                          | 3            |                    3 | 0xfe70       | 1.3.9999.6.5.7              |
+| sphincssha2192ssimple **hybrid with** p384        | NIST Round 3 submission                          | 3            |                    3 | 0xfe71       | 1.3.9999.6.5.8              |
+| sphincssha256256frobust                           | NIST Round 3 submission                          | 3            |                    5 | 0xfe72       | 1.3.9999.6.6.1              |
+| sphincssha256256frobust **hybrid with** p521      | NIST Round 3 submission                          | 3            |                    5 | 0xfe73       | 1.3.9999.6.6.2              |
+| sphincssha2256fsimple                             | NIST Round 3 submission, v3.1 (June 10, 2022)    | 3            |                    5 | 0xfebd       | 1.3.9999.6.6.10             |
+| sphincssha2256fsimple **hybrid with** p521        | NIST Round 3 submission, v3.1 (June 10, 2022)    | 3            |                    5 | 0xfebe       | 1.3.9999.6.6.11             |
+| sphincssha2256fsimple                             | NIST Round 3 submission                          | 3            |                    5 | 0xfe74       | 1.3.9999.6.6.3              |
+| sphincssha2256fsimple **hybrid with** p521        | NIST Round 3 submission                          | 3            |                    5 | 0xfe75       | 1.3.9999.6.6.4              |
+| sphincssha256256srobust                           | NIST Round 3 submission                          | 3            |                    5 | 0xfe76       | 1.3.9999.6.6.5              |
+| sphincssha256256srobust **hybrid with** p521      | NIST Round 3 submission                          | 3            |                    5 | 0xfe77       | 1.3.9999.6.6.6              |
+| sphincssha2256ssimple                             | NIST Round 3 submission, v3.1 (June 10, 2022)    | 3            |                    5 | 0xfec0       | 1.3.9999.6.6.12             |
+| sphincssha2256ssimple **hybrid with** p521        | NIST Round 3 submission, v3.1 (June 10, 2022)    | 3            |                    5 | 0xfec1       | 1.3.9999.6.6.13             |
+| sphincssha2256ssimple                             | NIST Round 3 submission                          | 3            |                    5 | 0xfe78       | 1.3.9999.6.6.7              |
+| sphincssha2256ssimple **hybrid with** p521        | NIST Round 3 submission                          | 3            |                    5 | 0xfe79       | 1.3.9999.6.6.8              |
+| sphincsshake256128frobust                         | NIST Round 3 submission                          | 3            |                    1 | 0xfe7a       | 1.3.9999.6.7.1              |
+| sphincsshake256128frobust **hybrid with** p256    | NIST Round 3 submission                          | 3            |                    1 | 0xfe7b       | 1.3.9999.6.7.2              |
+| sphincsshake256128frobust **hybrid with** rsa3072 | NIST Round 3 submission                          | 3            |                    1 | 0xfe7c       | 1.3.9999.6.7.3              |
+| sphincsshake128fsimple                            | NIST Round 3 submission, v3.1 (June 10, 2022)    | 3            |                    1 | 0xfec2       | 1.3.9999.6.7.13             |
+| sphincsshake128fsimple **hybrid with** p256       | NIST Round 3 submission, v3.1 (June 10, 2022)    | 3            |                    1 | 0xfec3       | 1.3.9999.6.7.14             |
+| sphincsshake128fsimple **hybrid with** rsa3072    | NIST Round 3 submission, v3.1 (June 10, 2022)    | 3            |                    1 | 0xfec4       | 1.3.9999.6.7.15             |
+| sphincsshake128fsimple                            | NIST Round 3 submission                          | 3            |                    1 | 0xfe7d       | 1.3.9999.6.7.4              |
+| sphincsshake128fsimple **hybrid with** p256       | NIST Round 3 submission                          | 3            |                    1 | 0xfe7e       | 1.3.9999.6.7.5              |
+| sphincsshake128fsimple **hybrid with** rsa3072    | NIST Round 3 submission                          | 3            |                    1 | 0xfe7f       | 1.3.9999.6.7.6              |
+| sphincsshake256128srobust                         | NIST Round 3 submission                          | 3            |                    1 | 0xfe80       | 1.3.9999.6.7.7              |
+| sphincsshake256128srobust **hybrid with** p256    | NIST Round 3 submission                          | 3            |                    1 | 0xfe81       | 1.3.9999.6.7.8              |
+| sphincsshake256128srobust **hybrid with** rsa3072 | NIST Round 3 submission                          | 3            |                    1 | 0xfe82       | 1.3.9999.6.7.9              |
+| sphincsshake128ssimple                            | NIST Round 3 submission, v3.1 (June 10, 2022)    | 3            |                    1 | 0xfec5       | 1.3.9999.6.7.16             |
+| sphincsshake128ssimple **hybrid with** p256       | NIST Round 3 submission, v3.1 (June 10, 2022)    | 3            |                    1 | 0xfec6       | 1.3.9999.6.7.17             |
+| sphincsshake128ssimple **hybrid with** rsa3072    | NIST Round 3 submission, v3.1 (June 10, 2022)    | 3            |                    1 | 0xfec7       | 1.3.9999.6.7.18             |
+| sphincsshake128ssimple                            | NIST Round 3 submission                          | 3            |                    1 | 0xfe83       | 1.3.9999.6.7.10             |
+| sphincsshake128ssimple **hybrid with** p256       | NIST Round 3 submission                          | 3            |                    1 | 0xfe84       | 1.3.9999.6.7.11             |
+| sphincsshake128ssimple **hybrid with** rsa3072    | NIST Round 3 submission                          | 3            |                    1 | 0xfe85       | 1.3.9999.6.7.12             |
+| sphincsshake256192frobust                         | NIST Round 3 submission                          | 3            |                    3 | 0xfe86       | 1.3.9999.6.8.1              |
+| sphincsshake256192frobust **hybrid with** p384    | NIST Round 3 submission                          | 3            |                    3 | 0xfe87       | 1.3.9999.6.8.2              |
+| sphincsshake192fsimple                            | NIST Round 3 submission, v3.1 (June 10, 2022)    | 3            |                    3 | 0xfec8       | 1.3.9999.6.8.10             |
+| sphincsshake192fsimple **hybrid with** p384       | NIST Round 3 submission, v3.1 (June 10, 2022)    | 3            |                    3 | 0xfec9       | 1.3.9999.6.8.11             |
+| sphincsshake192fsimple                            | NIST Round 3 submission                          | 3            |                    3 | 0xfe88       | 1.3.9999.6.8.3              |
+| sphincsshake192fsimple **hybrid with** p384       | NIST Round 3 submission                          | 3            |                    3 | 0xfe89       | 1.3.9999.6.8.4              |
+| sphincsshake256192srobust                         | NIST Round 3 submission                          | 3            |                    3 | 0xfe8a       | 1.3.9999.6.8.5              |
+| sphincsshake256192srobust **hybrid with** p384    | NIST Round 3 submission                          | 3            |                    3 | 0xfe8b       | 1.3.9999.6.8.6              |
+| sphincsshake192ssimple                            | NIST Round 3 submission, v3.1 (June 10, 2022)    | 3            |                    3 | 0xfeca       | 1.3.9999.6.8.12             |
+| sphincsshake192ssimple **hybrid with** p384       | NIST Round 3 submission, v3.1 (June 10, 2022)    | 3            |                    3 | 0xfecb       | 1.3.9999.6.8.13             |
+| sphincsshake192ssimple                            | NIST Round 3 submission                          | 3            |                    3 | 0xfe8c       | 1.3.9999.6.8.7              |
+| sphincsshake192ssimple **hybrid with** p384       | NIST Round 3 submission                          | 3            |                    3 | 0xfe8d       | 1.3.9999.6.8.8              |
+| sphincsshake256256frobust                         | NIST Round 3 submission                          | 3            |                    5 | 0xfe8e       | 1.3.9999.6.9.1              |
+| sphincsshake256256frobust **hybrid with** p521    | NIST Round 3 submission                          | 3            |                    5 | 0xfe8f       | 1.3.9999.6.9.2              |
+| sphincsshake256fsimple                            | NIST Round 3 submission, v3.1 (June 10, 2022)    | 3            |                    5 | 0xfecc       | 1.3.9999.6.9.10             |
+| sphincsshake256fsimple **hybrid with** p521       | NIST Round 3 submission, v3.1 (June 10, 2022)    | 3            |                    5 | 0xfecd       | 1.3.9999.6.9.11             |
+| sphincsshake256fsimple                            | NIST Round 3 submission                          | 3            |                    5 | 0xfe90       | 1.3.9999.6.9.3              |
+| sphincsshake256fsimple **hybrid with** p521       | NIST Round 3 submission                          | 3            |                    5 | 0xfe91       | 1.3.9999.6.9.4              |
+| sphincsshake256256srobust                         | NIST Round 3 submission                          | 3            |                    5 | 0xfe92       | 1.3.9999.6.9.5              |
+| sphincsshake256256srobust **hybrid with** p521    | NIST Round 3 submission                          | 3            |                    5 | 0xfe93       | 1.3.9999.6.9.6              |
+| sphincsshake256ssimple                            | NIST Round 3 submission, v3.1 (June 10, 2022)    | 3            |                    5 | 0xfece       | 1.3.9999.6.9.12             |
+| sphincsshake256ssimple **hybrid with** p521       | NIST Round 3 submission, v3.1 (June 10, 2022)    | 3            |                    5 | 0xfecf       | 1.3.9999.6.9.13             |
+| sphincsshake256ssimple                            | NIST Round 3 submission                          | 3            |                    5 | 0xfe94       | 1.3.9999.6.9.7              |
+| sphincsshake256ssimple **hybrid with** p521       | NIST Round 3 submission                          | 3            |                    5 | 0xfe95       | 1.3.9999.6.9.8              |

--- a/oqsprov/oqsprov_capabilities.c
+++ b/oqsprov/oqsprov_capabilities.c
@@ -35,15 +35,15 @@ typedef struct oqs_group_constants_st {
 static OQS_GROUP_CONSTANTS oqs_group_list[] = {
     // ad-hoc assignments - take from OQS generate data structures
     ///// OQS_TEMPLATE_FRAGMENT_GROUP_ASSIGNMENTS_START
-    {0x0200, 128, TLS1_3_VERSION, 0, -1, -1, 1},
+    {65024, 128, TLS1_3_VERSION, 0, -1, -1, 1},
 
     {0x2F00, 128, TLS1_3_VERSION, 0, -1, -1, 1},
     {0x2F80, 128, TLS1_3_VERSION, 0, -1, -1, 1},
-    {0x0201, 128, TLS1_3_VERSION, 0, -1, -1, 1},
+    {65025, 128, TLS1_3_VERSION, 0, -1, -1, 1},
 
     {0x2F01, 128, TLS1_3_VERSION, 0, -1, -1, 1},
     {0x2F81, 128, TLS1_3_VERSION, 0, -1, -1, 1},
-    {0x0202, 192, TLS1_3_VERSION, 0, -1, -1, 1},
+    {65026, 192, TLS1_3_VERSION, 0, -1, -1, 1},
 
     {0x2F02, 192, TLS1_3_VERSION, 0, -1, -1, 1},
     {0x2F82, 192, TLS1_3_VERSION, 0, -1, -1, 1},
@@ -70,17 +70,17 @@ static OQS_GROUP_CONSTANTS oqs_group_list[] = {
     {0x023D, 256, TLS1_3_VERSION, 0, -1, -1, 1},
 
     {0x2F3D, 256, TLS1_3_VERSION, 0, -1, -1, 1},
-    {261, 128, TLS1_3_VERSION, 0, -1, -1, 1},
+    {512, 128, TLS1_3_VERSION, 0, -1, -1, 1},
 
     {0x2F4B, 128, TLS1_3_VERSION, 0, -1, -1, 1},
     {0x2FB6, 128, TLS1_3_VERSION, 0, -1, -1, 1},
-    {262, 192, TLS1_3_VERSION, 0, -1, -1, 1},
+    {513, 192, TLS1_3_VERSION, 0, -1, -1, 1},
 
     {0x2F4C, 192, TLS1_3_VERSION, 0, -1, -1, 1},
     {0x2FB7, 192, TLS1_3_VERSION, 0, -1, -1, 1},
     {0x11ec, 192, TLS1_3_VERSION, 0, -1, -1, 1},
     {0x11eb, 192, TLS1_3_VERSION, 0, -1, -1, 1},
-    {263, 256, TLS1_3_VERSION, 0, -1, -1, 1},
+    {514, 256, TLS1_3_VERSION, 0, -1, -1, 1},
 
     {0x2F4D, 256, TLS1_3_VERSION, 0, -1, -1, 1},
     {0x2F4E, 256, TLS1_3_VERSION, 0, -1, -1, 1},

--- a/scripts/oqsprovider-externalinterop.sh
+++ b/scripts/oqsprovider-externalinterop.sh
@@ -28,13 +28,14 @@ fi
 
 # Ascertain algorithms are available:
 
-echo " Cloudflare:"
-
-if ! ($OPENSSL_APP list -kem-algorithms | grep x25519_kyber768); then
-   echo "Skipping unconfigured x25519_kyber768 interop test"
-else
-   (echo -e "GET /cdn-cgi/trace HTTP/1.1\nHost: cloudflare.com\n\n"; sleep 1; echo $'\cc') | "${OPENSSL_APP}" s_client ${USE_PROXY} -connect pq.cloudflareresearch.com:443 -groups x25519_kyber768 -servername cloudflare.com -ign_eof 2>/dev/null | grep kex=X25519Kyber768Draft00
-fi
+# Cloudflare seems to have disabled this algorithm: Remove for good?
+# echo " Cloudflare:"
+# 
+# if ! ($OPENSSL_APP list -kem-algorithms | grep x25519_kyber768); then
+#    echo "Skipping unconfigured x25519_kyber768 interop test"
+# else
+#    (echo -e "GET /cdn-cgi/trace HTTP/1.1\nHost: cloudflare.com\n\n"; sleep 1; echo $'\cc') | "${OPENSSL_APP}" s_client ${USE_PROXY} -connect pq.cloudflareresearch.com:443 -groups x25519_kyber768 -servername cloudflare.com -ign_eof 2>/dev/null | grep kex=X25519Kyber768Draft00
+# fi
 
 echo " Google:"
 


### PR DESCRIPTION
Fixes #556

- Also integrates latest upstream sig changes
- Also disables testing Cloudflare interop with deprecated Kyber
