### PR TITLE
Adding version-conditional context string support

### DIFF
--- a/.github/workflows/coding_style.yml
+++ b/.github/workflows/coding_style.yml
@@ -18,3 +18,17 @@ jobs:
 
       - name: Check coding style using clang-format
         run: ./scripts/do_code_format.sh
+
+      - name: Verify nothing changes on re-generate code
+        run: |
+          git config --global user.name "ciuser" && \
+          git clone https://github.com/open-quantum-safe/liboqs.git && \
+          git config --global user.email "ci@openquantumsafe.org" && \
+          git config --global --add safe.directory `pwd` && \
+          export LIBOQS_SRC_DIR=`pwd`/liboqs && \
+          ! pip3 install -r oqs-template/requirements.txt 2>&1 | grep ERROR && \
+          python3 oqs-template/generate.py && \
+          ./scripts/do_code_format.sh --no-dry-run && \
+          git diff && \
+          ! git status | grep modified
+

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -73,6 +73,8 @@ jobs:
           export LIBOQS_SRC_DIR=`pwd`/liboqs && \
           ! pip3 install -r oqs-template/requirements.txt 2>&1 | grep ERROR && \
           python3 oqs-template/generate.py
+      - name: Full re-build
+        run: rm -rf _build && ./scripts/fullbuild.sh
       - name: Build .deb install package
         run: cpack -C DebPack
         working-directory: _build

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -64,7 +64,7 @@ jobs:
         run: cd _build/lib && ln -s oqsprovider.so oqsprovider2.so
       - name: Test
         run: ./scripts/runtests.sh -V
-      - name: Verify nothing changes on re-generate code
+      - name: Re-generate code
         run: |
           apt-get update && apt-get install -y clang-format && \
           git config --global user.name "ciuser" && \
@@ -72,10 +72,7 @@ jobs:
           git config --global --add safe.directory `pwd` && \
           export LIBOQS_SRC_DIR=`pwd`/liboqs && \
           ! pip3 install -r oqs-template/requirements.txt 2>&1 | grep ERROR && \
-          python3 oqs-template/generate.py && \
-          ./scripts/do_code_format.sh --no-dry-run && \
-          git diff && \
-          ! git status | grep modified
+          python3 oqs-template/generate.py
       - name: Build .deb install package
         run: cpack -C DebPack
         working-directory: _build

--- a/README.md
+++ b/README.md
@@ -144,7 +144,9 @@ Also not fully supported in 3.0.2 is performance testing as per the openssl
 
 These versions have full support for all TLS1.3 operations using PQ algorithms
 when deploying `oqsprovider`, particularly with regard to the use of signature
-algorithms.
+algorithms. This also includes support for the "OSSL_SIGNATURE_PARAM_CONTEXT_STRING"
+parameter that had not been supported before and for which limited support in
+single PQ algorithms is available since `liboqs` version 0.12.
 
 ## 3.4 and greater
 

