### PR TITLE
Expand 'oqs_test_kem' to perform encapsulation from pubkey only

### DIFF
--- a/oqs-template/oqsprov/oqsprov.c/disable_ossl_algs.fragment
+++ b/oqs-template/oqsprov/oqsprov.c/disable_ossl_algs.fragment
@@ -2,6 +2,7 @@
   {% for variant in sig.variants %}
     {% if variant.openssl_version is defined %}
     if (strcmp("{{ variant.openssl_version }}", ossl_versionp) <= 0) {
+        rt_algo_filter_enabled = 1;
         sk_OPENSSL_STRING_push(rt_disabled_algs, "{{ variant.name }}");
     }
     {% endif %}
@@ -11,6 +12,7 @@
 {% for kem in config.kems %}
   {% if kem.openssl_version is defined %}
     if (strcmp("{{ kem.openssl_version }}", ossl_versionp) <= 0) {
+        rt_algo_filter_enabled = 1;
         sk_OPENSSL_STRING_push(rt_disabled_algs, "{{ kem.name_group }}");
     }
   {% endif %}
@@ -19,6 +21,7 @@
     {% for hybrid in kem.extra_nids.current %}
       {% if hybrid.openssl_version is defined %}
     if (strcmp("{{ hybrid.openssl_version }}", ossl_versionp) <= 0) {
+        rt_algo_filter_enabled = 1;
         sk_OPENSSL_STRING_push(rt_disabled_algs, "{{ hybrid.standard_name }}");
     }
       {% endif %}

--- a/oqsprov/oqsprov.c
+++ b/oqsprov/oqsprov.c
@@ -1355,9 +1355,6 @@ int OQS_PROVIDER_ENTRYPOINT_NAME(const OSSL_CORE_HANDLE *handle,
     }
 
     if (strcmp("3.5.0", ossl_versionp) <= 0) {
-        // Enable rt algo filter
-        rt_algo_filter_enabled = 1;
-
         sk_OPENSSL_STRING_push(rt_disabled_algs, "mlkem512");
     }
 

