### PR TITLE
Fix hardcoded cert expiration

### DIFF
--- a/scripts/oqsprovider-ca.sh
+++ b/scripts/oqsprovider-ca.sh
@@ -46,7 +46,14 @@ if [ $? -ne 0 ]; then
    exit 1
 fi
 
-$OPENSSL_APP ca -batch -startdate 150123080000Z -enddate 250823090000Z -keyfile $1_rootCA.key -cert $1_rootCA.crt -policy policy_anything -notext -out $1.crt -infiles $1.csr
+# Compute start and end dates (UTC) for certificate validity
+# Default validity is 365 days; override with OQS_CA_DAYS environment variable
+START_DATE=$(date -u +"%Y%m%d%H%M%SZ")
+DAYS=${OQS_CA_DAYS:-365}
+# Use GNU date to compute end date; this should work on Linux test environments
+END_DATE=$(date -u -d "+$DAYS days" +"%Y%m%d%H%M%SZ")
+
+$OPENSSL_APP ca -batch -startdate "$START_DATE" -enddate "$END_DATE" -keyfile $1_rootCA.key -cert $1_rootCA.crt -policy policy_anything -notext -out $1.crt -infiles $1.csr
 
 if [ $? -ne 0 ]; then
    echo "Failed to generate server CRT. Exiting."


### PR DESCRIPTION
This PR fixes issue #695.

This fix was suggested and created by GitHub Copilot, as part of an exercise to explore [AI contributions to OQS project](https://github.com/orgs/open-quantum-safe/discussions/2253). I created the PR with the files modified by Copilot; I didn't change anything else.

### Prompt

This is the prompt I used in Visual Studio Code's GitHub Copilot chat (in agent mode using the "custom" model):
"I built the project using ./scripts/fullbuild.sh and ran the tests using ./scripts/runtests.sh. Test fails. Please fix the issue"

### Response

GitHub Copilot

I ran the test script and reproduced the failure: the CA cert created by the tests used hard-coded start/end dates that have now expired (end date 2025-08-23). I updated the CA script to compute start and end dates dynamically so certificates created during tests are valid for a reasonable period.

Change made

Modified oqsprovider-ca.sh:
* Replaced the hard-coded -startdate 150123080000Z -enddate 250823090000Z with dynamically computed UTC start and end dates.
* Default validity is 365 days, configurable via the OQS_CA_DAYS environment variable.

Why this fixes the tests

* The previous fixed end date caused certificate verification to fail when the current date passed that fixed date. Using a dynamic end date prevents expiry-related failures in test runs.

What I ran

* Re-ran runtests.sh after the change; all repository tests passed.

If you want

* I can change the default validity duration (e.g., longer than 365 days) or add a macOS-compatible fallback (since date -d is GNU-specific) to make the script more portable.
