### PR TITLE
Update HQC codepoints following #676

### DIFF
--- a/oqs-template/generate.yml
+++ b/oqs-template/generate.yml
@@ -416,14 +416,14 @@ kems:
   -
     family: 'HQC'
     name_group: 'hqc128'
-    nid: '0x0244'
-    nid_hybrid: '0x2F44'
+    nid: '65048'
+    nid_hybrid: '65049'
     oqs_alg: 'OQS_KEM_alg_hqc_128'
     enable_kem: false
     extra_nids:
       current:
         - hybrid_group: "x25519"
-          nid: '0x2FB0'
+          nid: '65050'
       old:
         - implementation_version: NIST Round 3 submission
           nist-round: 3
@@ -439,14 +439,14 @@ kems:
   -
     family: 'HQC'
     name_group: 'hqc192'
-    nid: '0x0245'
-    nid_hybrid: '0x2F45'
+    nid: '65051'
+    nid_hybrid: '65052'
     oqs_alg: 'OQS_KEM_alg_hqc_192'
     enable_kem: false
     extra_nids:
       current:
         - hybrid_group: "x448"
-          nid: '0x2FB1'
+          nid: '65053'
       old:
         - implementation_version: NIST Round 3 submission
           nist-round: 3
@@ -462,10 +462,10 @@ kems:
   -
     family: 'HQC'
     name_group: 'hqc256'
-    nid: '0x0246'
-    nid_hybrid: '0x2F46'
+    nid: '65054'
+    nid_hybrid: '65055'
     oqs_alg: 'OQS_KEM_alg_hqc_256'
-    enable_kem:: false
+    enable_kem: false
     extra_nids:
       old:
         - implementation_version: NIST Round 3 submission

--- a/oqs-template/oqs-kem-info.md
+++ b/oqs-template/oqs-kem-info.md
@@ -77,14 +77,14 @@
 | HQC            | NIST Round 3 submission  | hqc192         | 3            |                    3 | 0x2FAD       | x448                             |
 | HQC            | NIST Round 3 submission  | hqc256         | 3            |                    5 | 0x022E       |                                  |
 | HQC            | NIST Round 3 submission  | hqc256         | 3            |                    5 | 0x2F2E       | secp521_r1                       |
-| HQC            | 2023-04-30               | hqc128         | 4            |                    1 | 0x0244       |                                  |
-| HQC            | 2023-04-30               | hqc128         | 4            |                    1 | 0x2F44       | secp256_r1                       |
-| HQC            | 2023-04-30               | hqc128         | 4            |                    1 | 0x2FB0       | x25519                           |
-| HQC            | 2023-04-30               | hqc192         | 4            |                    3 | 0x0245       |                                  |
-| HQC            | 2023-04-30               | hqc192         | 4            |                    3 | 0x2F45       | secp384_r1                       |
-| HQC            | 2023-04-30               | hqc192         | 4            |                    3 | 0x2FB1       | x448                             |
-| HQC            | 2023-04-30               | hqc256         | 4            |                    5 | 0x0246       |                                  |
-| HQC            | 2023-04-30               | hqc256         | 4            |                    5 | 0x2F46       | secp521_r1                       |
+| HQC            | 2023-04-30               | hqc128         | 4            |                    1 | 65048        |                                  |
+| HQC            | 2023-04-30               | hqc128         | 4            |                    1 | 65049        | secp256_r1                       |
+| HQC            | 2023-04-30               | hqc128         | 4            |                    1 | 65050        | x25519                           |
+| HQC            | 2023-04-30               | hqc192         | 4            |                    3 | 65051        |                                  |
+| HQC            | 2023-04-30               | hqc192         | 4            |                    3 | 65052        | secp384_r1                       |
+| HQC            | 2023-04-30               | hqc192         | 4            |                    3 | 65053        | x448                             |
+| HQC            | 2023-04-30               | hqc256         | 4            |                    5 | 65054        |                                  |
+| HQC            | 2023-04-30               | hqc256         | 4            |                    5 | 65055        | secp521_r1                       |
 | ML-KEM         | ML-KEM                   | mlkem1024      | FIPS203      |                    5 | 0x11ED       | secp384_r1                       |
 | ML-KEM         | ML-KEM                   | mlkem1024      | FIPS203      |                    5 | 0x2F4D       | secp521_r1                       |
 | ML-KEM         | ML-KEM                   | mlkem1024      | FIPS203      |                    5 | 514          |                                  |


### PR DESCRIPTION
<!-- Please give a brief explanation of the purpose of this pull request. -->

This updates HQC codepoints following #676 to allow building with HQC enabled. Fixes a typo in `generate.yml` introduced in #670. 

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->