--- a/oqsprov/oqs_sig.c
+++ b/oqsprov/oqs_sig.c
@@ -519,15 +519,18 @@ static int oqs_sig_sign(void *vpoqs_sigctx, unsigned char *sig, size_t *siglen,
                 oqs_sig_len = oqsxkey->oqsx_provider_ctx.oqsx_qs_ctx.sig
                                   ->length_signature;
                 buf = OPENSSL_malloc(oqs_sig_len);
-#if !defined OQS_VERSION_MINOR || (OQS_VERSION_MAJOR == 0 && OQS_VERSION_MINOR < 12)
+#if !defined OQS_VERSION_MINOR ||                                              \
+    (OQS_VERSION_MAJOR == 0 && OQS_VERSION_MINOR < 12)
                 if (OQS_SIG_sign(oqs_key, buf, &oqs_sig_len,
                                  (const unsigned char *)final_tbs, final_tbslen,
                                  oqsxkey->comp_privkey[i]) != OQS_SUCCESS) {
 #else
-                if (OQS_SIG_sign_with_ctx_str(oqs_key, buf, &oqs_sig_len,
-                                 (const unsigned char *)final_tbs, final_tbslen,
-                                 poqs_sigctx->context_string, poqs_sigctx->context_string_length,
-                                 oqsxkey->comp_privkey[i]) != OQS_SUCCESS) {
+                if (OQS_SIG_sign_with_ctx_str(
+                        oqs_key, buf, &oqs_sig_len,
+                        (const unsigned char *)final_tbs, final_tbslen,
+                        poqs_sigctx->context_string,
+                        poqs_sigctx->context_string_length,
+                        oqsxkey->comp_privkey[i]) != OQS_SUCCESS) {
 #endif
                     ERR_raise(ERR_LIB_USER, OQSPROV_R_SIGNING_FAILED);
                     CompositeSignature_free(compsig);
@@ -675,11 +678,14 @@ static int oqs_sig_sign(void *vpoqs_sigctx, unsigned char *sig, size_t *siglen,
 
         CompositeSignature_free(compsig);
         OPENSSL_free(final_tbs);
-#if !defined OQS_VERSION_MINOR || (OQS_VERSION_MAJOR == 0 && OQS_VERSION_MINOR < 12)
+#if !defined OQS_VERSION_MINOR ||                                              \
+    (OQS_VERSION_MAJOR == 0 && OQS_VERSION_MINOR < 12)
     } else if (OQS_SIG_sign(oqs_key, sig + index, &oqs_sig_len, tbs, tbslen,
 #else
-    } else if (OQS_SIG_sign_with_ctx_str(oqs_key, sig + index, &oqs_sig_len, tbs, tbslen,
-                            poqs_sigctx->context_string, poqs_sigctx->context_string_length,
+    } else if (OQS_SIG_sign_with_ctx_str(
+                   oqs_key, sig + index, &oqs_sig_len, tbs, tbslen,
+                   poqs_sigctx->context_string,
+                   poqs_sigctx->context_string_length,
 #endif
                             oqsxkey->comp_privkey[oqsxkey->numkeys - 1]) !=
                OQS_SUCCESS) {
@@ -1316,8 +1322,9 @@ static int oqs_sig_set_ctx_params(void *vpoqs_sigctx,
     }
     p = OSSL_PARAM_locate_const(params, OSSL_SIGNATURE_PARAM_CONTEXT_STRING);
     if (p != NULL) {
-        if (!OSSL_PARAM_get_octet_string(p, &poqs_sigctx->context_string, 0,
-                                         &(poqs_sigctx->context_string_length))) {
+        if (!OSSL_PARAM_get_octet_string(
+                p, &poqs_sigctx->context_string, 0,
+                &(poqs_sigctx->context_string_length))) {
             poqs_sigctx->context_string_length = 0;
             return 0;
         }

--- a/oqsprov/oqs_sig.c
+++ b/oqsprov/oqs_sig.c
@@ -121,6 +121,8 @@ ASN1_NDEF_SEQUENCE(CompositeSignature) =
     size_t mdsize;
     // for collecting data if no MD is active:
     unsigned char *mddata;
+    void *context_string;
+    size_t context_string_length;
     int operation;
 } PROV_OQSSIG_CTX;
 
@@ -517,9 +519,16 @@ static int oqs_sig_sign(void *vpoqs_sigctx, unsigned char *sig, size_t *siglen,
                 oqs_sig_len = oqsxkey->oqsx_provider_ctx.oqsx_qs_ctx.sig
                                   ->length_signature;
                 buf = OPENSSL_malloc(oqs_sig_len);
+#if !defined OQS_VERSION_MINOR || (OQS_VERSION_MAJOR == 0 && OQS_VERSION_MINOR < 12)
                 if (OQS_SIG_sign(oqs_key, buf, &oqs_sig_len,
                                  (const unsigned char *)final_tbs, final_tbslen,
                                  oqsxkey->comp_privkey[i]) != OQS_SUCCESS) {
+#else
+                if (OQS_SIG_sign_with_ctx_str(oqs_key, buf, &oqs_sig_len,
+                                 (const unsigned char *)final_tbs, final_tbslen,
+                                 poqs_sigctx->context_string, poqs_sigctx->context_string_length,
+                                 oqsxkey->comp_privkey[i]) != OQS_SUCCESS) {
+#endif
                     ERR_raise(ERR_LIB_USER, OQSPROV_R_SIGNING_FAILED);
                     CompositeSignature_free(compsig);
                     OPENSSL_free(final_tbs);
@@ -666,7 +675,12 @@ static int oqs_sig_sign(void *vpoqs_sigctx, unsigned char *sig, size_t *siglen,
 
         CompositeSignature_free(compsig);
         OPENSSL_free(final_tbs);
+#if !defined OQS_VERSION_MINOR || (OQS_VERSION_MAJOR == 0 && OQS_VERSION_MINOR < 12)
     } else if (OQS_SIG_sign(oqs_key, sig + index, &oqs_sig_len, tbs, tbslen,
+#else
+    } else if (OQS_SIG_sign_with_ctx_str(oqs_key, sig + index, &oqs_sig_len, tbs, tbslen,
+                            poqs_sigctx->context_string, poqs_sigctx->context_string_length,
+#endif
                             oqsxkey->comp_privkey[oqsxkey->numkeys - 1]) !=
                OQS_SUCCESS) {
         ERR_raise(ERR_LIB_USER, OQSPROV_R_SIGNING_FAILED);
@@ -1176,6 +1190,7 @@ static void oqs_sig_freectx(void *vpoqs_sigctx) {
     OPENSSL_free(ctx->aid);
     ctx->aid = NULL;
     ctx->aid_len = 0;
+    OPENSSL_free(ctx->context_string);
     OPENSSL_free(ctx);
 }
 
@@ -1299,6 +1314,14 @@ static int oqs_sig_set_ctx_params(void *vpoqs_sigctx,
         if (!oqs_sig_setup_md(poqs_sigctx, mdname, mdprops))
             return 0;
     }
+    p = OSSL_PARAM_locate_const(params, OSSL_SIGNATURE_PARAM_CONTEXT_STRING);
+    if (p != NULL) {
+        if (!OSSL_PARAM_get_octet_string(p, &poqs_sigctx->context_string, 0,
+                                         &(poqs_sigctx->context_string_length))) {
+            poqs_sigctx->context_string_length = 0;
+            return 0;
+        }
+    }
 
     // not passing in parameters we can act on is no error
     return 1;
@@ -1307,6 +1330,7 @@ static int oqs_sig_set_ctx_params(void *vpoqs_sigctx,
 static const OSSL_PARAM known_settable_ctx_params[] = {
     OSSL_PARAM_utf8_string(OSSL_SIGNATURE_PARAM_DIGEST, NULL, 0),
     OSSL_PARAM_utf8_string(OSSL_SIGNATURE_PARAM_PROPERTIES, NULL, 0),
+    OSSL_PARAM_octet_string(OSSL_SIGNATURE_PARAM_CONTEXT_STRING, NULL, 0),
     OSSL_PARAM_END};
 
 static const OSSL_PARAM *

--- a/oqsprov/oqs_sig.c
+++ b/oqsprov/oqs_sig.c
@@ -1320,17 +1320,16 @@ static int oqs_sig_set_ctx_params(void *vpoqs_sigctx,
         if (!oqs_sig_setup_md(poqs_sigctx, mdname, mdprops))
             return 0;
     }
-    if (OPENSSL_VERSION_PREREQ(3, 2)) {
-        p = OSSL_PARAM_locate_const(params,
-                                    OSSL_SIGNATURE_PARAM_CONTEXT_STRING);
-        if (p != NULL) {
-            if (!OSSL_PARAM_get_octet_string(
-                    p, &poqs_sigctx->context_string, 0,
-                    &(poqs_sigctx->context_string_length))) {
-                poqs_sigctx->context_string_length = 0;
-                return 0;
-            }
+#if (OPENSSL_VERSION_PREREQ(3, 2))
+    p = OSSL_PARAM_locate_const(params, OSSL_SIGNATURE_PARAM_CONTEXT_STRING);
+    if (p != NULL) {
+        if (!OSSL_PARAM_get_octet_string(
+                p, &poqs_sigctx->context_string, 0,
+                &(poqs_sigctx->context_string_length))) {
+            poqs_sigctx->context_string_length = 0;
+            return 0;
         }
+#endif
     }
 
     // not passing in parameters we can act on is no error

--- a/oqsprov/oqs_sig.c
+++ b/oqsprov/oqs_sig.c
@@ -1320,13 +1320,16 @@ static int oqs_sig_set_ctx_params(void *vpoqs_sigctx,
         if (!oqs_sig_setup_md(poqs_sigctx, mdname, mdprops))
             return 0;
     }
-    p = OSSL_PARAM_locate_const(params, OSSL_SIGNATURE_PARAM_CONTEXT_STRING);
-    if (p != NULL) {
-        if (!OSSL_PARAM_get_octet_string(
-                p, &poqs_sigctx->context_string, 0,
-                &(poqs_sigctx->context_string_length))) {
-            poqs_sigctx->context_string_length = 0;
-            return 0;
+    if (OPENSSL_VERSION_PREREQ(3, 2)) {
+        p = OSSL_PARAM_locate_const(params,
+                                    OSSL_SIGNATURE_PARAM_CONTEXT_STRING);
+        if (p != NULL) {
+            if (!OSSL_PARAM_get_octet_string(
+                    p, &poqs_sigctx->context_string, 0,
+                    &(poqs_sigctx->context_string_length))) {
+                poqs_sigctx->context_string_length = 0;
+                return 0;
+            }
         }
     }
 
@@ -1337,7 +1340,9 @@ static int oqs_sig_set_ctx_params(void *vpoqs_sigctx,
 static const OSSL_PARAM known_settable_ctx_params[] = {
     OSSL_PARAM_utf8_string(OSSL_SIGNATURE_PARAM_DIGEST, NULL, 0),
     OSSL_PARAM_utf8_string(OSSL_SIGNATURE_PARAM_PROPERTIES, NULL, 0),
+#if (OPENSSL_VERSION_PREREQ(3, 2))
     OSSL_PARAM_octet_string(OSSL_SIGNATURE_PARAM_CONTEXT_STRING, NULL, 0),
+#endif
     OSSL_PARAM_END};
 
 static const OSSL_PARAM *

--- a/oqsprov/oqs_sig.c
+++ b/oqsprov/oqs_sig.c
@@ -1329,8 +1329,8 @@ static int oqs_sig_set_ctx_params(void *vpoqs_sigctx,
             poqs_sigctx->context_string_length = 0;
             return 0;
         }
-#endif
     }
+#endif
 
     // not passing in parameters we can act on is no error
     return 1;


### PR DESCRIPTION
This also acts as a test for the new `liboqs` version define feature by conditionally enabling context string support during signature operations for plain PQ algorithms supporting that feature and in openssl versions also supporting that feature.
