### PR TITLE
Change remaining 'printf' to 'fprint(stderr'

### DIFF
--- a/oqsprov/oqs_decode_der2key.c
+++ b/oqsprov/oqs_decode_der2key.c
@@ -32,13 +32,13 @@ int asn1_d2i_read_bio(BIO *in, BUF_MEM **pb); // TBD: OK to use?
 #else
 #define OQS_DEC_PRINTF(a)                                                      \
     if (getenv("OQSDEC"))                                                      \
-    printf(a)
+    fprintf(stderr, a)
 #define OQS_DEC_PRINTF2(a, b)                                                  \
     if (getenv("OQSDEC"))                                                      \
-    printf(a, b)
+    fprintf(stderr, a, b)
 #define OQS_DEC_PRINTF3(a, b, c)                                               \
     if (getenv("OQSDEC"))                                                      \
-    printf(a, b, c)
+    fprintf(stderr, a, b, c)
 #endif // NDEBUG
 
 struct der2key_ctx_st; /* Forward declaration */

--- a/oqsprov/oqs_encode_key2any.c
+++ b/oqsprov/oqs_encode_key2any.c
@@ -30,13 +30,13 @@
 #else
 #define OQS_ENC_PRINTF(a)                                                      \
     if (getenv("OQSENC"))                                                      \
-    printf(a)
+    fprintf(stderr, a)
 #define OQS_ENC_PRINTF2(a, b)                                                  \
     if (getenv("OQSENC"))                                                      \
-    printf(a, b)
+    fprintf(stderr, a, b)
 #define OQS_ENC_PRINTF3(a, b, c)                                               \
     if (getenv("OQSENC"))                                                      \
