### PR TITLE
update SIG alg info

### DIFF
--- a/oqs-template/oqs-sig-info.md
+++ b/oqs-template/oqs-sig-info.md
@@ -1,192 +1,192 @@
-| Algorithm                                         | Implementation Version                           | NIST round   |   Claimed NIST Level | Code Point   | OID                         |
-|:--------------------------------------------------|:-------------------------------------------------|:-------------|---------------------:|:-------------|:----------------------------|
-| CROSSrsdp128balanced                              | 1.2 + Keccak_x4 + PQClean fixes + endianness fix | 1            |                    1 | 0xfef6       | 1.3.6.1.4.1.62245.2.1.1     |
-| CROSSrsdp128fast                                  | 1.2 + Keccak_x4 + PQClean fixes + endianness fix | 1            |                    1 | 0xfef7       | 1.3.6.1.4.1.62245.2.1.2     |
-| CROSSrsdp128small                                 | 1.2 + Keccak_x4 + PQClean fixes + endianness fix | 1            |                    1 | 0xfef8       | 1.3.6.1.4.1.62245.2.1.3     |
-| CROSSrsdp192balanced                              | 1.2 + Keccak_x4 + PQClean fixes + endianness fix | 1            |                    3 | 0xfef9       | 1.3.6.1.4.1.62245.2.1.4     |
-| CROSSrsdp192fast                                  | 1.2 + Keccak_x4 + PQClean fixes + endianness fix | 1            |                    3 | 0xfefa       | 1.3.6.1.4.1.62245.2.1.5     |
-| CROSSrsdp192small                                 | 1.2 + Keccak_x4 + PQClean fixes + endianness fix | 1            |                    3 | 0xfefb       | 1.3.6.1.4.1.62245.2.1.6     |
-| CROSSrsdp256small                                 | 1.2 + Keccak_x4 + PQClean fixes + endianness fix | 1            |                    5 | 0xfefc       | 1.3.6.1.4.1.62245.2.1.9     |
-| CROSSrsdpg128balanced                             | 1.2 + Keccak_x4 + PQClean fixes + endianness fix | 1            |                    1 | 0xfefd       | 1.3.6.1.4.1.62245.2.1.10    |
-| CROSSrsdpg128fast                                 | 1.2 + Keccak_x4 + PQClean fixes + endianness fix | 1            |                    1 | 0xfefe       | 1.3.6.1.4.1.62245.2.1.11    |
-| CROSSrsdpg128small                                | 1.2 + Keccak_x4 + PQClean fixes + endianness fix | 1            |                    1 | 0xfeff       | 1.3.6.1.4.1.62245.2.1.12    |
-| CROSSrsdpg192balanced                             | 1.2 + Keccak_x4 + PQClean fixes + endianness fix | 1            |                    3 | 0xff00       | 1.3.6.1.4.1.62245.2.1.13    |
-| CROSSrsdpg192fast                                 | 1.2 + Keccak_x4 + PQClean fixes + endianness fix | 1            |                    3 | 0xff01       | 1.3.6.1.4.1.62245.2.1.14    |
-| CROSSrsdpg192small                                | 1.2 + Keccak_x4 + PQClean fixes + endianness fix | 1            |                    3 | 0xff02       | 1.3.6.1.4.1.62245.2.1.15    |
-| CROSSrsdpg256balanced                             | 1.2 + Keccak_x4 + PQClean fixes + endianness fix | 1            |                    5 | 0xff03       | 1.3.6.1.4.1.62245.2.1.16    |
-| CROSSrsdpg256fast                                 | 1.2 + Keccak_x4 + PQClean fixes + endianness fix | 1            |                    5 | 0xff04       | 1.3.6.1.4.1.62245.2.1.17    |
-| CROSSrsdpg256small                                | 1.2 + Keccak_x4 + PQClean fixes + endianness fix | 1            |                    5 | 0xff05       | 1.3.6.1.4.1.62245.2.1.18    |
-| dilithium2                                        | 3.1                                              | 3            |                    2 | 0xfea0       | 1.3.6.1.4.1.2.267.7.4.4     |
-| dilithium2 **hybrid with** p256                   | 3.1                                              | 3            |                    2 | 0xfea1       | 1.3.9999.2.7.1              |
-| dilithium2 **hybrid with** rsa3072                | 3.1                                              | 3            |                    2 | 0xfea2       | 1.3.9999.2.7.2              |
-| dilithium3                                        | 3.1                                              | 3            |                    3 | 0xfea3       | 1.3.6.1.4.1.2.267.7.6.5     |
-| dilithium3 **hybrid with** p384                   | 3.1                                              | 3            |                    3 | 0xfea4       | 1.3.9999.2.7.3              |
-| dilithium5                                        | 3.1                                              | 3            |                    5 | 0xfea5       | 1.3.6.1.4.1.2.267.7.8.7     |
-| dilithium5 **hybrid with** p521                   | 3.1                                              | 3            |                    5 | 0xfea6       | 1.3.9999.2.7.4              |
-| dilithium2_aes                                    | NIST Round 3 submission                          | 3            |                    2 | 0xfea7       | 1.3.6.1.4.1.2.267.11.4.4    |
-| dilithium2_aes **hybrid with** p256               | NIST Round 3 submission                          | 3            |                    2 | 0xfea8       | 1.3.9999.2.11.1             |
-| dilithium2_aes **hybrid with** rsa3072            | NIST Round 3 submission                          | 3            |                    2 | 0xfea9       | 1.3.9999.2.11.2             |
-| dilithium3_aes                                    | NIST Round 3 submission                          | 3            |                    3 | 0xfeaa       | 1.3.6.1.4.1.2.267.11.6.5    |
-| dilithium3_aes **hybrid with** p384               | NIST Round 3 submission                          | 3            |                    3 | 0xfeab       | 1.3.9999.2.11.3             |
-| dilithium5_aes                                    | NIST Round 3 submission                          | 3            |                    5 | 0xfeac       | 1.3.6.1.4.1.2.267.11.8.7    |
-| dilithium5_aes **hybrid with** p521               | NIST Round 3 submission                          | 3            |                    5 | 0xfead       | 1.3.9999.2.11.4             |
-| falcon512                                         | 20211101                                         | 3            |                    1 | 0xfed7       | 1.3.9999.3.11               |
-| falcon512 **hybrid with** p256                    | 20211101                                         | 3            |                    1 | 0xfed8       | 1.3.9999.3.12               |
-| falcon512 **hybrid with** rsa3072                 | 20211101                                         | 3            |                    1 | 0xfed9       | 1.3.9999.3.13               |
-| falcon512                                         | PQClean Round 3 version labelled 20211101        | 3            |                    1 | 0xfeae       | 1.3.9999.3.6                |
-| falcon512 **hybrid with** p256                    | PQClean Round 3 version labelled 20211101        | 3            |                    1 | 0xfeaf       | 1.3.9999.3.7                |
-| falcon512 **hybrid with** rsa3072                 | PQClean Round 3 version labelled 20211101        | 3            |                    1 | 0xfeb0       | 1.3.9999.3.8                |
-| falcon512                                         | NIST Round 3 submission                          | 3            |                    1 | 0xfe0b       | 1.3.9999.3.1                |
-| falcon512 **hybrid with** p256                    | NIST Round 3 submission                          | 3            |                    1 | 0xfe0c       | 1.3.9999.3.2                |
-| falcon512 **hybrid with** rsa3072                 | NIST Round 3 submission                          | 3            |                    1 | 0xfe0d       | 1.3.9999.3.3                |
-| falconpadded512                                   | 20211101                                         | 3            |                    1 | 0xfedc       | 1.3.9999.3.16               |
-| falconpadded512 **hybrid with** p256              | 20211101                                         | 3            |                    1 | 0xfedd       | 1.3.9999.3.17               |
-| falconpadded512 **hybrid with** rsa3072           | 20211101                                         | 3            |                    1 | 0xfede       | 1.3.9999.3.18               |
-| falcon1024                                        | 20211101                                         | 3            |                    5 | 0xfeda       | 1.3.9999.3.14               |
-| falcon1024 **hybrid with** p521                   | 20211101                                         | 3            |                    5 | 0xfedb       | 1.3.9999.3.15               |
-| falcon1024                                        | PQClean Round 3 version labelled 20211101        | 3            |                    5 | 0xfeb1       | 1.3.9999.3.9                |
-| falcon1024 **hybrid with** p521                   | PQClean Round 3 version labelled 20211101        | 3            |                    5 | 0xfeb2       | 1.3.9999.3.10               |
-| falcon1024                                        | NIST Round 3 submission                          | 3            |                    5 | 0xfe0e       | 1.3.9999.3.4                |
-| falcon1024 **hybrid with** p521                   | NIST Round 3 submission                          | 3            |                    5 | 0xfe0f       | 1.3.9999.3.5                |
-| falconpadded1024                                  | 20211101                                         | 3            |                    5 | 0xfedf       | 1.3.9999.3.19               |
-| falconpadded1024 **hybrid with** p521             | 20211101                                         | 3            |                    5 | 0xfee0       | 1.3.9999.3.20               |
-| mayo1                                             | https://doi.org/10.46586/tches.v2024.i2.252-275  | 1            |                    1 | 0xfeee       | 1.3.9999.8.1.1              |
-| mayo1 **hybrid with** p256                        | https://doi.org/10.46586/tches.v2024.i2.252-275  | 1            |                    1 | 0xfef2       | 1.3.9999.8.1.2              |
-| mayo2                                             | https://doi.org/10.46586/tches.v2024.i2.252-275  | 1            |                    1 | 0xfeef       | 1.3.9999.8.2.1              |
-| mayo2 **hybrid with** p256                        | https://doi.org/10.46586/tches.v2024.i2.252-275  | 1            |                    1 | 0xfef3       | 1.3.9999.8.2.2              |
-| mayo3                                             | https://doi.org/10.46586/tches.v2024.i2.252-275  | 1            |                    3 | 0xfef0       | 1.3.9999.8.3.1              |
-| mayo3 **hybrid with** p384                        | https://doi.org/10.46586/tches.v2024.i2.252-275  | 1            |                    3 | 0xfef4       | 1.3.9999.8.3.2              |
-| mayo5                                             | https://doi.org/10.46586/tches.v2024.i2.252-275  | 1            |                    5 | 0xfef1       | 1.3.9999.8.5.1              |
-| mayo5 **hybrid with** p521                        | https://doi.org/10.46586/tches.v2024.i2.252-275  | 1            |                    5 | 0xfef5       | 1.3.9999.8.5.2              |
-| mldsa44                                           | ML-DSA                                           | FIPS204      |                    1 | 0x0904       | 2.16.840.1.101.3.4.3.17     |
-| mldsa44 **hybrid with** p256                      | ML-DSA                                           | FIPS204      |                    1 | 0xff06       | 1.3.9999.7.5                |
-| mldsa44 **hybrid with** rsa3072                   | ML-DSA                                           | FIPS204      |                    1 | 0xff07       | 1.3.9999.7.6                |
-| mldsa44 **composite with** pss2048                | ML-DSA                                           | FIPS204      |                    1 | 0x090f       | 2.16.840.1.114027.80.8.1.1  |
-| mldsa44 **composite with** rsa2048                | ML-DSA                                           | FIPS204      |                    1 | 0x090c       | 2.16.840.1.114027.80.8.1.2  |
-| mldsa44 **composite with** ed25519                | ML-DSA                                           | FIPS204      |                    1 | 0x090a       | 2.16.840.1.114027.80.8.1.3  |
-| mldsa44 **composite with** p256                   | ML-DSA                                           | FIPS204      |                    1 | 0x0907       | 2.16.840.1.114027.80.8.1.4  |
-| mldsa44 **composite with** bp256                  | ML-DSA                                           | FIPS204      |                    1 | 0xfee5       | 2.16.840.1.114027.80.8.1.5  |
-| mldsa65                                           | ML-DSA                                           | FIPS204      |                    3 | 0x0905       | 2.16.840.1.101.3.4.3.18     |
-| mldsa65 **hybrid with** p384                      | ML-DSA                                           | FIPS204      |                    3 | 0xff08       | 1.3.9999.7.7                |
-| mldsa65 **composite with** pss3072                | ML-DSA                                           | FIPS204      |                    3 | 0x0910       | 2.16.840.1.114027.80.8.1.6  |
-| mldsa65 **composite with** rsa3072                | ML-DSA                                           | FIPS204      |                    3 | 0x090d       | 2.16.840.1.114027.80.8.1.7  |
-| mldsa65 **composite with** p256                   | ML-DSA                                           | FIPS204      |                    3 | 0x0908       | 2.16.840.1.114027.80.8.1.8  |
-| mldsa65 **composite with** bp256                  | ML-DSA                                           | FIPS204      |                    3 | 0xfee9       | 2.16.840.1.114027.80.8.1.9  |
-| mldsa65 **composite with** ed25519                | ML-DSA                                           | FIPS204      |                    3 | 0x090b       | 2.16.840.1.114027.80.8.1.10 |
-| mldsa87                                           | ML-DSA                                           | FIPS204      |                    5 | 0x0906       | 2.16.840.1.101.3.4.3.19     |
-| mldsa87 **hybrid with** p521                      | ML-DSA                                           | FIPS204      |                    5 | 0xff09       | 1.3.9999.7.8                |
-| mldsa87 **composite with** p384                   | ML-DSA                                           | FIPS204      |                    5 | 0x0909       | 2.16.840.1.114027.80.8.1.11 |
-| mldsa87 **composite with** bp384                  | ML-DSA                                           | FIPS204      |                    5 | 0xfeec       | 2.16.840.1.114027.80.8.1.12 |
-| mldsa87 **composite with** ed448                  | ML-DSA                                           | FIPS204      |                    5 | 0x0912       | 2.16.840.1.114027.80.8.1.13 |
-| sphincsharaka128frobust                           | NIST Round 3 submission                          | 3            |                    1 | 0xfe42       | 1.3.9999.6.1.1              |
-| sphincsharaka128frobust **hybrid with** p256      | NIST Round 3 submission                          | 3            |                    1 | 0xfe43       | 1.3.9999.6.1.2              |
-| sphincsharaka128frobust **hybrid with** rsa3072   | NIST Round 3 submission                          | 3            |                    1 | 0xfe44       | 1.3.9999.6.1.3              |
-| sphincsharaka128fsimple                           | NIST Round 3 submission                          | 3            |                    1 | 0xfe45       | 1.3.9999.6.1.4              |
-| sphincsharaka128fsimple **hybrid with** p256      | NIST Round 3 submission                          | 3            |                    1 | 0xfe46       | 1.3.9999.6.1.5              |
-| sphincsharaka128fsimple **hybrid with** rsa3072   | NIST Round 3 submission                          | 3            |                    1 | 0xfe47       | 1.3.9999.6.1.6              |
-| sphincsharaka128srobust                           | NIST Round 3 submission                          | 3            |                    1 | 0xfe48       | 1.3.9999.6.1.7              |
-| sphincsharaka128srobust **hybrid with** p256      | NIST Round 3 submission                          | 3            |                    1 | 0xfe49       | 1.3.9999.6.1.8              |
-| sphincsharaka128srobust **hybrid with** rsa3072   | NIST Round 3 submission                          | 3            |                    1 | 0xfe4a       | 1.3.9999.6.1.9              |
-| sphincsharaka128ssimple                           | NIST Round 3 submission                          | 3            |                    1 | 0xfe4b       | 1.3.9999.6.1.10             |
-| sphincsharaka128ssimple **hybrid with** p256      | NIST Round 3 submission                          | 3            |                    1 | 0xfe4c       | 1.3.9999.6.1.11             |
-| sphincsharaka128ssimple **hybrid with** rsa3072   | NIST Round 3 submission                          | 3            |                    1 | 0xfe4d       | 1.3.9999.6.1.12             |
-| sphincsharaka192frobust                           | NIST Round 3 submission                          | 3            |                    3 | 0xfe4e       | 1.3.9999.6.2.1              |
-| sphincsharaka192frobust **hybrid with** p384      | NIST Round 3 submission                          | 3            |                    3 | 0xfe4f       | 1.3.9999.6.2.2              |
-| sphincsharaka192fsimple                           | NIST Round 3 submission                          | 3            |                    3 | 0xfe50       | 1.3.9999.6.2.3              |
-| sphincsharaka192fsimple **hybrid with** p384      | NIST Round 3 submission                          | 3            |                    3 | 0xfe51       | 1.3.9999.6.2.4              |
-| sphincsharaka192srobust                           | NIST Round 3 submission                          | 3            |                    3 | 0xfe52       | 1.3.9999.6.2.5              |
-| sphincsharaka192srobust **hybrid with** p384      | NIST Round 3 submission                          | 3            |                    3 | 0xfe53       | 1.3.9999.6.2.6              |
-| sphincsharaka192ssimple                           | NIST Round 3 submission                          | 3            |                    3 | 0xfe54       | 1.3.9999.6.2.7              |
-| sphincsharaka192ssimple **hybrid with** p384      | NIST Round 3 submission                          | 3            |                    3 | 0xfe55       | 1.3.9999.6.2.8              |
-| sphincsharaka256frobust                           | NIST Round 3 submission                          | 3            |                    3 | 0xfe56       | 1.3.9999.6.3.1              |
-| sphincsharaka256frobust **hybrid with** p521      | NIST Round 3 submission                          | 3            |                    3 | 0xfe57       | 1.3.9999.6.3.2              |
-| sphincsharaka256fsimple                           | NIST Round 3 submission                          | 3            |                    5 | 0xfe58       | 1.3.9999.6.3.3              |
-| sphincsharaka256fsimple **hybrid with** p521      | NIST Round 3 submission                          | 3            |                    5 | 0xfe59       | 1.3.9999.6.3.4              |
-| sphincsharaka256srobust                           | NIST Round 3 submission                          | 3            |                    5 | 0xfe5a       | 1.3.9999.6.3.5              |
-| sphincsharaka256srobust **hybrid with** p521      | NIST Round 3 submission                          | 3            |                    5 | 0xfe5b       | 1.3.9999.6.3.6              |
-| sphincsharaka256ssimple                           | NIST Round 3 submission                          | 3            |                    5 | 0xfe5c       | 1.3.9999.6.3.7              |
-| sphincsharaka256ssimple **hybrid with** p521      | NIST Round 3 submission                          | 3            |                    5 | 0xfe5d       | 1.3.9999.6.3.8              |
-| sphincssha26128frobust                            | NIST Round 3 submission                          | 3            |                    5 | 0xfe5e       | 1.3.9999.6.4.1              |
-| sphincssha26128frobust **hybrid with** p256       | NIST Round 3 submission                          | 3            |                    5 | 0xfe5f       | 1.3.9999.6.4.2              |
-| sphincssha26128frobust **hybrid with** rsa3072    | NIST Round 3 submission                          | 3            |                    5 | 0xfe60       | 1.3.9999.6.4.3              |
-| sphincssha2128fsimple                             | NIST Round 3 submission, v3.1 (June 10, 2022)    | 3            |                    1 | 0xfeb3       | 1.3.9999.6.4.13             |
-| sphincssha2128fsimple **hybrid with** p256        | NIST Round 3 submission, v3.1 (June 10, 2022)    | 3            |                    1 | 0xfeb4       | 1.3.9999.6.4.14             |
-| sphincssha2128fsimple **hybrid with** rsa3072     | NIST Round 3 submission, v3.1 (June 10, 2022)    | 3            |                    1 | 0xfeb5       | 1.3.9999.6.4.15             |
-| sphincssha2128fsimple                             | NIST Round 3 submission                          | 3            |                    1 | 0xfe61       | 1.3.9999.6.4.4              |
-| sphincssha2128fsimple **hybrid with** p256        | NIST Round 3 submission                          | 3            |                    1 | 0xfe62       | 1.3.9999.6.4.5              |
-| sphincssha2128fsimple **hybrid with** rsa3072     | NIST Round 3 submission                          | 3            |                    1 | 0xfe63       | 1.3.9999.6.4.6              |
-| sphincssha256128srobust                           | NIST Round 3 submission                          | 3            |                    5 | 0xfe64       | 1.3.9999.6.4.7              |
-| sphincssha256128srobust **hybrid with** p256      | NIST Round 3 submission                          | 3            |                    5 | 0xfe65       | 1.3.9999.6.4.8              |
-| sphincssha256128srobust **hybrid with** rsa3072   | NIST Round 3 submission                          | 3            |                    5 | 0xfe66       | 1.3.9999.6.4.9              |
-| sphincssha2128ssimple                             | NIST Round 3 submission, v3.1 (June 10, 2022)    | 3            |                    1 | 0xfeb6       | 1.3.9999.6.4.16             |
-| sphincssha2128ssimple **hybrid with** p256        | NIST Round 3 submission, v3.1 (June 10, 2022)    | 3            |                    1 | 0xfeb7       | 1.3.9999.6.4.17             |
-| sphincssha2128ssimple **hybrid with** rsa3072     | NIST Round 3 submission, v3.1 (June 10, 2022)    | 3            |                    1 | 0xfeb8       | 1.3.9999.6.4.18             |
-| sphincssha2128ssimple                             | NIST Round 3 submission                          | 3            |                    1 | 0xfe67       | 1.3.9999.6.4.10             |
-| sphincssha2128ssimple **hybrid with** p256        | NIST Round 3 submission                          | 3            |                    1 | 0xfe68       | 1.3.9999.6.4.11             |
-| sphincssha2128ssimple **hybrid with** rsa3072     | NIST Round 3 submission                          | 3            |                    1 | 0xfe69       | 1.3.9999.6.4.12             |
-| sphincssha256192frobust                           | NIST Round 3 submission                          | 3            |                    5 | 0xfe6a       | 1.3.9999.6.5.1              |
-| sphincssha256192frobust **hybrid with** p384      | NIST Round 3 submission                          | 3            |                    5 | 0xfe6b       | 1.3.9999.6.5.2              |
-| sphincssha2192fsimple                             | NIST Round 3 submission, v3.1 (June 10, 2022)    | 3            |                    3 | 0xfeb9       | 1.3.9999.6.5.10             |
-| sphincssha2192fsimple **hybrid with** p384        | NIST Round 3 submission, v3.1 (June 10, 2022)    | 3            |                    3 | 0xfeba       | 1.3.9999.6.5.11             |
-| sphincssha2192fsimple                             | NIST Round 3 submission                          | 3            |                    3 | 0xfe6c       | 1.3.9999.6.5.3              |
-| sphincssha2192fsimple **hybrid with** p384        | NIST Round 3 submission                          | 3            |                    3 | 0xfe6d       | 1.3.9999.6.5.4              |
-| sphincssha256192srobust                           | NIST Round 3 submission                          | 3            |                    5 | 0xfe6e       | 1.3.9999.6.5.5              |
-| sphincssha256192srobust **hybrid with** p384      | NIST Round 3 submission                          | 3            |                    5 | 0xfe6f       | 1.3.9999.6.5.6              |
-| sphincssha2192ssimple                             | NIST Round 3 submission, v3.1 (June 10, 2022)    | 3            |                    3 | 0xfebb       | 1.3.9999.6.5.12             |
-| sphincssha2192ssimple **hybrid with** p384        | NIST Round 3 submission, v3.1 (June 10, 2022)    | 3            |                    3 | 0xfebc       | 1.3.9999.6.5.13             |
-| sphincssha2192ssimple                             | NIST Round 3 submission                          | 3            |                    3 | 0xfe70       | 1.3.9999.6.5.7              |
-| sphincssha2192ssimple **hybrid with** p384        | NIST Round 3 submission                          | 3            |                    3 | 0xfe71       | 1.3.9999.6.5.8              |
-| sphincssha256256frobust                           | NIST Round 3 submission                          | 3            |                    5 | 0xfe72       | 1.3.9999.6.6.1              |
-| sphincssha256256frobust **hybrid with** p521      | NIST Round 3 submission                          | 3            |                    5 | 0xfe73       | 1.3.9999.6.6.2              |
-| sphincssha2256fsimple                             | NIST Round 3 submission, v3.1 (June 10, 2022)    | 3            |                    5 | 0xfebd       | 1.3.9999.6.6.10             |
-| sphincssha2256fsimple **hybrid with** p521        | NIST Round 3 submission, v3.1 (June 10, 2022)    | 3            |                    5 | 0xfebe       | 1.3.9999.6.6.11             |
-| sphincssha2256fsimple                             | NIST Round 3 submission                          | 3            |                    5 | 0xfe74       | 1.3.9999.6.6.3              |
-| sphincssha2256fsimple **hybrid with** p521        | NIST Round 3 submission                          | 3            |                    5 | 0xfe75       | 1.3.9999.6.6.4              |
-| sphincssha256256srobust                           | NIST Round 3 submission                          | 3            |                    5 | 0xfe76       | 1.3.9999.6.6.5              |
-| sphincssha256256srobust **hybrid with** p521      | NIST Round 3 submission                          | 3            |                    5 | 0xfe77       | 1.3.9999.6.6.6              |
-| sphincssha2256ssimple                             | NIST Round 3 submission, v3.1 (June 10, 2022)    | 3            |                    5 | 0xfec0       | 1.3.9999.6.6.12             |
-| sphincssha2256ssimple **hybrid with** p521        | NIST Round 3 submission, v3.1 (June 10, 2022)    | 3            |                    5 | 0xfec1       | 1.3.9999.6.6.13             |
-| sphincssha2256ssimple                             | NIST Round 3 submission                          | 3            |                    5 | 0xfe78       | 1.3.9999.6.6.7              |
-| sphincssha2256ssimple **hybrid with** p521        | NIST Round 3 submission                          | 3            |                    5 | 0xfe79       | 1.3.9999.6.6.8              |
-| sphincsshake256128frobust                         | NIST Round 3 submission                          | 3            |                    1 | 0xfe7a       | 1.3.9999.6.7.1              |
-| sphincsshake256128frobust **hybrid with** p256    | NIST Round 3 submission                          | 3            |                    1 | 0xfe7b       | 1.3.9999.6.7.2              |
-| sphincsshake256128frobust **hybrid with** rsa3072 | NIST Round 3 submission                          | 3            |                    1 | 0xfe7c       | 1.3.9999.6.7.3              |
-| sphincsshake128fsimple                            | NIST Round 3 submission, v3.1 (June 10, 2022)    | 3            |                    1 | 0xfec2       | 1.3.9999.6.7.13             |
-| sphincsshake128fsimple **hybrid with** p256       | NIST Round 3 submission, v3.1 (June 10, 2022)    | 3            |                    1 | 0xfec3       | 1.3.9999.6.7.14             |
-| sphincsshake128fsimple **hybrid with** rsa3072    | NIST Round 3 submission, v3.1 (June 10, 2022)    | 3            |                    1 | 0xfec4       | 1.3.9999.6.7.15             |
-| sphincsshake128fsimple                            | NIST Round 3 submission                          | 3            |                    1 | 0xfe7d       | 1.3.9999.6.7.4              |
-| sphincsshake128fsimple **hybrid with** p256       | NIST Round 3 submission                          | 3            |                    1 | 0xfe7e       | 1.3.9999.6.7.5              |
-| sphincsshake128fsimple **hybrid with** rsa3072    | NIST Round 3 submission                          | 3            |                    1 | 0xfe7f       | 1.3.9999.6.7.6              |
-| sphincsshake256128srobust                         | NIST Round 3 submission                          | 3            |                    1 | 0xfe80       | 1.3.9999.6.7.7              |
-| sphincsshake256128srobust **hybrid with** p256    | NIST Round 3 submission                          | 3            |                    1 | 0xfe81       | 1.3.9999.6.7.8              |
-| sphincsshake256128srobust **hybrid with** rsa3072 | NIST Round 3 submission                          | 3            |                    1 | 0xfe82       | 1.3.9999.6.7.9              |
-| sphincsshake128ssimple                            | NIST Round 3 submission, v3.1 (June 10, 2022)    | 3            |                    1 | 0xfec5       | 1.3.9999.6.7.16             |
-| sphincsshake128ssimple **hybrid with** p256       | NIST Round 3 submission, v3.1 (June 10, 2022)    | 3            |                    1 | 0xfec6       | 1.3.9999.6.7.17             |
-| sphincsshake128ssimple **hybrid with** rsa3072    | NIST Round 3 submission, v3.1 (June 10, 2022)    | 3            |                    1 | 0xfec7       | 1.3.9999.6.7.18             |
-| sphincsshake128ssimple                            | NIST Round 3 submission                          | 3            |                    1 | 0xfe83       | 1.3.9999.6.7.10             |
-| sphincsshake128ssimple **hybrid with** p256       | NIST Round 3 submission                          | 3            |                    1 | 0xfe84       | 1.3.9999.6.7.11             |
-| sphincsshake128ssimple **hybrid with** rsa3072    | NIST Round 3 submission                          | 3            |                    1 | 0xfe85       | 1.3.9999.6.7.12             |
-| sphincsshake256192frobust                         | NIST Round 3 submission                          | 3            |                    3 | 0xfe86       | 1.3.9999.6.8.1              |
-| sphincsshake256192frobust **hybrid with** p384    | NIST Round 3 submission                          | 3            |                    3 | 0xfe87       | 1.3.9999.6.8.2              |
-| sphincsshake192fsimple                            | NIST Round 3 submission, v3.1 (June 10, 2022)    | 3            |                    3 | 0xfec8       | 1.3.9999.6.8.10             |
-| sphincsshake192fsimple **hybrid with** p384       | NIST Round 3 submission, v3.1 (June 10, 2022)    | 3            |                    3 | 0xfec9       | 1.3.9999.6.8.11             |
-| sphincsshake192fsimple                            | NIST Round 3 submission                          | 3            |                    3 | 0xfe88       | 1.3.9999.6.8.3              |
-| sphincsshake192fsimple **hybrid with** p384       | NIST Round 3 submission                          | 3            |                    3 | 0xfe89       | 1.3.9999.6.8.4              |
-| sphincsshake256192srobust                         | NIST Round 3 submission                          | 3            |                    3 | 0xfe8a       | 1.3.9999.6.8.5              |
-| sphincsshake256192srobust **hybrid with** p384    | NIST Round 3 submission                          | 3            |                    3 | 0xfe8b       | 1.3.9999.6.8.6              |
-| sphincsshake192ssimple                            | NIST Round 3 submission, v3.1 (June 10, 2022)    | 3            |                    3 | 0xfeca       | 1.3.9999.6.8.12             |
-| sphincsshake192ssimple **hybrid with** p384       | NIST Round 3 submission, v3.1 (June 10, 2022)    | 3            |                    3 | 0xfecb       | 1.3.9999.6.8.13             |
-| sphincsshake192ssimple                            | NIST Round 3 submission                          | 3            |                    3 | 0xfe8c       | 1.3.9999.6.8.7              |
-| sphincsshake192ssimple **hybrid with** p384       | NIST Round 3 submission                          | 3            |                    3 | 0xfe8d       | 1.3.9999.6.8.8              |
-| sphincsshake256256frobust                         | NIST Round 3 submission                          | 3            |                    5 | 0xfe8e       | 1.3.9999.6.9.1              |
-| sphincsshake256256frobust **hybrid with** p521    | NIST Round 3 submission                          | 3            |                    5 | 0xfe8f       | 1.3.9999.6.9.2              |
-| sphincsshake256fsimple                            | NIST Round 3 submission, v3.1 (June 10, 2022)    | 3            |                    5 | 0xfecc       | 1.3.9999.6.9.10             |
-| sphincsshake256fsimple **hybrid with** p521       | NIST Round 3 submission, v3.1 (June 10, 2022)    | 3            |                    5 | 0xfecd       | 1.3.9999.6.9.11             |
-| sphincsshake256fsimple                            | NIST Round 3 submission                          | 3            |                    5 | 0xfe90       | 1.3.9999.6.9.3              |
-| sphincsshake256fsimple **hybrid with** p521       | NIST Round 3 submission                          | 3            |                    5 | 0xfe91       | 1.3.9999.6.9.4              |
-| sphincsshake256256srobust                         | NIST Round 3 submission                          | 3            |                    5 | 0xfe92       | 1.3.9999.6.9.5              |
-| sphincsshake256256srobust **hybrid with** p521    | NIST Round 3 submission                          | 3            |                    5 | 0xfe93       | 1.3.9999.6.9.6              |
-| sphincsshake256ssimple                            | NIST Round 3 submission, v3.1 (June 10, 2022)    | 3            |                    5 | 0xfece       | 1.3.9999.6.9.12             |
-| sphincsshake256ssimple **hybrid with** p521       | NIST Round 3 submission, v3.1 (June 10, 2022)    | 3            |                    5 | 0xfecf       | 1.3.9999.6.9.13             |
-| sphincsshake256ssimple                            | NIST Round 3 submission                          | 3            |                    5 | 0xfe94       | 1.3.9999.6.9.7              |
-| sphincsshake256ssimple **hybrid with** p521       | NIST Round 3 submission                          | 3            |                    5 | 0xfe95       | 1.3.9999.6.9.8              |
+| Algorithm                                         | Implementation Version                          | NIST round   |   Claimed NIST Level | Code Point   | OID                         |
+|:--------------------------------------------------|:------------------------------------------------|:-------------|---------------------:|:-------------|:----------------------------|
+| CROSSrsdp128balanced                              | 2.0 + PQClean and OQS patches                   | 2            |                    1 | 0xfef6       | 1.3.6.1.4.1.62245.2.1.1     |
+| CROSSrsdp128fast                                  | 2.0 + PQClean and OQS patches                   | 2            |                    1 | 0xfef7       | 1.3.6.1.4.1.62245.2.1.2     |
+| CROSSrsdp128small                                 | 2.0 + PQClean and OQS patches                   | 2            |                    1 | 0xfef8       | 1.3.6.1.4.1.62245.2.1.3     |
+| CROSSrsdp192balanced                              | 2.0 + PQClean and OQS patches                   | 2            |                    3 | 0xfef9       | 1.3.6.1.4.1.62245.2.1.4     |
+| CROSSrsdp192fast                                  | 2.0 + PQClean and OQS patches                   | 2            |                    3 | 0xfefa       | 1.3.6.1.4.1.62245.2.1.5     |
+| CROSSrsdp192small                                 | 2.0 + PQClean and OQS patches                   | 2            |                    3 | 0xfefb       | 1.3.6.1.4.1.62245.2.1.6     |
+| CROSSrsdp256small                                 | 2.0 + PQClean and OQS patches                   | 2            |                    5 | 0xfefc       | 1.3.6.1.4.1.62245.2.1.9     |
+| CROSSrsdpg128balanced                             | 2.0 + PQClean and OQS patches                   | 2            |                    1 | 0xfefd       | 1.3.6.1.4.1.62245.2.1.10    |
+| CROSSrsdpg128fast                                 | 2.0 + PQClean and OQS patches                   | 2            |                    1 | 0xfefe       | 1.3.6.1.4.1.62245.2.1.11    |
+| CROSSrsdpg128small                                | 2.0 + PQClean and OQS patches                   | 2            |                    1 | 0xfeff       | 1.3.6.1.4.1.62245.2.1.12    |
+| CROSSrsdpg192balanced                             | 2.0 + PQClean and OQS patches                   | 2            |                    3 | 0xff00       | 1.3.6.1.4.1.62245.2.1.13    |
+| CROSSrsdpg192fast                                 | 2.0 + PQClean and OQS patches                   | 2            |                    3 | 0xff01       | 1.3.6.1.4.1.62245.2.1.14    |
+| CROSSrsdpg192small                                | 2.0 + PQClean and OQS patches                   | 2            |                    3 | 0xff02       | 1.3.6.1.4.1.62245.2.1.15    |
+| CROSSrsdpg256balanced                             | 2.0 + PQClean and OQS patches                   | 2            |                    5 | 0xff03       | 1.3.6.1.4.1.62245.2.1.16    |
+| CROSSrsdpg256fast                                 | 2.0 + PQClean and OQS patches                   | 2            |                    5 | 0xff04       | 1.3.6.1.4.1.62245.2.1.17    |
+| CROSSrsdpg256small                                | 2.0 + PQClean and OQS patches                   | 2            |                    5 | 0xff05       | 1.3.6.1.4.1.62245.2.1.18    |
+| dilithium2                                        | 3.1                                             | 3            |                    2 | 0xfea0       | 1.3.6.1.4.1.2.267.7.4.4     |
+| dilithium2 **hybrid with** p256                   | 3.1                                             | 3            |                    2 | 0xfea1       | 1.3.9999.2.7.1              |
+| dilithium2 **hybrid with** rsa3072                | 3.1                                             | 3            |                    2 | 0xfea2       | 1.3.9999.2.7.2              |
+| dilithium3                                        | 3.1                                             | 3            |                    3 | 0xfea3       | 1.3.6.1.4.1.2.267.7.6.5     |
+| dilithium3 **hybrid with** p384                   | 3.1                                             | 3            |                    3 | 0xfea4       | 1.3.9999.2.7.3              |
+| dilithium5                                        | 3.1                                             | 3            |                    5 | 0xfea5       | 1.3.6.1.4.1.2.267.7.8.7     |
+| dilithium5 **hybrid with** p521                   | 3.1                                             | 3            |                    5 | 0xfea6       | 1.3.9999.2.7.4              |
+| dilithium2_aes                                    | NIST Round 3 submission                         | 3            |                    2 | 0xfea7       | 1.3.6.1.4.1.2.267.11.4.4    |
+| dilithium2_aes **hybrid with** p256               | NIST Round 3 submission                         | 3            |                    2 | 0xfea8       | 1.3.9999.2.11.1             |
+| dilithium2_aes **hybrid with** rsa3072            | NIST Round 3 submission                         | 3            |                    2 | 0xfea9       | 1.3.9999.2.11.2             |
+| dilithium3_aes                                    | NIST Round 3 submission                         | 3            |                    3 | 0xfeaa       | 1.3.6.1.4.1.2.267.11.6.5    |
+| dilithium3_aes **hybrid with** p384               | NIST Round 3 submission                         | 3            |                    3 | 0xfeab       | 1.3.9999.2.11.3             |
+| dilithium5_aes                                    | NIST Round 3 submission                         | 3            |                    5 | 0xfeac       | 1.3.6.1.4.1.2.267.11.8.7    |
+| dilithium5_aes **hybrid with** p521               | NIST Round 3 submission                         | 3            |                    5 | 0xfead       | 1.3.9999.2.11.4             |
+| falcon512                                         | 20211101                                        | 3            |                    1 | 0xfed7       | 1.3.9999.3.11               |
+| falcon512 **hybrid with** p256                    | 20211101                                        | 3            |                    1 | 0xfed8       | 1.3.9999.3.12               |
+| falcon512 **hybrid with** rsa3072                 | 20211101                                        | 3            |                    1 | 0xfed9       | 1.3.9999.3.13               |
+| falcon512                                         | PQClean Round 3 version labelled 20211101       | 3            |                    1 | 0xfeae       | 1.3.9999.3.6                |
+| falcon512 **hybrid with** p256                    | PQClean Round 3 version labelled 20211101       | 3            |                    1 | 0xfeaf       | 1.3.9999.3.7                |
+| falcon512 **hybrid with** rsa3072                 | PQClean Round 3 version labelled 20211101       | 3            |                    1 | 0xfeb0       | 1.3.9999.3.8                |
+| falcon512                                         | NIST Round 3 submission                         | 3            |                    1 | 0xfe0b       | 1.3.9999.3.1                |
+| falcon512 **hybrid with** p256                    | NIST Round 3 submission                         | 3            |                    1 | 0xfe0c       | 1.3.9999.3.2                |
+| falcon512 **hybrid with** rsa3072                 | NIST Round 3 submission                         | 3            |                    1 | 0xfe0d       | 1.3.9999.3.3                |
+| falconpadded512                                   | 20211101                                        | 3            |                    1 | 0xfedc       | 1.3.9999.3.16               |
+| falconpadded512 **hybrid with** p256              | 20211101                                        | 3            |                    1 | 0xfedd       | 1.3.9999.3.17               |
+| falconpadded512 **hybrid with** rsa3072           | 20211101                                        | 3            |                    1 | 0xfede       | 1.3.9999.3.18               |
+| falcon1024                                        | 20211101                                        | 3            |                    5 | 0xfeda       | 1.3.9999.3.14               |
+| falcon1024 **hybrid with** p521                   | 20211101                                        | 3            |                    5 | 0xfedb       | 1.3.9999.3.15               |
+| falcon1024                                        | PQClean Round 3 version labelled 20211101       | 3            |                    5 | 0xfeb1       | 1.3.9999.3.9                |
+| falcon1024 **hybrid with** p521                   | PQClean Round 3 version labelled 20211101       | 3            |                    5 | 0xfeb2       | 1.3.9999.3.10               |
+| falcon1024                                        | NIST Round 3 submission                         | 3            |                    5 | 0xfe0e       | 1.3.9999.3.4                |
+| falcon1024 **hybrid with** p521                   | NIST Round 3 submission                         | 3            |                    5 | 0xfe0f       | 1.3.9999.3.5                |
+| falconpadded1024                                  | 20211101                                        | 3            |                    5 | 0xfedf       | 1.3.9999.3.19               |
+| falconpadded1024 **hybrid with** p521             | 20211101                                        | 3            |                    5 | 0xfee0       | 1.3.9999.3.20               |
+| mayo1                                             | https://doi.org/10.46586/tches.v2024.i2.252-275 | 1            |                    1 | 0xfeee       | 1.3.9999.8.1.1              |
+| mayo1 **hybrid with** p256                        | https://doi.org/10.46586/tches.v2024.i2.252-275 | 1            |                    1 | 0xfef2       | 1.3.9999.8.1.2              |
+| mayo2                                             | https://doi.org/10.46586/tches.v2024.i2.252-275 | 1            |                    1 | 0xfeef       | 1.3.9999.8.2.1              |
+| mayo2 **hybrid with** p256                        | https://doi.org/10.46586/tches.v2024.i2.252-275 | 1            |                    1 | 0xfef3       | 1.3.9999.8.2.2              |
+| mayo3                                             | https://doi.org/10.46586/tches.v2024.i2.252-275 | 1            |                    3 | 0xfef0       | 1.3.9999.8.3.1              |
+| mayo3 **hybrid with** p384                        | https://doi.org/10.46586/tches.v2024.i2.252-275 | 1            |                    3 | 0xfef4       | 1.3.9999.8.3.2              |
+| mayo5                                             | https://doi.org/10.46586/tches.v2024.i2.252-275 | 1            |                    5 | 0xfef1       | 1.3.9999.8.5.1              |
+| mayo5 **hybrid with** p521                        | https://doi.org/10.46586/tches.v2024.i2.252-275 | 1            |                    5 | 0xfef5       | 1.3.9999.8.5.2              |
+| mldsa44                                           | ML-DSA                                          | FIPS204      |                    1 | 0x0904       | 2.16.840.1.101.3.4.3.17     |
+| mldsa44 **hybrid with** p256                      | ML-DSA                                          | FIPS204      |                    1 | 0xff06       | 1.3.9999.7.5                |
+| mldsa44 **hybrid with** rsa3072                   | ML-DSA                                          | FIPS204      |                    1 | 0xff07       | 1.3.9999.7.6                |
+| mldsa44 **composite with** pss2048                | ML-DSA                                          | FIPS204      |                    1 | 0x090f       | 2.16.840.1.114027.80.8.1.1  |
+| mldsa44 **composite with** rsa2048                | ML-DSA                                          | FIPS204      |                    1 | 0x090c       | 2.16.840.1.114027.80.8.1.2  |
+| mldsa44 **composite with** ed25519                | ML-DSA                                          | FIPS204      |                    1 | 0x090a       | 2.16.840.1.114027.80.8.1.3  |
+| mldsa44 **composite with** p256                   | ML-DSA                                          | FIPS204      |                    1 | 0x0907       | 2.16.840.1.114027.80.8.1.4  |
+| mldsa44 **composite with** bp256                  | ML-DSA                                          | FIPS204      |                    1 | 0xfee5       | 2.16.840.1.114027.80.8.1.5  |
+| mldsa65                                           | ML-DSA                                          | FIPS204      |                    3 | 0x0905       | 2.16.840.1.101.3.4.3.18     |
+| mldsa65 **hybrid with** p384                      | ML-DSA                                          | FIPS204      |                    3 | 0xff08       | 1.3.9999.7.7                |
+| mldsa65 **composite with** pss3072                | ML-DSA                                          | FIPS204      |                    3 | 0x0910       | 2.16.840.1.114027.80.8.1.6  |
+| mldsa65 **composite with** rsa3072                | ML-DSA                                          | FIPS204      |                    3 | 0x090d       | 2.16.840.1.114027.80.8.1.7  |
+| mldsa65 **composite with** p256                   | ML-DSA                                          | FIPS204      |                    3 | 0x0908       | 2.16.840.1.114027.80.8.1.8  |
+| mldsa65 **composite with** bp256                  | ML-DSA                                          | FIPS204      |                    3 | 0xfee9       | 2.16.840.1.114027.80.8.1.9  |
+| mldsa65 **composite with** ed25519                | ML-DSA                                          | FIPS204      |                    3 | 0x090b       | 2.16.840.1.114027.80.8.1.10 |
+| mldsa87                                           | ML-DSA                                          | FIPS204      |                    5 | 0x0906       | 2.16.840.1.101.3.4.3.19     |
+| mldsa87 **hybrid with** p521                      | ML-DSA                                          | FIPS204      |                    5 | 0xff09       | 1.3.9999.7.8                |
+| mldsa87 **composite with** p384                   | ML-DSA                                          | FIPS204      |                    5 | 0x0909       | 2.16.840.1.114027.80.8.1.11 |
+| mldsa87 **composite with** bp384                  | ML-DSA                                          | FIPS204      |                    5 | 0xfeec       | 2.16.840.1.114027.80.8.1.12 |
+| mldsa87 **composite with** ed448                  | ML-DSA                                          | FIPS204      |                    5 | 0x0912       | 2.16.840.1.114027.80.8.1.13 |
+| sphincsharaka128frobust                           | NIST Round 3 submission                         | 3            |                    1 | 0xfe42       | 1.3.9999.6.1.1              |
+| sphincsharaka128frobust **hybrid with** p256      | NIST Round 3 submission                         | 3            |                    1 | 0xfe43       | 1.3.9999.6.1.2              |
+| sphincsharaka128frobust **hybrid with** rsa3072   | NIST Round 3 submission                         | 3            |                    1 | 0xfe44       | 1.3.9999.6.1.3              |
+| sphincsharaka128fsimple                           | NIST Round 3 submission                         | 3            |                    1 | 0xfe45       | 1.3.9999.6.1.4              |
+| sphincsharaka128fsimple **hybrid with** p256      | NIST Round 3 submission                         | 3            |                    1 | 0xfe46       | 1.3.9999.6.1.5              |
+| sphincsharaka128fsimple **hybrid with** rsa3072   | NIST Round 3 submission                         | 3            |                    1 | 0xfe47       | 1.3.9999.6.1.6              |
+| sphincsharaka128srobust                           | NIST Round 3 submission                         | 3            |                    1 | 0xfe48       | 1.3.9999.6.1.7              |
+| sphincsharaka128srobust **hybrid with** p256      | NIST Round 3 submission                         | 3            |                    1 | 0xfe49       | 1.3.9999.6.1.8              |
+| sphincsharaka128srobust **hybrid with** rsa3072   | NIST Round 3 submission                         | 3            |                    1 | 0xfe4a       | 1.3.9999.6.1.9              |
+| sphincsharaka128ssimple                           | NIST Round 3 submission                         | 3            |                    1 | 0xfe4b       | 1.3.9999.6.1.10             |
+| sphincsharaka128ssimple **hybrid with** p256      | NIST Round 3 submission                         | 3            |                    1 | 0xfe4c       | 1.3.9999.6.1.11             |
+| sphincsharaka128ssimple **hybrid with** rsa3072   | NIST Round 3 submission                         | 3            |                    1 | 0xfe4d       | 1.3.9999.6.1.12             |
+| sphincsharaka192frobust                           | NIST Round 3 submission                         | 3            |                    3 | 0xfe4e       | 1.3.9999.6.2.1              |
+| sphincsharaka192frobust **hybrid with** p384      | NIST Round 3 submission                         | 3            |                    3 | 0xfe4f       | 1.3.9999.6.2.2              |
+| sphincsharaka192fsimple                           | NIST Round 3 submission                         | 3            |                    3 | 0xfe50       | 1.3.9999.6.2.3              |
+| sphincsharaka192fsimple **hybrid with** p384      | NIST Round 3 submission                         | 3            |                    3 | 0xfe51       | 1.3.9999.6.2.4              |
+| sphincsharaka192srobust                           | NIST Round 3 submission                         | 3            |                    3 | 0xfe52       | 1.3.9999.6.2.5              |
+| sphincsharaka192srobust **hybrid with** p384      | NIST Round 3 submission                         | 3            |                    3 | 0xfe53       | 1.3.9999.6.2.6              |
+| sphincsharaka192ssimple                           | NIST Round 3 submission                         | 3            |                    3 | 0xfe54       | 1.3.9999.6.2.7              |
+| sphincsharaka192ssimple **hybrid with** p384      | NIST Round 3 submission                         | 3            |                    3 | 0xfe55       | 1.3.9999.6.2.8              |
+| sphincsharaka256frobust                           | NIST Round 3 submission                         | 3            |                    3 | 0xfe56       | 1.3.9999.6.3.1              |
+| sphincsharaka256frobust **hybrid with** p521      | NIST Round 3 submission                         | 3            |                    3 | 0xfe57       | 1.3.9999.6.3.2              |
+| sphincsharaka256fsimple                           | NIST Round 3 submission                         | 3            |                    5 | 0xfe58       | 1.3.9999.6.3.3              |
+| sphincsharaka256fsimple **hybrid with** p521      | NIST Round 3 submission                         | 3            |                    5 | 0xfe59       | 1.3.9999.6.3.4              |
+| sphincsharaka256srobust                           | NIST Round 3 submission                         | 3            |                    5 | 0xfe5a       | 1.3.9999.6.3.5              |
+| sphincsharaka256srobust **hybrid with** p521      | NIST Round 3 submission                         | 3            |                    5 | 0xfe5b       | 1.3.9999.6.3.6              |
+| sphincsharaka256ssimple                           | NIST Round 3 submission                         | 3            |                    5 | 0xfe5c       | 1.3.9999.6.3.7              |
+| sphincsharaka256ssimple **hybrid with** p521      | NIST Round 3 submission                         | 3            |                    5 | 0xfe5d       | 1.3.9999.6.3.8              |
+| sphincssha26128frobust                            | NIST Round 3 submission                         | 3            |                    5 | 0xfe5e       | 1.3.9999.6.4.1              |
+| sphincssha26128frobust **hybrid with** p256       | NIST Round 3 submission                         | 3            |                    5 | 0xfe5f       | 1.3.9999.6.4.2              |
+| sphincssha26128frobust **hybrid with** rsa3072    | NIST Round 3 submission                         | 3            |                    5 | 0xfe60       | 1.3.9999.6.4.3              |
+| sphincssha2128fsimple                             | NIST Round 3 submission, v3.1 (June 10, 2022)   | 3            |                    1 | 0xfeb3       | 1.3.9999.6.4.13             |
+| sphincssha2128fsimple **hybrid with** p256        | NIST Round 3 submission, v3.1 (June 10, 2022)   | 3            |                    1 | 0xfeb4       | 1.3.9999.6.4.14             |
+| sphincssha2128fsimple **hybrid with** rsa3072     | NIST Round 3 submission, v3.1 (June 10, 2022)   | 3            |                    1 | 0xfeb5       | 1.3.9999.6.4.15             |
+| sphincssha2128fsimple                             | NIST Round 3 submission                         | 3            |                    1 | 0xfe61       | 1.3.9999.6.4.4              |
+| sphincssha2128fsimple **hybrid with** p256        | NIST Round 3 submission                         | 3            |                    1 | 0xfe62       | 1.3.9999.6.4.5              |
+| sphincssha2128fsimple **hybrid with** rsa3072     | NIST Round 3 submission                         | 3            |                    1 | 0xfe63       | 1.3.9999.6.4.6              |
+| sphincssha256128srobust                           | NIST Round 3 submission                         | 3            |                    5 | 0xfe64       | 1.3.9999.6.4.7              |
+| sphincssha256128srobust **hybrid with** p256      | NIST Round 3 submission                         | 3            |                    5 | 0xfe65       | 1.3.9999.6.4.8              |
+| sphincssha256128srobust **hybrid with** rsa3072   | NIST Round 3 submission                         | 3            |                    5 | 0xfe66       | 1.3.9999.6.4.9              |
+| sphincssha2128ssimple                             | NIST Round 3 submission, v3.1 (June 10, 2022)   | 3            |                    1 | 0xfeb6       | 1.3.9999.6.4.16             |
+| sphincssha2128ssimple **hybrid with** p256        | NIST Round 3 submission, v3.1 (June 10, 2022)   | 3            |                    1 | 0xfeb7       | 1.3.9999.6.4.17             |
+| sphincssha2128ssimple **hybrid with** rsa3072     | NIST Round 3 submission, v3.1 (June 10, 2022)   | 3            |                    1 | 0xfeb8       | 1.3.9999.6.4.18             |
+| sphincssha2128ssimple                             | NIST Round 3 submission                         | 3            |                    1 | 0xfe67       | 1.3.9999.6.4.10             |
+| sphincssha2128ssimple **hybrid with** p256        | NIST Round 3 submission                         | 3            |                    1 | 0xfe68       | 1.3.9999.6.4.11             |
+| sphincssha2128ssimple **hybrid with** rsa3072     | NIST Round 3 submission                         | 3            |                    1 | 0xfe69       | 1.3.9999.6.4.12             |
+| sphincssha256192frobust                           | NIST Round 3 submission                         | 3            |                    5 | 0xfe6a       | 1.3.9999.6.5.1              |
+| sphincssha256192frobust **hybrid with** p384      | NIST Round 3 submission                         | 3            |                    5 | 0xfe6b       | 1.3.9999.6.5.2              |
+| sphincssha2192fsimple                             | NIST Round 3 submission, v3.1 (June 10, 2022)   | 3            |                    3 | 0xfeb9       | 1.3.9999.6.5.10             |
+| sphincssha2192fsimple **hybrid with** p384        | NIST Round 3 submission, v3.1 (June 10, 2022)   | 3            |                    3 | 0xfeba       | 1.3.9999.6.5.11             |
+| sphincssha2192fsimple                             | NIST Round 3 submission                         | 3            |                    3 | 0xfe6c       | 1.3.9999.6.5.3              |
+| sphincssha2192fsimple **hybrid with** p384        | NIST Round 3 submission                         | 3            |                    3 | 0xfe6d       | 1.3.9999.6.5.4              |
+| sphincssha256192srobust                           | NIST Round 3 submission                         | 3            |                    5 | 0xfe6e       | 1.3.9999.6.5.5              |
+| sphincssha256192srobust **hybrid with** p384      | NIST Round 3 submission                         | 3            |                    5 | 0xfe6f       | 1.3.9999.6.5.6              |
+| sphincssha2192ssimple                             | NIST Round 3 submission, v3.1 (June 10, 2022)   | 3            |                    3 | 0xfebb       | 1.3.9999.6.5.12             |
+| sphincssha2192ssimple **hybrid with** p384        | NIST Round 3 submission, v3.1 (June 10, 2022)   | 3            |                    3 | 0xfebc       | 1.3.9999.6.5.13             |
+| sphincssha2192ssimple                             | NIST Round 3 submission                         | 3            |                    3 | 0xfe70       | 1.3.9999.6.5.7              |
+| sphincssha2192ssimple **hybrid with** p384        | NIST Round 3 submission                         | 3            |                    3 | 0xfe71       | 1.3.9999.6.5.8              |
+| sphincssha256256frobust                           | NIST Round 3 submission                         | 3            |                    5 | 0xfe72       | 1.3.9999.6.6.1              |
+| sphincssha256256frobust **hybrid with** p521      | NIST Round 3 submission                         | 3            |                    5 | 0xfe73       | 1.3.9999.6.6.2              |
+| sphincssha2256fsimple                             | NIST Round 3 submission, v3.1 (June 10, 2022)   | 3            |                    5 | 0xfebd       | 1.3.9999.6.6.10             |
+| sphincssha2256fsimple **hybrid with** p521        | NIST Round 3 submission, v3.1 (June 10, 2022)   | 3            |                    5 | 0xfebe       | 1.3.9999.6.6.11             |
+| sphincssha2256fsimple                             | NIST Round 3 submission                         | 3            |                    5 | 0xfe74       | 1.3.9999.6.6.3              |
+| sphincssha2256fsimple **hybrid with** p521        | NIST Round 3 submission                         | 3            |                    5 | 0xfe75       | 1.3.9999.6.6.4              |
+| sphincssha256256srobust                           | NIST Round 3 submission                         | 3            |                    5 | 0xfe76       | 1.3.9999.6.6.5              |
+| sphincssha256256srobust **hybrid with** p521      | NIST Round 3 submission                         | 3            |                    5 | 0xfe77       | 1.3.9999.6.6.6              |
+| sphincssha2256ssimple                             | NIST Round 3 submission, v3.1 (June 10, 2022)   | 3            |                    5 | 0xfec0       | 1.3.9999.6.6.12             |
+| sphincssha2256ssimple **hybrid with** p521        | NIST Round 3 submission, v3.1 (June 10, 2022)   | 3            |                    5 | 0xfec1       | 1.3.9999.6.6.13             |
+| sphincssha2256ssimple                             | NIST Round 3 submission                         | 3            |                    5 | 0xfe78       | 1.3.9999.6.6.7              |
+| sphincssha2256ssimple **hybrid with** p521        | NIST Round 3 submission                         | 3            |                    5 | 0xfe79       | 1.3.9999.6.6.8              |
+| sphincsshake256128frobust                         | NIST Round 3 submission                         | 3            |                    1 | 0xfe7a       | 1.3.9999.6.7.1              |
+| sphincsshake256128frobust **hybrid with** p256    | NIST Round 3 submission                         | 3            |                    1 | 0xfe7b       | 1.3.9999.6.7.2              |
+| sphincsshake256128frobust **hybrid with** rsa3072 | NIST Round 3 submission                         | 3            |                    1 | 0xfe7c       | 1.3.9999.6.7.3              |
+| sphincsshake128fsimple                            | NIST Round 3 submission, v3.1 (June 10, 2022)   | 3            |                    1 | 0xfec2       | 1.3.9999.6.7.13             |
+| sphincsshake128fsimple **hybrid with** p256       | NIST Round 3 submission, v3.1 (June 10, 2022)   | 3            |                    1 | 0xfec3       | 1.3.9999.6.7.14             |
+| sphincsshake128fsimple **hybrid with** rsa3072    | NIST Round 3 submission, v3.1 (June 10, 2022)   | 3            |                    1 | 0xfec4       | 1.3.9999.6.7.15             |
+| sphincsshake128fsimple                            | NIST Round 3 submission                         | 3            |                    1 | 0xfe7d       | 1.3.9999.6.7.4              |
+| sphincsshake128fsimple **hybrid with** p256       | NIST Round 3 submission                         | 3            |                    1 | 0xfe7e       | 1.3.9999.6.7.5              |
+| sphincsshake128fsimple **hybrid with** rsa3072    | NIST Round 3 submission                         | 3            |                    1 | 0xfe7f       | 1.3.9999.6.7.6              |
+| sphincsshake256128srobust                         | NIST Round 3 submission                         | 3            |                    1 | 0xfe80       | 1.3.9999.6.7.7              |
+| sphincsshake256128srobust **hybrid with** p256    | NIST Round 3 submission                         | 3            |                    1 | 0xfe81       | 1.3.9999.6.7.8              |
+| sphincsshake256128srobust **hybrid with** rsa3072 | NIST Round 3 submission                         | 3            |                    1 | 0xfe82       | 1.3.9999.6.7.9              |
+| sphincsshake128ssimple                            | NIST Round 3 submission, v3.1 (June 10, 2022)   | 3            |                    1 | 0xfec5       | 1.3.9999.6.7.16             |
+| sphincsshake128ssimple **hybrid with** p256       | NIST Round 3 submission, v3.1 (June 10, 2022)   | 3            |                    1 | 0xfec6       | 1.3.9999.6.7.17             |
+| sphincsshake128ssimple **hybrid with** rsa3072    | NIST Round 3 submission, v3.1 (June 10, 2022)   | 3            |                    1 | 0xfec7       | 1.3.9999.6.7.18             |
+| sphincsshake128ssimple                            | NIST Round 3 submission                         | 3            |                    1 | 0xfe83       | 1.3.9999.6.7.10             |
+| sphincsshake128ssimple **hybrid with** p256       | NIST Round 3 submission                         | 3            |                    1 | 0xfe84       | 1.3.9999.6.7.11             |
+| sphincsshake128ssimple **hybrid with** rsa3072    | NIST Round 3 submission                         | 3            |                    1 | 0xfe85       | 1.3.9999.6.7.12             |
+| sphincsshake256192frobust                         | NIST Round 3 submission                         | 3            |                    3 | 0xfe86       | 1.3.9999.6.8.1              |
+| sphincsshake256192frobust **hybrid with** p384    | NIST Round 3 submission                         | 3            |                    3 | 0xfe87       | 1.3.9999.6.8.2              |
+| sphincsshake192fsimple                            | NIST Round 3 submission, v3.1 (June 10, 2022)   | 3            |                    3 | 0xfec8       | 1.3.9999.6.8.10             |
+| sphincsshake192fsimple **hybrid with** p384       | NIST Round 3 submission, v3.1 (June 10, 2022)   | 3            |                    3 | 0xfec9       | 1.3.9999.6.8.11             |
+| sphincsshake192fsimple                            | NIST Round 3 submission                         | 3            |                    3 | 0xfe88       | 1.3.9999.6.8.3              |
+| sphincsshake192fsimple **hybrid with** p384       | NIST Round 3 submission                         | 3            |                    3 | 0xfe89       | 1.3.9999.6.8.4              |
+| sphincsshake256192srobust                         | NIST Round 3 submission                         | 3            |                    3 | 0xfe8a       | 1.3.9999.6.8.5              |
+| sphincsshake256192srobust **hybrid with** p384    | NIST Round 3 submission                         | 3            |                    3 | 0xfe8b       | 1.3.9999.6.8.6              |
+| sphincsshake192ssimple                            | NIST Round 3 submission, v3.1 (June 10, 2022)   | 3            |                    3 | 0xfeca       | 1.3.9999.6.8.12             |
+| sphincsshake192ssimple **hybrid with** p384       | NIST Round 3 submission, v3.1 (June 10, 2022)   | 3            |                    3 | 0xfecb       | 1.3.9999.6.8.13             |
+| sphincsshake192ssimple                            | NIST Round 3 submission                         | 3            |                    3 | 0xfe8c       | 1.3.9999.6.8.7              |
+| sphincsshake192ssimple **hybrid with** p384       | NIST Round 3 submission                         | 3            |                    3 | 0xfe8d       | 1.3.9999.6.8.8              |
+| sphincsshake256256frobust                         | NIST Round 3 submission                         | 3            |                    5 | 0xfe8e       | 1.3.9999.6.9.1              |
+| sphincsshake256256frobust **hybrid with** p521    | NIST Round 3 submission                         | 3            |                    5 | 0xfe8f       | 1.3.9999.6.9.2              |
+| sphincsshake256fsimple                            | NIST Round 3 submission, v3.1 (June 10, 2022)   | 3            |                    5 | 0xfecc       | 1.3.9999.6.9.10             |
+| sphincsshake256fsimple **hybrid with** p521       | NIST Round 3 submission, v3.1 (June 10, 2022)   | 3            |                    5 | 0xfecd       | 1.3.9999.6.9.11             |
+| sphincsshake256fsimple                            | NIST Round 3 submission                         | 3            |                    5 | 0xfe90       | 1.3.9999.6.9.3              |
+| sphincsshake256fsimple **hybrid with** p521       | NIST Round 3 submission                         | 3            |                    5 | 0xfe91       | 1.3.9999.6.9.4              |
+| sphincsshake256256srobust                         | NIST Round 3 submission                         | 3            |                    5 | 0xfe92       | 1.3.9999.6.9.5              |
+| sphincsshake256256srobust **hybrid with** p521    | NIST Round 3 submission                         | 3            |                    5 | 0xfe93       | 1.3.9999.6.9.6              |
+| sphincsshake256ssimple                            | NIST Round 3 submission, v3.1 (June 10, 2022)   | 3            |                    5 | 0xfece       | 1.3.9999.6.9.12             |
+| sphincsshake256ssimple **hybrid with** p521       | NIST Round 3 submission, v3.1 (June 10, 2022)   | 3            |                    5 | 0xfecf       | 1.3.9999.6.9.13             |
+| sphincsshake256ssimple                            | NIST Round 3 submission                         | 3            |                    5 | 0xfe94       | 1.3.9999.6.9.7              |
+| sphincsshake256ssimple **hybrid with** p521       | NIST Round 3 submission                         | 3            |                    5 | 0xfe95       | 1.3.9999.6.9.8              |


### PR DESCRIPTION
Eliminates CI error due to missing check-in of latest CROSS alg update in `liboqs`.
