### PR TITLE
limit testing to oqsprovider

### DIFF
--- a/test/oqs_test_endecode.c
+++ b/test/oqs_test_endecode.c
@@ -16,7 +16,9 @@
 static OSSL_LIB_CTX *libctx = NULL;
 static char *modulename = NULL;
 static char *configfile = NULL;
-static char *testpropq = NULL;
+// as different providers may support different key formats, limit testing to
+// oqsprovider
+static char *testpropq = "provider=oqsprovider";
 static OSSL_LIB_CTX *keyctx = NULL;
 static OSSL_LIB_CTX *testctx = NULL;
 

--- a/test/oqs_test_evp_pkey_params.c
+++ b/test/oqs_test_evp_pkey_params.c
@@ -172,7 +172,9 @@ static OSSL_LIB_CTX *init_openssl(void) {
 static EVP_PKEY_CTX *init_EVP_PKEY_CTX(OSSL_LIB_CTX *libctx, const char *alg) {
     EVP_PKEY_CTX *ctx;
 
-    if (!(ctx = EVP_PKEY_CTX_new_from_name(libctx, alg, NULL))) {
+    // make sure we only test oqsprovider
+    if (!(ctx = EVP_PKEY_CTX_new_from_name(libctx, alg,
+                                           "provider=oqsprovider"))) {
         fprintf(stderr,
                 cRED "`EVP_PKEY_CTX_new_from_name` failed with algorithm %s: ",
                 alg);

--- a/test/oqs_test_kems.c
+++ b/test/oqs_test_kems.c
@@ -27,12 +27,13 @@ static int test_oqs_kems(const char *kemalg_name) {
         return 1;
     }
     // test with built-in digest only if default provider is active:
-    // TBD revisit when hybrids are activated: They always need default
-    // provider
+    // limit testing to oqsprovider as other implementations may support
+    // different key formats than what is defined by NIST
     if (OSSL_PROVIDER_available(libctx, "default")) {
-        testresult &= (ctx = EVP_PKEY_CTX_new_from_name(libctx, kemalg_name,
-                                                        NULL)) != NULL &&
-                      EVP_PKEY_keygen_init(ctx) && EVP_PKEY_generate(ctx, &key);
+        testresult &=
+            (ctx = EVP_PKEY_CTX_new_from_name(
+                 libctx, kemalg_name, "provider=oqsprovider")) != NULL &&
+            EVP_PKEY_keygen_init(ctx) && EVP_PKEY_generate(ctx, &key);
 
         if (!testresult)
             goto err;

--- a/test/oqs_test_signatures.c
+++ b/test/oqs_test_signatures.c
@@ -34,6 +34,9 @@ static int test_oqs_signatures(const char *sigalg_name) {
     // TBD revisit when hybrids are activated: They always need default
     // provider
     if (OSSL_PROVIDER_available(libctx, "default")) {
+        // XXX testing omits passing propq limited to oqsprovider for now
+        // as sig key formats area reasonably stable; revisit as and when
+        // this changes to only test against itself
         testresult &=
             (ctx = EVP_PKEY_CTX_new_from_name(libctx, sigalg_name, NULL)) !=
                 NULL &&
@@ -62,6 +65,10 @@ static int test_oqs_signatures(const char *sigalg_name) {
     OPENSSL_free(sig);
     mdctx = NULL;
     key = NULL;
+
+    // XXX testing omits passing propq limited to oqsprovider for now
+    // as sig key formats area reasonably stable; revisit as and when
+    // this changes to only test against itself
 
     // this test must work also with default provider inactive:
     testresult &=

--- a/test/oqs_test_signatures.c
+++ b/test/oqs_test_signatures.c
@@ -34,12 +34,9 @@ static int test_oqs_signatures(const char *sigalg_name) {
     // TBD revisit when hybrids are activated: They always need default
     // provider
     if (OSSL_PROVIDER_available(libctx, "default")) {
-        // XXX testing omits passing propq limited to oqsprovider for now
-        // as sig key formats area reasonably stable; revisit as and when
-        // this changes to only test against itself
         testresult &=
-            (ctx = EVP_PKEY_CTX_new_from_name(libctx, sigalg_name, NULL)) !=
-                NULL &&
+            (ctx = EVP_PKEY_CTX_new_from_name(
+                 libctx, sigalg_name, "provider=oqsprovider")) != NULL &&
             EVP_PKEY_keygen_init(ctx) && EVP_PKEY_generate(ctx, &key) &&
             (mdctx = EVP_MD_CTX_new()) != NULL &&
             EVP_DigestSignInit_ex(mdctx, NULL, "SHA512", libctx, NULL, key,
@@ -66,13 +63,10 @@ static int test_oqs_signatures(const char *sigalg_name) {
     mdctx = NULL;
     key = NULL;
 
-    // XXX testing omits passing propq limited to oqsprovider for now
-    // as sig key formats area reasonably stable; revisit as and when
-    // this changes to only test against itself
-
     // this test must work also with default provider inactive:
     testresult &=
-        (ctx = EVP_PKEY_CTX_new_from_name(libctx, sigalg_name, NULL)) != NULL &&
+        (ctx = EVP_PKEY_CTX_new_from_name(libctx, sigalg_name,
+                                          "provider=oqsprovider")) != NULL &&
         EVP_PKEY_keygen_init(ctx) && EVP_PKEY_generate(ctx, &key) &&
         (mdctx = EVP_MD_CTX_new()) != NULL &&
         EVP_DigestSignInit_ex(mdctx, NULL, NULL, libctx, NULL, key, NULL) &&

--- a/test/tlstest_helpers.c
+++ b/test/tlstest_helpers.c
@@ -7,6 +7,7 @@
 /* Stolen from openssl/tests/sslapitest.c: */
 int create_cert_key(OSSL_LIB_CTX *libctx, char *algname, char *certfilename,
                     char *privkeyfilename) {
+    // do test against any provider as handshaking should work with any provider
     EVP_PKEY_CTX *evpctx = EVP_PKEY_CTX_new_from_name(libctx, algname, NULL);
     EVP_PKEY *pkey = NULL;
     X509 *x509 = X509_new();

--- a/test/tlstest_helpers.c
+++ b/test/tlstest_helpers.c
@@ -7,8 +7,8 @@
 /* Stolen from openssl/tests/sslapitest.c: */
 int create_cert_key(OSSL_LIB_CTX *libctx, char *algname, char *certfilename,
                     char *privkeyfilename) {
-    // do test against any provider as handshaking should work with any provider
-    EVP_PKEY_CTX *evpctx = EVP_PKEY_CTX_new_from_name(libctx, algname, NULL);
+    EVP_PKEY_CTX *evpctx =
+        EVP_PKEY_CTX_new_from_name(libctx, algname, "provider=oqsprovider");
     EVP_PKEY *pkey = NULL;
     X509 *x509 = X509_new();
     X509_NAME *name = NULL;


### PR DESCRIPTION
Fixes #609 .

Question to the community, particularly @mattcaswell @t8m @SWilson4 : Should we limit all testing to `oqsprovider` or still allow interaction with other implementations for the same algorithms in different providers (propq==NULL) as is still possible for some tests as per this PR? See also #610 .

Advantage: Other code also gets tested.
Disadvantage: `oqsprovider` code may not get tested.

The latter leads me to prefer extending this PR to limit all testing completely to `provider=oqsprovider` and not just of experimental features that are OQS-specific as with this the PR as done initially.