### PR TITLE
oqs_provider. Enable Algo Fetch Cache mechanism only for OpenSSL v3.5.0 or newer.

### DIFF
--- a/CONFIGURE.md
+++ b/CONFIGURE.md
@@ -217,8 +217,4 @@ e.g., as such: `openssl list -kem-algorithms -propquery oqsprovider.security_bit
 The bit strength of hybrid algorithms is always defined by the bit strength
 of the classic algorithm.
 
-### OQS_CACHE
 
-It is possible to enabled algorithm fetch cache (and greatly improve the performance) via "OQS_CACHE" environmental variable,
-e.g. `OQS_CACHE=1 ./sbin/nginx -c ./conf/nginx.conf`.
-As that feature disables runtime-algorithm filtering, it is only safe for OpenSSL < 3.5.

--- a/oqsprov/oqsprov.c
+++ b/oqsprov/oqsprov.c
@@ -35,7 +35,7 @@
     fprintf(stderr, a, b, c)
 #endif // NDEBUG
 
-static int rt_algo_filter_enabled = 1;
+static int rt_algo_filter_enabled = 0;
 
 static STACK_OF(OPENSSL_STRING) *rt_disabled_algs = NULL;
 STACK_OF(OPENSSL_STRING) * oqsprov_get_rt_disabled_algs() {
@@ -1173,6 +1173,9 @@ int OQS_PROVIDER_ENTRYPOINT_NAME(const OSSL_CORE_HANDLE *handle,
     // ML-KEM implementation in OpenSSL 3.5 is _much_ more developed than this
     // code
     if (strcmp("3.5.0", ossl_versionp) <= 0) {
+        // Enable rt algo filter
+        rt_algo_filter_enabled = 1;
+
         sk_OPENSSL_STRING_push(rt_disabled_algs, "mlkem512");
         sk_OPENSSL_STRING_push(rt_disabled_algs, "mlkem768");
         sk_OPENSSL_STRING_push(rt_disabled_algs, "X25519MLKEM768");
@@ -1205,9 +1208,6 @@ int OQS_PROVIDER_ENTRYPOINT_NAME(const OSSL_CORE_HANDLE *handle,
     sk_OPENSSL_STRING_value(rt_disabled_algs, i), ossl_versionp);
     }
     */
-
-    if (getenv("OQS_CACHE"))
-        rt_algo_filter_enabled = 0;
 
     // if libctx not yet existing, create a new one
     if (((corebiometh = oqs_bio_prov_init_bio_method()) == NULL) ||


### PR DESCRIPTION
Patch to enable Algo Fetch Cache mechanism for OpenSSL v3.5.0 or newer.
Fix for mem allocation issue in FILTERED_ALGS macro.

Fixes #719

Review: https://github.com/woinan/oqs-provider/pull/2