### PR TITLE
oqsprovider: allow building as shared library again

### DIFF
--- a/oqsprov/CMakeLists.txt
+++ b/oqsprov/CMakeLists.txt
@@ -18,7 +18,12 @@ set(PROVIDER_HEADER_FILES
   oqs_prov.h oqs_endecoder_local.h
 )
 
-set(OQS_LIBRARY_TYPE MODULE)
+if(BUILD_SHARED_LIBS)
+  set(OQS_LIBRARY_TYPE SHARED)
+else()
+  set(OQS_LIBRARY_TYPE MODULE)
+endif()
+
 if(OQS_PROVIDER_BUILD_STATIC)
   set(OQS_LIBRARY_TYPE STATIC)
 endif()
@@ -42,7 +47,7 @@ set_target_properties(oqsprovider
     # For Windows DLLs
     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")
 
-if (OQS_LIBRARY_TYPE STREQUAL "MODULE")
+if (NOT OQS_LIBRARY_TYPE STREQUAL "STATIC")
   # When openssl looks for provider modules it does not prepend "lib" to the
   # provider name.
   set_target_properties(oqsprovider


### PR DESCRIPTION
Fix #207.

PR 207 changed the default CMake type from `SHARED` to `MODULE` which generates a shared object that isn't meant to be directly linked against but loaded at runtime[1]. The resulting compilation artifact on Linux is a shared object called `oqsproviver.so` which doesn't have the `SONAME` and `SOVERSION` fields set:

```
./scripts/fullbuild.sh
readelf -d _build/lib/oqsprovider.so | grep -c SONAME
0
```

The default behaviour of CMake is to supply dependencies as absolut paths to the linker e.g. `-L/xyz/oqsprovider.so` if a full path is supplied. But fallsback to let the linker search for the requested library in case the `SONAME` field isn't set[2]:

> There are some cases where CMake may ask the linker to search for the
> library (e.g. /usr/lib/libfoo.so becomes -lfoo), such as when a shared
> library is detected to have no SONAME field.

This is problematic when adding oqsprovider as a shared library with a full path to a CMake based application - which becomes `-loqsprovider`. The linking stage will fail in this case as the linker expects to find a `liboqsprovider.so` shared object.

As workaround `BUILD_SHARED_LIBS` will produce a shared object called `oqsprovider.so` with `SONAME` and `SOVERSION` set again, but prevserves the behaviour of #207 to output a `MODULE`:

```
OQSPROV_CMAKE_PARAMS=-DBUILD_SHARED_LIBS=ON ./scripts/fullbuild.sh
readelf -d _build/lib/oqsprovider.so | grep -c SONAME
1
```

[1]: https://cmake.org/cmake/help/v4.0/manual/cmake-buildsystem.7.html#module-libraries
[2]: https://cmake.org/cmake/help/v4.0/command/target_link_libraries.html#overview

Fixes: 466a537587122df60a88236b28eba3d00e28cac8 (#207)

<!-- Please give a brief explanation of the purpose of this pull request. -->

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->
