### PR TITLE
Updating Governance

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -106,20 +106,22 @@ Votes are to be executed by way of open GitHub discussions. No quorum is needed 
 ### Maintainers
 
 @baentsch
+@ashman-p
 
 ### Committers
 
 @baentsch
 @bhess
+@ashman-p
 @RodriM11
 
 ### Release managers
 
-@ashman-p
 @xuganyu96
 @dstebila
 
 ### Emeritus Committers
+
 @zadlg
 @christianpaquin
 


### PR DESCRIPTION
This updates GOVERNANCE.md to make explicit the [already existing](https://github.com/open-quantum-safe/tsc/blob/63966be103c47682cd69976cce9f49c8399a4cde/config.yaml#L53) role of "Release Manager" as per https://github.com/open-quantum-safe/tsc/issues/211#issuecomment-3486529821.

This then also aligns all role assignments with actual activities. Particularly tagging @ashman-p to prompt for feedback as this also removes your Committer status: Rationale: While [reviewing activity levels](https://github.com/open-quantum-safe/oqs-provider/pull/713) it turned out there are only 60 lines of code (in about 30'000) and 5 code-changing PRs (out of 331) originating with your GH ID: Please speak up if you'd think you're a true [Committer as documented](https://github.com/open-quantum-safe/oqs-provider/blob/main/GOVERNANCE.md#committers) regardless to revert this change; my goal with this PR is to be fair for and open to everyone (contributors and users alike) in aligning documented role assignments with actual activity levels.


