### PR TITLE
chore: update GitHub actions

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -80,7 +80,7 @@ jobs:
         run: cpack -C DebPack
         working-directory: _build
       - name: Retain .deb installer
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: oqsprovider-x64
           path: _build/*.deb
@@ -251,7 +251,7 @@ jobs:
             dpkg -I oqs-provider-*.deb | grep -q "Architecture: arm64"
 
       - name: Retain .deb installer
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: oqsprovider-aarch64
           path: build/*.deb

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -84,7 +84,7 @@ jobs:
             fi'
         working-directory: scripts
       - name: Retain oqsprovider.dylib
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: oqs-provider-${{matrix.os}}-x64
           path: _build/lib/oqsprovider.dylib

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -98,7 +98,7 @@ jobs:
         run: bash -c "echo $PATH && PATH=/opt/openssl32/bin:/usr/bin ctest -V"
         working-directory: _build
       - name: Retain oqsprovider.dll
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: oqs-provider-cygwin
           path: D:/a/oqs-provider/oqs-provider/_build/bin/oqsprovider.dll
@@ -209,7 +209,7 @@ jobs:
         run: |
           ctest -V --test-dir _build
       - name: Retain oqsprovider.dll
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: oqs-provider-msvc
           path: D:/a/oqs-provider/oqs-provider/_build/lib/oqsprovider.dll
@@ -315,7 +315,7 @@ jobs:
           run: |
             ctest --test-dir _build -C ${{ matrix.type }}
         - name: Retain oqsprovider.dll
-          uses: actions/upload-artifact@v3
+          uses: actions/upload-artifact@v4
           with:
             name: oqs-provider-msvc
             path: D:/a/oqs-provider/oqs-provider/_build/lib/oqsprovider.dll


### PR DESCRIPTION
The actions upload-artifact@v3 and download-artifact@v3 have been deprecated.

Fixes #618