### PR TITLE
disable OpenSSL algorithms in scripts/common.py

### DIFF
--- a/oqs-template/scripts/common.py/ossl_kex_algs.fragment
+++ b/oqs-template/scripts/common.py/ossl_kex_algs.fragment
@@ -1,0 +1,13 @@
+{%- for kem in config.kems -%}
+  {%- if kem.openssl_version is defined %}
+                     '{{ kem.name_group }}',
+  {%- endif -%}
+  {%- if kem.extra_nids is defined and kem.extra_nids.current is defined -%}
+    {%- for hybrid in kem.extra_nids.current -%}
+      {%- if hybrid.openssl_version is defined %}
+                     '{{ hybrid.standard_name }}',
+      {%- endif -%}
+    {%- endfor -%}
+  {%- endif -%}
+{%- endfor %}
+

--- a/oqs-template/scripts/common.py/ossl_sig_algs.fragment
+++ b/oqs-template/scripts/common.py/ossl_sig_algs.fragment
@@ -1,0 +1,8 @@
+{%- for sig in config.sigs -%}
+  {%- for variant in sig.variants -%}
+    {%- if variant.openssl_version is defined %}
+                  '{{ variant.name }}',
+    {%- endif -%}
+  {%- endfor -%}
+{%- endfor %}
+

--- a/scripts/common.py
+++ b/scripts/common.py
@@ -23,9 +23,36 @@ signatures_oqs = [
     ##### OQS_TEMPLATE_FRAGMENT_SIG_ALGS_END
 ]
 
-key_exchanges_ossl = ['mlkem512','mlkem768','mlkem1024', 'X25519MLKEM768','SecP256r1MLKEM768', 'SecP384r1MLKEM1024']
+key_exchanges_ossl = [
+##### OQS_TEMPLATE_FRAGMENT_OSSL_KEX_ALGS_START
+                     'mlkem512',
+                     'mlkem768',
+                     'X25519MLKEM768',
+                     'SecP256r1MLKEM768',
+                     'mlkem1024',
+                     'SecP384r1MLKEM1024',
+##### OQS_TEMPLATE_FRAGMENT_OSSL_KEX_ALGS_END
+                     ]
 
-signatures_ossl = ['mldsa44', 'mldsa56', 'mldsa87', 'mldsa44_pss2048','mldsa44_rsa2048','mldsa44_ed25519','mldsa44_p256','mldsa44_bp256','mldsa65_pss3072','mldsa65_rsa3072','mldsa65_p256','mldsa65_bp256','mldsa65_ed25519','mldsa87_p384','mldsa87_bp384','mldsa87_ed448']
+signatures_ossl = [
+##### OQS_TEMPLATE_FRAGMENT_OSSL_SIG_ALGS_START
+                  'mldsa44',
+                  'mldsa65',
+                  'mldsa87',
+                  'slhdsasha2128s',
+                  'slhdsasha2128f',
+                  'slhdsasha2192s',
+                  'slhdsasha2192f',
+                  'slhdsasha2256s',
+                  'slhdsasha2256f',
+                  'slhdsashake128s',
+                  'slhdsashake128f',
+                  'slhdsashake192s',
+                  'slhdsashake192f',
+                  'slhdsashake256s',
+                  'slhdsashake256f',
+##### OQS_TEMPLATE_FRAGMENT_OSSL_SIG_ALGS_END
+                  ]
 
 key_exchanges = [kex for kex in key_exchanges_oqs if kex not in key_exchanges_ossl]
 signatures = [sig for sig in signatures_oqs if sig not in signatures_ossl]


### PR DESCRIPTION
- Removed composite-related code (final cleanup)
- Listed OpenSSL-available algorithms in scripts/common.py using a template