### PR TITLE
restrict libctx test to oqsprovider

### DIFF
--- a/test/oqs_test_endecode.c
+++ b/test/oqs_test_endecode.c
@@ -16,9 +16,6 @@
 static OSSL_LIB_CTX *libctx = NULL;
 static char *modulename = NULL;
 static char *configfile = NULL;
-// as different providers may support different key formats, limit testing to
-// oqsprovider
-static char *testpropq = "provider=oqsprovider";
 static OSSL_LIB_CTX *keyctx = NULL;
 static OSSL_LIB_CTX *testctx = NULL;
 
@@ -64,8 +61,8 @@ static EVP_PKEY *oqstest_make_key(const char *type, EVP_PKEY *template,
     }
 
     ctx = (template != NULL)
-              ? EVP_PKEY_CTX_new_from_pkey(keyctx, template, testpropq)
-              : EVP_PKEY_CTX_new_from_name(keyctx, type, testpropq);
+              ? EVP_PKEY_CTX_new_from_pkey(keyctx, template, OQSPROV_PROPQ)
+              : EVP_PKEY_CTX_new_from_name(keyctx, type, OQSPROV_PROPQ);
 
     /*
      * No real need to check the errors other than for the cascade

--- a/test/oqs_test_evp_pkey_params.c
+++ b/test/oqs_test_evp_pkey_params.c
@@ -63,9 +63,7 @@ static OSSL_LIB_CTX *init_openssl(void) {
 static EVP_PKEY_CTX *init_EVP_PKEY_CTX(OSSL_LIB_CTX *libctx, const char *alg) {
     EVP_PKEY_CTX *ctx;
 
-    // make sure we only test oqsprovider
-    if (!(ctx = EVP_PKEY_CTX_new_from_name(libctx, alg,
-                                           "provider=oqsprovider"))) {
+    if (!(ctx = EVP_PKEY_CTX_new_from_name(libctx, alg, OQSPROV_PROPQ))) {
         fprintf(stderr,
                 cRED "`EVP_PKEY_CTX_new_from_name` failed with algorithm %s: ",
                 alg);

--- a/test/oqs_test_kems.c
+++ b/test/oqs_test_kems.c
@@ -30,10 +30,9 @@ static int test_oqs_kems(const char *kemalg_name) {
     // limit testing to oqsprovider as other implementations may support
     // different key formats than what is defined by NIST
     if (OSSL_PROVIDER_available(libctx, "default")) {
-        testresult &=
-            (ctx = EVP_PKEY_CTX_new_from_name(
-                 libctx, kemalg_name, "provider=oqsprovider")) != NULL &&
-            EVP_PKEY_keygen_init(ctx) && EVP_PKEY_generate(ctx, &key);
+        testresult &= (ctx = EVP_PKEY_CTX_new_from_name(
+                           libctx, kemalg_name, OQSPROV_PROPQ)) != NULL &&
+                      EVP_PKEY_keygen_init(ctx) && EVP_PKEY_generate(ctx, &key);
 
         if (!testresult)
             goto err;
@@ -41,7 +40,8 @@ static int test_oqs_kems(const char *kemalg_name) {
         ctx = NULL;
 
         testresult &=
-            (ctx = EVP_PKEY_CTX_new_from_pkey(libctx, key, NULL)) != NULL &&
+            (ctx = EVP_PKEY_CTX_new_from_pkey(libctx, key, OQSPROV_PROPQ)) !=
+                NULL &&
             EVP_PKEY_encapsulate_init(ctx, NULL) &&
             EVP_PKEY_encapsulate(ctx, NULL, &outlen, NULL, &seclen) &&
             (out = OPENSSL_malloc(outlen)) != NULL &&

--- a/test/oqs_test_libctx.c
+++ b/test/oqs_test_libctx.c
@@ -159,7 +159,7 @@ static int oqs_generate_kem_elems(const char *kemalg_name, EVP_PKEY **key,
 
     if (OSSL_PROVIDER_available(libctx, "default")) {
         testresult = (ctx = EVP_PKEY_CTX_new_from_name(libctx, kemalg_name,
-                                                       NULL)) != NULL &&
+                                                       "provider=oqsprovider")) != NULL &&
                      EVP_PKEY_keygen_init(ctx) && EVP_PKEY_generate(ctx, key);
 
         if (!testresult)

--- a/test/oqs_test_libctx.c
+++ b/test/oqs_test_libctx.c
@@ -158,9 +158,10 @@ static int oqs_generate_kem_elems(const char *kemalg_name, EVP_PKEY **key,
     }
 
     if (OSSL_PROVIDER_available(libctx, "default")) {
-        testresult = (ctx = EVP_PKEY_CTX_new_from_name(libctx, kemalg_name,
-                                                       "provider=oqsprovider")) != NULL &&
-                     EVP_PKEY_keygen_init(ctx) && EVP_PKEY_generate(ctx, key);
+        testresult =
+            (ctx = EVP_PKEY_CTX_new_from_name(
+                 libctx, kemalg_name, "provider=oqsprovider")) != NULL &&
+            EVP_PKEY_keygen_init(ctx) && EVP_PKEY_generate(ctx, key);
 
         if (!testresult)
             goto err;

--- a/test/oqs_test_libctx.c
+++ b/test/oqs_test_libctx.c
@@ -158,10 +158,9 @@ static int oqs_generate_kem_elems(const char *kemalg_name, EVP_PKEY **key,
     }
 
     if (OSSL_PROVIDER_available(libctx, "default")) {
-        testresult =
-            (ctx = EVP_PKEY_CTX_new_from_name(
-                 libctx, kemalg_name, "provider=oqsprovider")) != NULL &&
-            EVP_PKEY_keygen_init(ctx) && EVP_PKEY_generate(ctx, key);
+        testresult = (ctx = EVP_PKEY_CTX_new_from_name(
+                          libctx, kemalg_name, OQSPROV_PROPQ)) != NULL &&
+                     EVP_PKEY_keygen_init(ctx) && EVP_PKEY_generate(ctx, key);
 
         if (!testresult)
             goto err;
@@ -169,7 +168,8 @@ static int oqs_generate_kem_elems(const char *kemalg_name, EVP_PKEY **key,
         ctx = NULL;
 
         testresult &=
-            (ctx = EVP_PKEY_CTX_new_from_pkey(libctx, *key, NULL)) != NULL &&
+            (ctx = EVP_PKEY_CTX_new_from_pkey(libctx, *key, OQSPROV_PROPQ)) !=
+                NULL &&
             EVP_PKEY_encapsulate_init(ctx, NULL) &&
             EVP_PKEY_encapsulate(ctx, NULL, outlen, NULL, seclen) &&
             (*out = OPENSSL_malloc(*outlen)) != NULL &&
@@ -210,8 +210,8 @@ static int oqs_generate_sig_elems(const char *sigalg_name, const char *msg,
     }
 
     if (OSSL_PROVIDER_available(libctx, "default")) {
-        testresult = (ctx = EVP_PKEY_CTX_new_from_name(libctx, sigalg_name,
-                                                       NULL)) != NULL &&
+        testresult = (ctx = EVP_PKEY_CTX_new_from_name(
+                          libctx, sigalg_name, OQSPROV_PROPQ)) != NULL &&
                      EVP_PKEY_keygen_init(ctx) && EVP_PKEY_generate(ctx, key) &&
                      (mdctx = EVP_MD_CTX_new()) != NULL &&
                      EVP_DigestSignInit_ex(mdctx, NULL, "SHA512", libctx, NULL,

--- a/test/oqs_test_signatures.c
+++ b/test/oqs_test_signatures.c
@@ -35,8 +35,8 @@ static int test_oqs_signatures(const char *sigalg_name) {
     // provider
     if (OSSL_PROVIDER_available(libctx, "default")) {
         testresult &=
-            (ctx = EVP_PKEY_CTX_new_from_name(
-                 libctx, sigalg_name, "provider=oqsprovider")) != NULL &&
+            (ctx = EVP_PKEY_CTX_new_from_name(libctx, sigalg_name,
+                                              OQSPROV_PROPQ)) != NULL &&
             EVP_PKEY_keygen_init(ctx) && EVP_PKEY_generate(ctx, &key) &&
             (mdctx = EVP_MD_CTX_new()) != NULL &&
             EVP_DigestSignInit_ex(mdctx, NULL, "SHA512", libctx, NULL, key,
@@ -66,7 +66,7 @@ static int test_oqs_signatures(const char *sigalg_name) {
     // this test must work also with default provider inactive:
     testresult &=
         (ctx = EVP_PKEY_CTX_new_from_name(libctx, sigalg_name,
-                                          "provider=oqsprovider")) != NULL &&
+                                          OQSPROV_PROPQ)) != NULL &&
         EVP_PKEY_keygen_init(ctx) && EVP_PKEY_generate(ctx, &key) &&
         (mdctx = EVP_MD_CTX_new()) != NULL &&
         EVP_DigestSignInit_ex(mdctx, NULL, NULL, libctx, NULL, key, NULL) &&

--- a/test/test_common.h
+++ b/test/test_common.h
@@ -4,6 +4,9 @@
 #include <openssl/provider.h>
 #include <stdio.h>
 
+/* limit testing to just this guy */
+#define OQSPROV_PROPQ "provider=oqsprovider"
+
 /* For controlled success */
 #define T(e)                                                                   \
     if (!(e)) {                                                                \

--- a/test/tlstest_helpers.c
+++ b/test/tlstest_helpers.c
@@ -2,13 +2,15 @@
 #include <openssl/err.h>
 #include <openssl/ssl.h>
 
+#include "test_common.h"
+
 #define MAXLOOPS 1000000
 
 /* Stolen from openssl/tests/sslapitest.c: */
 int create_cert_key(OSSL_LIB_CTX *libctx, char *algname, char *certfilename,
                     char *privkeyfilename) {
     EVP_PKEY_CTX *evpctx =
-        EVP_PKEY_CTX_new_from_name(libctx, algname, "provider=oqsprovider");
+        EVP_PKEY_CTX_new_from_name(libctx, algname, OQSPROV_PROPQ);
     EVP_PKEY *pkey = NULL;
     X509 *x509 = X509_new();
     X509_NAME *name = NULL;


### PR DESCRIPTION
Restrict libctx test to `oqsprovider` as it is using `oqsprovider` specific features
