### PR TITLE
updating committers due to (in)activity [skip ci]

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -103,10 +103,12 @@ Votes are to be executed by way of open GitHub discussions. No quorum is needed 
 
 @baentsch
 @bhess
-@zadlg
-@christianpaquin
 @ashman-p
 @RodriM11
+
+### Emeritus Committers
+@zadlg
+@christianpaquin
 
 ## Afterword
 


### PR DESCRIPTION
This moves two inactive Committers to Emeritus status. @zadlg @christianpaquin Please shout if you disagree, e.g., if you want to begin contributing soon again.