-    printf(a, b, c)
+    fprintf(stderr, a, b, c)
 #endif // NDEBUG
 
 struct key2any_ctx_st {

--- a/oqsprov/oqs_kem.c
+++ b/oqsprov/oqs_kem.c
@@ -26,13 +26,13 @@
 #else
 #define OQS_KEM_PRINTF(a)                                                      \
     if (getenv("OQSKEM"))                                                      \
-    printf(a)
+    fprintf(stderr, a)
 #define OQS_KEM_PRINTF2(a, b)                                                  \
     if (getenv("OQSKEM"))                                                      \
-    printf(a, b)
+    fprintf(stderr, a, b)
 #define OQS_KEM_PRINTF3(a, b, c)                                               \
     if (getenv("OQSKEM"))                                                      \
-    printf(a, b, c)
+    fprintf(stderr, a, b, c)
 #endif // NDEBUG
 
 static OSSL_FUNC_kem_newctx_fn oqs_kem_newctx;

--- a/oqsprov/oqs_kmgmt.c
+++ b/oqsprov/oqs_kmgmt.c
@@ -43,13 +43,13 @@ int oqsx_param_build_set_octet_string(OSSL_PARAM_BLD *bld, OSSL_PARAM *p,
 #else
 #define OQS_KM_PRINTF(a)                                                       \
     if (getenv("OQSKM"))                                                       \
-    printf(a)
+    fprintf(stderr, a)
 #define OQS_KM_PRINTF2(a, b)                                                   \
     if (getenv("OQSKM"))                                                       \
-    printf(a, b)
+    fprintf(stderr, a, b)
 #define OQS_KM_PRINTF3(a, b, c)                                                \
     if (getenv("OQSKM"))                                                       \
-    printf(a, b, c)
+    fprintf(stderr, a, b, c)
 #endif // NDEBUG
 
 // our own error codes:

--- a/oqsprov/oqs_sig.c
+++ b/oqsprov/oqs_sig.c
@@ -32,13 +32,13 @@
 #else
 #define OQS_SIG_PRINTF(a)                                                      \
     if (getenv("OQSSIG"))                                                      \
-    printf(a)
+    fprintf(stderr, a)
 #define OQS_SIG_PRINTF2(a, b)                                                  \
     if (getenv("OQSSIG"))                                                      \
-    printf(a, b)
+    fprintf(stderr, a, b)
 #define OQS_SIG_PRINTF3(a, b, c)                                               \
     if (getenv("OQSSIG"))                                                      \
-    printf(a, b, c)
+    fprintf(stderr, a, b, c)
 #endif // NDEBUG
 
 static OSSL_FUNC_signature_newctx_fn oqs_sig_newctx;

--- a/oqsprov/oqsprov.c
+++ b/oqsprov/oqsprov.c
@@ -26,13 +26,13 @@
 #else
 #define OQS_PROV_PRINTF(a)                                                     \
     if (getenv("OQSPROV"))                                                     \
-    printf(a)
+    fprintf(stderr, a)
 #define OQS_PROV_PRINTF2(a, b)                                                 \
     if (getenv("OQSPROV"))                                                     \
-    printf(a, b)
+    fprintf(stderr, a, b)
 #define OQS_PROV_PRINTF3(a, b, c)                                              \
     if (getenv("OQSPROV"))                                                     \
-    printf(a, b, c)
+    fprintf(stderr, a, b, c)
 #endif // NDEBUG
 
 static STACK_OF(OPENSSL_STRING) *rt_disabled_algs = NULL;
@@ -988,8 +988,9 @@ static const OSSL_ALGORITHM *oqsprovider_query(void *provctx, int operation_id,
         FILTERED_ALGS(oqsprovider_decoder);
     default:
         if (getenv("OQSPROV"))
-            printf("Unknown operation %d requested from OQS provider\n",
-                   operation_id);
+            fprintf(stderr,
+                    "Unknown operation %d requested from OQS provider\n",
+                    operation_id);
     }
     return NULL;
 }
@@ -1192,10 +1193,10 @@ int OQS_PROVIDER_ENTRYPOINT_NAME(const OSSL_CORE_HANDLE *handle,
 
     // output disabled algs:
     /*
-    printf("disabled algs: %p (cnt: %d)\n", rt_disabled_algs,
+    fprintf(stderr, "disabled algs: %p (cnt: %d)\n", rt_disabled_algs,
     sk_OPENSSL_STRING_num(rt_disabled_algs));
     for (int i = 0; i < sk_OPENSSL_STRING_num(rt_disabled_algs); ++i) {
-      printf("Disabled alg #%d: %s in OpenSSL version %s\n", i,
+      fprintf(stderr, "Disabled alg #%d: %s in OpenSSL version %s\n", i,
     sk_OPENSSL_STRING_value(rt_disabled_algs, i), ossl_versionp);
     }
     */

--- a/oqsprov/oqsprov_keys.c
+++ b/oqsprov/oqsprov_keys.c
@@ -26,13 +26,13 @@
 #else
 #define OQS_KEY_PRINTF(a)                                                      \
     if (getenv("OQSKEY"))                                                      \
-    printf(a)
+    fprintf(stderr, a)
 #define OQS_KEY_PRINTF2(a, b)                                                  \
     if (getenv("OQSKEY"))                                                      \
-    printf(a, b)
+    fprintf(stderr, a, b)
 #define OQS_KEY_PRINTF3(a, b, c)                                               \
     if (getenv("OQSKEY"))                                                      \
-    printf(a, b, c)
+    fprintf(stderr, a, b, c)
 #endif // NDEBUG
 
 typedef enum { KEY_OP_PUBLIC, KEY_OP_PRIVATE, KEY_OP_KEYGEN } oqsx_key_op_t;

--- a/test/oqs_test_endecode.c
+++ b/test/oqs_test_endecode.c
@@ -56,7 +56,8 @@ static EVP_PKEY *oqstest_make_key(const char *type, EVP_PKEY *template,
     EVP_PKEY_CTX *ctx = NULL;
 
     if (!alg_is_enabled(type)) {
-        printf("Not generating key for disabled algorithm %s.\n", type);
+        fprintf(stderr, "Not generating key for disabled algorithm %s.\n",
+                type);
         return NULL;
     }
 
@@ -87,7 +88,7 @@ static int encode_EVP_PKEY_prov(const EVP_PKEY *pkey, const char *format,
     ectx =
         OSSL_ENCODER_CTX_new_for_pkey(pkey, selection, format, structure, NULL);
     if (ectx == NULL) {
-        printf("No suitable encoder found\n");
+        fprintf(stderr, "No suitable encoder found\n");
         goto end;
     }
 
@@ -175,7 +176,7 @@ static int test_oqs_encdec(const char *alg_name) {
             goto end;
 
         if (!OBJ_sn2nid(alg_name)) {
-            printf("No OID registered for %s\n", alg_name);
+            fprintf(stderr, "No OID registered for %s\n", alg_name);
             ok = -1;
             goto end;
         }
@@ -183,7 +184,7 @@ static int test_oqs_encdec(const char *alg_name) {
                                   test_params_list[i].structure,
                                   test_params_list[i].pass,
                                   test_params_list[i].selection, &encoded)) {
-            printf("Failed encoding %s", alg_name);
+            fprintf(stderr, "Failed encoding %s", alg_name);
             goto end;
         }
         if (!decode_EVP_PKEY_prov(
@@ -191,12 +192,12 @@ static int test_oqs_encdec(const char *alg_name) {
                 test_params_list[i].pass, test_params_list[i].keytype,
                 test_params_list[i].selection, &decoded_pkey, encoded->data,
                 encoded->length)) {
-            printf("Failed decoding %s", alg_name);
+            fprintf(stderr, "Failed decoding %s", alg_name);
             goto end;
         }
 
         if (EVP_PKEY_eq(pkey, decoded_pkey) != 1) {
-            printf("Key equality failed for %s", alg_name);
+            fprintf(stderr, "Key equality failed for %s", alg_name);
             goto end;
         }
         EVP_PKEY_free(pkey);

--- a/test/oqs_test_groups.c
+++ b/test/oqs_test_groups.c
@@ -39,7 +39,7 @@ static int test_oqs_groups(const char *group_name, int dtls_flag) {
     int ret = 1, testresult = 0;
 
     if (!alg_is_enabled(group_name)) {
-        printf("Not testing disabled algorithm %s.\n", group_name);
+        fprintf(stderr, "Not testing disabled algorithm %s.\n", group_name);
         return 1;
     }
     testresult =

--- a/test/oqs_test_kems.c
+++ b/test/oqs_test_kems.c
@@ -23,7 +23,7 @@ static int test_oqs_kems(const char *kemalg_name) {
     int testresult = 1;
 
     if (!alg_is_enabled(kemalg_name)) {
-        printf("Not testing disabled algorithm %s.\n", kemalg_name);
+        fprintf(stderr, "Not testing disabled algorithm %s.\n", kemalg_name);
         return 1;
     }
     // test with built-in digest only if default provider is active:

--- a/test/oqs_test_libctx.c
+++ b/test/oqs_test_libctx.c
@@ -423,7 +423,7 @@ static int test_oqs_kems_libctx(const char *kemalg_name) {
     int testresult = 1;
 
     if (!alg_is_enabled(kemalg_name)) {
-        printf("Not testing disabled algorithm %s.\n", kemalg_name);
+        fprintf(stderr, "Not testing disabled algorithm %s.\n", kemalg_name);
         return 1;
     }
     testresult &= oqs_generate_kem_elems(kemalg_name, &key1, &secenc1, &sec1len,
@@ -466,7 +466,7 @@ static int test_oqs_sigs_libctx(const char *sigalg_name) {
     int testresult = 1;
 
     if (!alg_is_enabled(sigalg_name)) {
-        printf("Not testing disabled algorithm %s.\n", sigalg_name);
+        fprintf(stderr, "Not testing disabled algorithm %s.\n", sigalg_name);
         return 1;
     }
     testresult &= oqs_generate_sig_elems(sigalg_name, msg, sizeof(msg), &key1,

--- a/test/oqs_test_signatures.c
+++ b/test/oqs_test_signatures.c
@@ -27,7 +27,7 @@ static int test_oqs_signatures(const char *sigalg_name) {
     int testresult = 1;
 
     if (!alg_is_enabled(sigalg_name)) {
-        printf("Not testing disabled algorithm %s.\n", sigalg_name);
+        fprintf(stderr, "Not testing disabled algorithm %s.\n", sigalg_name);
         return 1;
     }
     // test with built-in digest only if default provider is active:

--- a/test/oqs_test_tlssig.c
+++ b/test/oqs_test_tlssig.c
@@ -31,7 +31,7 @@ static int test_oqs_tlssig(const char *sig_name, int dtls_flag) {
 #endif
 
     if (!alg_is_enabled(sig_name)) {
-        printf("Not testing disabled algorithm %s.\n", sig_name);
+        fprintf(stderr, "Not testing disabled algorithm %s.\n", sig_name);
         return 1;
     }
 
@@ -87,7 +87,7 @@ err:
 static void test_oqs_sigs(EVP_SIGNATURE *evpsig, void *vp) {
         OSSL_PROVIDER* prov = EVP_SIGNATURE_get0_provider(evpsig);
         if (!strcmp(OSSL_PROVIDER_get0_name(prov), "oqsprovider")) {
-                printf("Commencing test of %s:\n",
+                fprintf(stderr, "Commencing test of %s:\n",
 EVP_SIGNATURE_get0_name(evpsig));
                 test_oqs_tlssig(EVP_SIGNATURE_get0_name(evpsig));
         }

--- a/test/test_common.c
+++ b/test/test_common.c
@@ -64,9 +64,9 @@ void hexdump(const void *ptr, size_t len) {
 
     for (i = 0; i < len; i += j) {
         for (j = 0; j < 16 && i + j < len; j++)
-            printf("%s%02x", j ? "" : " ", p[i + j]);
+            fprintf(stderr, "%s%02x", j ? "" : " ", p[i + j]);
     }
-    printf("\n");
+    fprintf(stderr, "\n");
 }
 
 #define MIN(X, Y) (((X) < (Y)) ? (X) : (Y))

--- a/test/test_common.h
+++ b/test/test_common.h
@@ -33,9 +33,9 @@
 #define TEST_ASSERT(e)                                                         \
     {                                                                          \
         if (!(test = (e)))                                                     \
-            printf(cRED "  Test FAILED" cNORM "\n");                           \
+            fprintf(stderr, cRED "  Test FAILED" cNORM "\n");                  \
         else                                                                   \
-            printf(cGREEN "  Test passed" cNORM "\n");                         \
+            fprintf(stderr, cGREEN "  Test passed" cNORM "\n");                \
     }
 
 void hexdump(const void *ptr, size_t len);


### PR DESCRIPTION
Change all occurrences of 'printf' to 'fprint(stderr' in order to homogenize behavior. Fixes #594.
<!-- Please give a brief explanation of the purpose of this pull request. -->

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->
