### PR TITLE
Add CI to test against demos

### DIFF
--- a/.github/workflows/demos.yml
+++ b/.github/workflows/demos.yml
@@ -1,0 +1,15 @@
+name: Build & Test OQS Demos
+
+on:
+  push:
+    branches: [ 'main' ]
+  pull_request:
+    branches: [ 'main' ]
+
+jobs:
+  call:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: open-quantum-safe/oqs-demos/.github/workflows/build.yml@f12ff66fb78d00208aa4dac613be71beba2dc5ec
+        with:
+          build_main: true


### PR DESCRIPTION
As @baentsch  mentioned in https://github.com/open-quantum-safe/oqs-demos/pull/321#issuecomment-2530767025 we would like to add "upstream" CI that will build and test the OQS demos using the latest liboqs and oqsprovider code
