### PR TITLE
Finalise #671

### DIFF
--- a/oqsprov/oqsprov_keys.c
+++ b/oqsprov/oqsprov_keys.c
@@ -622,7 +622,7 @@ err_init:
 
 static const int oqshybkem_init_ecp(char *tls_name, OQSX_EVP_CTX *evp_ctx,
                                     OSSL_LIB_CTX *libctx) {
-    int ret = 0;
+    int ret = 1;
     const OQSX_EVP_INFO *evp_info = NULL;
 
     for (int i = 0; i < OSSL_NELEM(OQSX_ECP_NAMES); i++) {
@@ -659,7 +659,7 @@ err_init_ecp:
 
 static const int oqshybkem_init_ecx(char *tls_name, OQSX_EVP_CTX *evp_ctx,
                                     OSSL_LIB_CTX *libctx) {
-    int ret = 0;
+    int ret = 1;
     const OQSX_EVP_INFO *evp_info = NULL;
 
     for (int i = 0; i < OSSL_NELEM(OQSX_ECX_NAMES); i++) {

--- a/oqsprov/oqsprov_keys.c
+++ b/oqsprov/oqsprov_keys.c
@@ -536,9 +536,8 @@ static const OQSX_EVP_INFO nids_sig[] = {
 
 };
 // These two array need to stay synced:
-// note only leading 4 chars of alg name are checked
-static const char *OQSX_ECP_NAMES[] = {
-    "p256", "p384", "p521", "SecP256r1", "SecP384r1", "SecP521r1", 0};
+static const char *OQSX_ECP_NAMES[] = {"p256",      "p384",      "p521",
+                                       "SecP256r1", "SecP384r1", "SecP521r1"};
 static const OQSX_EVP_INFO nids_ecp[] = {
     {EVP_PKEY_EC, NID_X9_62_prime256v1, 0, 65, 121, 32, 0}, // 128 bit
     {EVP_PKEY_EC, NID_secp384r1, 0, 97, 167, 48, 0},        // 192 bit
@@ -546,18 +545,13 @@ static const OQSX_EVP_INFO nids_ecp[] = {
     {EVP_PKEY_EC, NID_X9_62_prime256v1, 0, 65, 121, 32, 0}, // 128 bit
     {EVP_PKEY_EC, NID_secp384r1, 0, 97, 167, 48, 0},        // 192 bit
     {EVP_PKEY_EC, NID_secp521r1, 0, 133, 223, 66, 0},       // 256 bit
-    {0, 0, 0, 0, 0, 0, 0}                                   // 256 bit
 };
 
 // These two array need to stay synced:
-// note only leading 4 chars of alg name are checked
-static const char *OQSX_ECX_NAMES[] = {"x25519", "x448", "X25519", "X448", 0};
+static const char *OQSX_ECX_NAMES[] = {"x25519", "x448"};
 static const OQSX_EVP_INFO nids_ecx[] = {
     {EVP_PKEY_X25519, 0, 1, 32, 32, 32, 0}, // 128 bit
     {EVP_PKEY_X448, 0, 1, 56, 56, 56, 0},   // 192 bit
-    {EVP_PKEY_X25519, 0, 1, 32, 32, 32, 0}, // 128 bit
-    {EVP_PKEY_X448, 0, 1, 56, 56, 56, 0},   // 192 bit
-    {0, 0, 0, 0, 0, 0, 0}                   // 256 bit
 };
 
 static int oqsx_hybsig_init(int bit_security, OQSX_EVP_CTX *evp_ctx,
@@ -628,17 +622,22 @@ err_init:
 
 static const int oqshybkem_init_ecp(char *tls_name, OQSX_EVP_CTX *evp_ctx,
                                     OSSL_LIB_CTX *libctx) {
-    int ret = 1;
-    int idx = 0;
+    int ret = 0;
+    const OQSX_EVP_INFO *evp_info = NULL;
 
-    while (idx < OSSL_NELEM(OQSX_ECP_NAMES)) {
-        if (!strncmp(tls_name, OQSX_ECP_NAMES[idx], (idx < 3) ? 4 : 7))
+    for (int i = 0; i < OSSL_NELEM(OQSX_ECP_NAMES); i++) {
+        if (!strncasecmp(tls_name, OQSX_ECP_NAMES[i],
+                         strlen(OQSX_ECP_NAMES[i]))) {
+            evp_info = &nids_ecp[i];
             break;
-        idx++;
+        }
     }
-    ON_ERR_GOTO(idx < 0 || idx > 6, err_init_ecp);
+    if (evp_info == NULL) {
+        OQS_KEY_PRINTF2("OQS KEY: Incorrect P hybrid KEM name: %s\n", tls_name);
+        goto err_init_ecp;
+    }
 
-    evp_ctx->evp_info = &nids_ecp[idx];
+    evp_ctx->evp_info = evp_info;
 
     evp_ctx->ctx = EVP_PKEY_CTX_new_from_name(
         libctx, OBJ_nid2sn(evp_ctx->evp_info->keytype), NULL);
@@ -660,17 +659,22 @@ err_init_ecp:
 
 static const int oqshybkem_init_ecx(char *tls_name, OQSX_EVP_CTX *evp_ctx,
                                     OSSL_LIB_CTX *libctx) {
-    int ret = 1;
-    int idx = 0;
+    int ret = 0;
+    const OQSX_EVP_INFO *evp_info = NULL;
 
-    while (idx < OSSL_NELEM(OQSX_ECX_NAMES)) {
-        if (!strncmp(tls_name, OQSX_ECX_NAMES[idx], 4))
+    for (int i = 0; i < OSSL_NELEM(OQSX_ECX_NAMES); i++) {
+        if (!strncasecmp(tls_name, OQSX_ECX_NAMES[i],
+                         strlen(OQSX_ECX_NAMES[i]))) {
+            evp_info = &nids_ecx[i];
             break;
-        idx++;
+        }
     }
-    ON_ERR_GOTO(idx < 0 || idx > 4, err_init_ecx);
+    if (evp_info == NULL) {
+        OQS_KEY_PRINTF2("OQS KEY: Incorrect X hybrid KEM name: %s\n", tls_name);
+        goto err_init_ecx;
+    }
 
-    evp_ctx->evp_info = &nids_ecx[idx];
+    evp_ctx->evp_info = evp_info;
 
     evp_ctx->keyParam = EVP_PKEY_new();
     ON_ERR_SET_GOTO(!evp_ctx->keyParam, ret, -1, err_init_ecx);


### PR DESCRIPTION
<!-- Please give a brief explanation of the purpose of this pull request. -->
Finalise #671 to address outstanding comments. This modifies `oqskybkem_init_*` return code to match `oqsx_key_new` error handling.

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->
