### PR TITLE
Add sign/verify message API from 3.4.0 onwards

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,14 @@ Also new in this version is the possibility to retrieve all currently
 active TLS signature algorithms via a new `openssl list` option:
 `openssl list -tls-signature-algorithms`.
 
+These versions also provide support for the new `sign/verify message`
+interface, which are intended to sign arbitrary large data. The inclusion
+of this capacity has modified the behavior of hybrid signature
+components: unconditional hashing is no longer present, and will only
+happen for `EVP_PKEY_OP_SIGNMSG/EVP_PKEY_OP_VERIFYMSG` operations. This
+means that the behavior of `EVP_PKEY_sign_init` interface is modified, as
+an appropriate message length for hybrid signature schemes is expected.
+
 ## 3.5 and greater
 
 These versions include support for the standard PQC algorithms ML-KEM, ML-DSA

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,8 @@
 # oqs-provider 0.12.0-dev
 
+### What's New
+Support for OpenSSL's sign/verify message API added.
+
 Previous Release Notes
 ======================
 

--- a/oqsprov/oqs_prov.h
+++ b/oqsprov/oqs_prov.h
@@ -99,6 +99,7 @@ void oqsx_freeprovctx(PROV_OQS_CTX *ctx);
 #define PROV_OQS_LIBCTX_OF(provctx)                                            \
     provctx ? (((PROV_OQS_CTX *)provctx)->libctx) : NULL
 
+void oqs_sig_activate_message_api(void);
 #include "oqs/oqs.h"
 
 /* helper structure for classic key components in hybrid keys.

--- a/oqsprov/oqsprov.c
+++ b/oqsprov/oqsprov.c
@@ -1290,6 +1290,11 @@ int OQS_PROVIDER_ENTRYPOINT_NAME(const OSSL_CORE_HANDLE *handle,
         }
     }
 
+    // OpenSSL 3.4.0 onwards includes sign/verify message API
+    if (strcmp("3.4.0", ossl_versionp) <= 0) {
+        oqs_sig_activate_message_api();
+    }
+
     // ML-KEM implementation in OpenSSL 3.5 is _much_ more developed than this
     // code
     ///// OQS_TEMPLATE_FRAGMENT_DISABLE_OSSL_ALGS_START


### PR DESCRIPTION
This PR introduces the 'sign/verify_message' functionality. Fixes https://github.com/open-quantum-safe/oqs-provider/issues/718. The current implementation:


- Leaves the DigestSign/Verify functionality untouched: the unconditional hash is still happening for this interface.
- The EVP_PKEY_sign/verify_init' behavior is modified for hybrid signature schemes: instead of unconditional hashing, this interface expects the message to already be hashed, and the message is redirected to the EVP_PKEY_sign` for the underlying classical algorithm. This is consisted with the expected behavior of this interface from OpenSSL 3.4.0 and so on.
- The new EVP_PKEY_message_* interface is included. The behavior mimics the old EVP_PKEY_sign/verify_init i.e. the hashing of the message for the classical components.
- Tests have also been updated to include testing of this interface.

Note that this PR modifies the behavior of the standard EVP_PKEY_sign/verify_init, and it should be sufficiently documented in the release notes of the version that incorporates these changes.

This behavior is only activated if BOTH at compilation time and at runtime an OpenSSL >= 3.4.0 is present.