--- a/oqsprov/oqsprov.c
+++ b/oqsprov/oqsprov.c
@@ -1295,86 +1295,107 @@ int OQS_PROVIDER_ENTRYPOINT_NAME(const OSSL_CORE_HANDLE *handle,
     ///// OQS_TEMPLATE_FRAGMENT_DISABLE_OSSL_ALGS_START
 
     if (strcmp("3.5.0", ossl_versionp) <= 0) {
+        rt_algo_filter_enabled = 1;
         sk_OPENSSL_STRING_push(rt_disabled_algs, "mldsa44");
     }
 
     if (strcmp("3.5.0", ossl_versionp) <= 0) {
+        rt_algo_filter_enabled = 1;
         sk_OPENSSL_STRING_push(rt_disabled_algs, "mldsa65");
     }
 
     if (strcmp("3.5.0", ossl_versionp) <= 0) {
+        rt_algo_filter_enabled = 1;
         sk_OPENSSL_STRING_push(rt_disabled_algs, "mldsa87");
     }
 
     if (strcmp("3.5.0", ossl_versionp) <= 0) {
+        rt_algo_filter_enabled = 1;
         sk_OPENSSL_STRING_push(rt_disabled_algs, "slhdsasha2128s");
     }
 
     if (strcmp("3.5.0", ossl_versionp) <= 0) {
+        rt_algo_filter_enabled = 1;
         sk_OPENSSL_STRING_push(rt_disabled_algs, "slhdsasha2128f");
     }
 
     if (strcmp("3.5.0", ossl_versionp) <= 0) {
+        rt_algo_filter_enabled = 1;
         sk_OPENSSL_STRING_push(rt_disabled_algs, "slhdsasha2192s");
     }
 
     if (strcmp("3.5.0", ossl_versionp) <= 0) {
+        rt_algo_filter_enabled = 1;
         sk_OPENSSL_STRING_push(rt_disabled_algs, "slhdsasha2192f");
     }
 
     if (strcmp("3.5.0", ossl_versionp) <= 0) {
+        rt_algo_filter_enabled = 1;
         sk_OPENSSL_STRING_push(rt_disabled_algs, "slhdsasha2256s");
     }
 
     if (strcmp("3.5.0", ossl_versionp) <= 0) {
+        rt_algo_filter_enabled = 1;
         sk_OPENSSL_STRING_push(rt_disabled_algs, "slhdsasha2256f");
     }
 
     if (strcmp("3.5.0", ossl_versionp) <= 0) {
+        rt_algo_filter_enabled = 1;
         sk_OPENSSL_STRING_push(rt_disabled_algs, "slhdsashake128s");
     }
 
     if (strcmp("3.5.0", ossl_versionp) <= 0) {
+        rt_algo_filter_enabled = 1;
         sk_OPENSSL_STRING_push(rt_disabled_algs, "slhdsashake128f");
     }
 
     if (strcmp("3.5.0", ossl_versionp) <= 0) {
+        rt_algo_filter_enabled = 1;
         sk_OPENSSL_STRING_push(rt_disabled_algs, "slhdsashake192s");
     }
 
     if (strcmp("3.5.0", ossl_versionp) <= 0) {
+        rt_algo_filter_enabled = 1;
         sk_OPENSSL_STRING_push(rt_disabled_algs, "slhdsashake192f");
     }
 
     if (strcmp("3.5.0", ossl_versionp) <= 0) {
+        rt_algo_filter_enabled = 1;
         sk_OPENSSL_STRING_push(rt_disabled_algs, "slhdsashake256s");
     }
 
     if (strcmp("3.5.0", ossl_versionp) <= 0) {
+        rt_algo_filter_enabled = 1;
         sk_OPENSSL_STRING_push(rt_disabled_algs, "slhdsashake256f");
     }
 
     if (strcmp("3.5.0", ossl_versionp) <= 0) {
+        rt_algo_filter_enabled = 1;
         sk_OPENSSL_STRING_push(rt_disabled_algs, "mlkem512");
     }
 
     if (strcmp("3.5.0", ossl_versionp) <= 0) {
+        rt_algo_filter_enabled = 1;
         sk_OPENSSL_STRING_push(rt_disabled_algs, "mlkem768");
     }
 
     if (strcmp("3.5.0", ossl_versionp) <= 0) {
+        rt_algo_filter_enabled = 1;
         sk_OPENSSL_STRING_push(rt_disabled_algs, "X25519MLKEM768");
     }
 
     if (strcmp("3.5.0", ossl_versionp) <= 0) {
+        rt_algo_filter_enabled = 1;
         sk_OPENSSL_STRING_push(rt_disabled_algs, "SecP256r1MLKEM768");
     }
 
     if (strcmp("3.5.0", ossl_versionp) <= 0) {
+        rt_algo_filter_enabled = 1;
         sk_OPENSSL_STRING_push(rt_disabled_algs, "mlkem1024");
     }
 
     if (strcmp("3.5.0", ossl_versionp) <= 0) {
+        rt_algo_filter_enabled = 1;
         sk_OPENSSL_STRING_push(rt_disabled_algs, "SecP384r1MLKEM1024");
     }
 

--- a/test/oqs_test_kems.c
+++ b/test/oqs_test_kems.c
@@ -68,10 +68,6 @@ static int test_oqs_kems(const char *kemalg_name) {
         if (!testresult)
             goto err;
 
-        OPENSSL_free(out);
-        OPENSSL_free(secenc);
-        OPENSSL_free(secdec);
-
         // Now encapsulation from public key context
         testresult &=
             EVP_PKEY_get_octet_string_param(key, OSSL_PKEY_PARAM_PUB_KEY, NULL,
@@ -86,6 +82,10 @@ static int test_oqs_kems(const char *kemalg_name) {
             goto err;
         EVP_PKEY_CTX_free(ctx);
         ctx = NULL;
+        OPENSSL_free(out);
+        out = NULL;
+        OPENSSL_free(secenc);
+        secenc = NULL;
 
         testresult &=
             (ctx = EVP_PKEY_CTX_new_from_pkey(libctx, peer, OQSPROV_PROPQ)) !=
@@ -101,6 +101,8 @@ static int test_oqs_kems(const char *kemalg_name) {
             goto err;
         EVP_PKEY_CTX_free(ctx);
         ctx = NULL;
+        OPENSSL_free(secdec);
+        secdec = NULL;
 
         testresult &=
             (ctx = EVP_PKEY_CTX_new_from_pkey(libctx, key, OQSPROV_PROPQ)) !=


### PR DESCRIPTION
Expand `oqs_test_kem` to also test KEM encapsulation from context with only public key present. Fixes #571.
