### PR TITLE
Add test for context strings in signatures

### DIFF
--- a/oqs-template/test/test_common.c/ctx_str_sig_algs.fragment
+++ b/oqs-template/test/test_common.c/ctx_str_sig_algs.fragment
@@ -13,7 +13,7 @@
 
 #define SIGS_DICT_LEN {{ count.val }}
 
-/** \brief List of signature algorithms with support for context strings. */
+/** \brief Mapping of signature algorithm with PQ naming in liboqs */
 oqs_naming_dict kOQSNameMapSignatureAlgorithms[SIGS_DICT_LEN] = {
 {% for sig in config['sigs'] %}
    {%- for variant in sig['variants'] %}

--- a/oqs-template/test/test_common.c/ctx_str_sig_algs.fragment
+++ b/oqs-template/test/test_common.c/ctx_str_sig_algs.fragment
@@ -1,0 +1,27 @@
+
+
+{% set count = namespace(val=0) %}
+
+{%- for sig in config['sigs'] %}
+{%- for variant in sig['variants'] -%}
+{%- set count.val = count.val + 1 -%}
+{%- for classical_alg in variant['mix_with'] %}
+{%- set count.val = count.val + 1 -%}
+{%- endfor -%}
+{%- endfor -%}
+{%- endfor %}
+
+#define SIGS_DICT_LEN {{ count.val }}
+
+/** \brief List of signature algorithms with support for context strings. */
+oqs_naming_dict kOQSNameMapSignatureAlgorithms[SIGS_DICT_LEN] = {
+{% for sig in config['sigs'] %}
+   {%- for variant in sig['variants'] %}
+      { {{variant['oqs_meth']}}, "{{variant['name']}}" },
+      {%- for classical_alg in variant['mix_with'] -%}
+        { {{variant['oqs_meth']}}, "{{ classical_alg['name'] }}_{{ variant['name'] }}" },
+      {%- endfor -%}
+   {%- endfor %}
+{%- endfor %}
+};
+

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -36,7 +36,7 @@ if (OQS_PROVIDER_BUILD_STATIC)
 endif()
 
 add_executable(oqs_test_signatures oqs_test_signatures.c test_common.c)
-target_link_libraries(oqs_test_signatures PRIVATE ${OPENSSL_CRYPTO_LIBRARY} ${OQS_ADDL_SOCKET_LIBS} ${REQ_LIBS_T})
+target_link_libraries(oqs_test_signatures PRIVATE OQS::oqs ${OPENSSL_CRYPTO_LIBRARY} ${OQS_ADDL_SOCKET_LIBS} ${REQ_LIBS_T})
 
 add_test(
   NAME oqs_kems
@@ -57,7 +57,7 @@ set_tests_properties(oqs_kems
 endif()
 
 add_executable(oqs_test_kems oqs_test_kems.c test_common.c)
-target_link_libraries(oqs_test_kems PRIVATE ${OPENSSL_CRYPTO_LIBRARY} ${OQS_ADDL_SOCKET_LIBS} ${REQ_LIBS_T})
+target_link_libraries(oqs_test_kems PRIVATE OQS::oqs ${OPENSSL_CRYPTO_LIBRARY} ${OQS_ADDL_SOCKET_LIBS} ${REQ_LIBS_T})
 
 add_test(
   NAME oqs_libctx
@@ -79,7 +79,7 @@ endif()
 
 add_executable(oqs_test_libctx oqs_test_libctx.c test_common.c)
 target_include_directories(oqs_test_libctx PRIVATE "../oqsprov")
-target_link_libraries(oqs_test_libctx PRIVATE ${OPENSSL_CRYPTO_LIBRARY} ${OQS_ADDL_SOCKET_LIBS} ${REQ_LIBS_T})
+target_link_libraries(oqs_test_libctx PRIVATE OQS::oqs ${OPENSSL_CRYPTO_LIBRARY} ${OQS_ADDL_SOCKET_LIBS} ${REQ_LIBS_T})
 
 add_test(
     NAME oqs_groups
@@ -100,7 +100,7 @@ set_tests_properties(oqs_groups
 )
 endif()
 add_executable(oqs_test_groups oqs_test_groups.c test_common.c tlstest_helpers.c)
-target_link_libraries(oqs_test_groups PRIVATE ${OPENSSL_SSL_LIBRARY} ${OPENSSL_CRYPTO_LIBRARY} ${OQS_ADDL_SOCKET_LIBS} ${REQ_LIBS_T})
+target_link_libraries(oqs_test_groups PRIVATE OQS::oqs ${OPENSSL_SSL_LIBRARY} ${OPENSSL_CRYPTO_LIBRARY} ${OQS_ADDL_SOCKET_LIBS} ${REQ_LIBS_T})
 
 add_test(
     NAME oqs_tlssig
@@ -122,10 +122,10 @@ set_tests_properties(oqs_tlssig
 )
 endif()
 add_executable(oqs_test_tlssig oqs_test_tlssig.c test_common.c tlstest_helpers.c)
-target_link_libraries(oqs_test_tlssig PRIVATE ${OPENSSL_SSL_LIBRARY} ${OPENSSL_CRYPTO_LIBRARY} ${OQS_ADDL_SOCKET_LIBS} ${REQ_LIBS_T})
+target_link_libraries(oqs_test_tlssig PRIVATE OQS::oqs ${OPENSSL_SSL_LIBRARY} ${OPENSSL_CRYPTO_LIBRARY} ${OQS_ADDL_SOCKET_LIBS} ${REQ_LIBS_T})
 
 add_executable(oqs_test_endecode oqs_test_endecode.c test_common.c)
-target_link_libraries(oqs_test_endecode PRIVATE ${OPENSSL_CRYPTO_LIBRARY} ${OQS_ADDL_SOCKET_LIBS} ${REQ_LIBS_T})
+target_link_libraries(oqs_test_endecode PRIVATE OQS::oqs ${OPENSSL_CRYPTO_LIBRARY} ${OQS_ADDL_SOCKET_LIBS} ${REQ_LIBS_T})
 add_test(
   NAME oqs_endecode
   COMMAND oqs_test_endecode
@@ -146,7 +146,7 @@ endif()
 
 add_executable(oqs_test_evp_pkey_params oqs_test_evp_pkey_params.c test_common.c)
 target_include_directories(oqs_test_evp_pkey_params PRIVATE "../oqsprov")
-target_link_libraries(oqs_test_evp_pkey_params PRIVATE ${OPENSSL_CRYPTO_LIBRARY} ${OQS_ADDL_SOCKET_LIBS} ${REQ_LIBS_T})
+target_link_libraries(oqs_test_evp_pkey_params PRIVATE OQS::oqs ${OPENSSL_CRYPTO_LIBRARY} ${OQS_ADDL_SOCKET_LIBS} ${REQ_LIBS_T})
 add_test(
   NAME oqs_evp_pkey_params
   COMMAND oqs_test_evp_pkey_params

--- a/test/oqs_test_signatures.c
+++ b/test/oqs_test_signatures.c
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0 AND MIT
 
+#include <openssl/core_names.h>
 #include <openssl/evp.h>
+#include <openssl/params.h>
 #include <openssl/provider.h>
 
 #include "oqs/oqs.h"
@@ -90,6 +92,55 @@ static int test_oqs_signatures(const char *sigalg_name) {
     return testresult;
 }
 
+static int test_oqs_signatures_with_ctx_str(const char *sigalg_name) {
+    EVP_MD_CTX *mdctx = NULL;
+    EVP_PKEY_CTX *ctx = NULL, *pctx = NULL;
+    EVP_PKEY *key = NULL;
+    OSSL_PARAM params[2] = {OSSL_PARAM_END, OSSL_PARAM_END};
+    const char msg[] = "The quick brown fox jumps over... you know what";
+    const char ctx_str[] = "Use a non-null context string";
+    unsigned char *sig;
+    size_t siglen;
+
+    int testresult = 1;
+
+    if (!alg_is_enabled(sigalg_name)) {
+        fprintf(stderr, "Not testing disabled algorithm %s.\n", sigalg_name);
+        return 1;
+    }
+#if (OPENSSL_VERSION_PREREQ(3, 2) &&                                           \
+     (defined OQS_VERSION_MINOR &&                                             \
+      (OQS_VERSION_MAJOR > 0 || OQS_VERSION_MINOR >= 14)))
+    params[0] = OSSL_PARAM_construct_octet_string(
+        OSSL_SIGNATURE_PARAM_CONTEXT_STRING, (void *)ctx_str, sizeof(ctx_str));
+
+    testresult &=
+        (ctx = EVP_PKEY_CTX_new_from_name(libctx, sigalg_name,
+                                          OQSPROV_PROPQ)) != NULL &&
+        EVP_PKEY_keygen_init(ctx) && EVP_PKEY_generate(ctx, &key) &&
+        (mdctx = EVP_MD_CTX_new()) != NULL &&
+        EVP_DigestSignInit_ex(mdctx, &pctx, NULL, libctx, NULL, key, NULL) &&
+        EVP_PKEY_CTX_set_params(pctx, params) &&
+        EVP_DigestSignUpdate(mdctx, msg, sizeof(msg)) &&
+        EVP_DigestSignFinal(mdctx, NULL, &siglen) &&
+        (sig = OPENSSL_malloc(siglen)) != NULL &&
+        EVP_DigestSignFinal(mdctx, sig, &siglen) &&
+        EVP_DigestVerifyInit_ex(mdctx, &pctx, NULL, libctx, NULL, key, NULL) &&
+        EVP_PKEY_CTX_set_params(pctx, params) &&
+        EVP_DigestVerifyUpdate(mdctx, msg, sizeof(msg)) &&
+        EVP_DigestVerifyFinal(mdctx, sig, siglen);
+
+    testresult =
+        testresult == does_signature_algorithm_support_ctx_str(sigalg_name);
+
+    EVP_MD_CTX_free(mdctx);
+    EVP_PKEY_free(key);
+    EVP_PKEY_CTX_free(ctx);
+    OPENSSL_free(sig);
+#endif
+    return testresult;
+}
+
 #define nelem(a) (sizeof(a) / sizeof((a)[0]))
 
 int main(int argc, char *argv[]) {
@@ -111,7 +162,8 @@ int main(int argc, char *argv[]) {
                                             &query_nocache);
     if (sigalgs) {
         for (; sigalgs->algorithm_names != NULL; sigalgs++) {
-            if (test_oqs_signatures(sigalgs->algorithm_names)) {
+            if (test_oqs_signatures(sigalgs->algorithm_names) &&
+                test_oqs_signatures_with_ctx_str(sigalgs->algorithm_names)) {
                 fprintf(stderr,
                         cGREEN "  Signature test succeeded: %s" cNORM "\n",
                         sigalgs->algorithm_names);
@@ -124,6 +176,7 @@ int main(int argc, char *argv[]) {
         }
     }
 
+    OSSL_PROVIDER_unload(oqsprov);
     OSSL_LIB_CTX_free(libctx);
 
     TEST_ASSERT(errcnt == 0)

--- a/test/test_common.c
+++ b/test/test_common.c
@@ -3,6 +3,7 @@
 #include "test_common.h"
 
 #include <openssl/evp.h>
+#include <oqs/oqs.h>
 #include <string.h>
 
 ///// OQS_TEMPLATE_FRAGMENT_HYBRID_SIG_ALGS_START
@@ -23,6 +24,77 @@ const char *kHybridSignatureAlgorithms[] = {
     "p521_snova2965",       NULL,
 };
 ///// OQS_TEMPLATE_FRAGMENT_HYBRID_SIG_ALGS_END
+
+typedef struct {
+    char *oqsname;
+    char *alg_name;
+} oqs_naming_dict;
+
+///// OQS_TEMPLATE_FRAGMENT_CTX_STR_SIG_ALGS_START
+
+#define SIGS_DICT_LEN 56
+
+/** \brief List of signature algorithms with support for context strings. */
+oqs_naming_dict kOQSNameMapSignatureAlgorithms[SIGS_DICT_LEN] = {
+
+    {OQS_SIG_alg_ml_dsa_44, "mldsa44"},
+    {OQS_SIG_alg_ml_dsa_44, "p256_mldsa44"},
+    {OQS_SIG_alg_ml_dsa_44, "rsa3072_mldsa44"},
+    {OQS_SIG_alg_ml_dsa_65, "mldsa65"},
+    {OQS_SIG_alg_ml_dsa_65, "p384_mldsa65"},
+    {OQS_SIG_alg_ml_dsa_87, "mldsa87"},
+    {OQS_SIG_alg_ml_dsa_87, "p521_mldsa87"},
+    {OQS_SIG_alg_falcon_512, "falcon512"},
+    {OQS_SIG_alg_falcon_512, "p256_falcon512"},
+    {OQS_SIG_alg_falcon_512, "rsa3072_falcon512"},
+    {OQS_SIG_alg_falcon_padded_512, "falconpadded512"},
+    {OQS_SIG_alg_falcon_padded_512, "p256_falconpadded512"},
+    {OQS_SIG_alg_falcon_padded_512, "rsa3072_falconpadded512"},
+    {OQS_SIG_alg_falcon_1024, "falcon1024"},
+    {OQS_SIG_alg_falcon_1024, "p521_falcon1024"},
+    {OQS_SIG_alg_falcon_padded_1024, "falconpadded1024"},
+    {OQS_SIG_alg_falcon_padded_1024, "p521_falconpadded1024"},
+    {OQS_SIG_alg_mayo_1, "mayo1"},
+    {OQS_SIG_alg_mayo_1, "p256_mayo1"},
+    {OQS_SIG_alg_mayo_2, "mayo2"},
+    {OQS_SIG_alg_mayo_2, "p256_mayo2"},
+    {OQS_SIG_alg_mayo_3, "mayo3"},
+    {OQS_SIG_alg_mayo_3, "p384_mayo3"},
+    {OQS_SIG_alg_mayo_5, "mayo5"},
+    {OQS_SIG_alg_mayo_5, "p521_mayo5"},
+    {OQS_SIG_alg_cross_rsdp_128_balanced, "CROSSrsdp128balanced"},
+    {OQS_SIG_alg_uov_ov_Is_pkc, "OV_Is_pkc"},
+    {OQS_SIG_alg_uov_ov_Is_pkc, "p256_OV_Is_pkc"},
+    {OQS_SIG_alg_uov_ov_Ip_pkc, "OV_Ip_pkc"},
+    {OQS_SIG_alg_uov_ov_Ip_pkc, "p256_OV_Ip_pkc"},
+    {OQS_SIG_alg_uov_ov_Is_pkc_skc, "OV_Is_pkc_skc"},
+    {OQS_SIG_alg_uov_ov_Is_pkc_skc, "p256_OV_Is_pkc_skc"},
+    {OQS_SIG_alg_uov_ov_Ip_pkc_skc, "OV_Ip_pkc_skc"},
+    {OQS_SIG_alg_uov_ov_Ip_pkc_skc, "p256_OV_Ip_pkc_skc"},
+    {OQS_SIG_alg_snova_SNOVA_24_5_4, "snova2454"},
+    {OQS_SIG_alg_snova_SNOVA_24_5_4, "p256_snova2454"},
+    {OQS_SIG_alg_snova_SNOVA_24_5_4_esk, "snova2454esk"},
+    {OQS_SIG_alg_snova_SNOVA_24_5_4_esk, "p256_snova2454esk"},
+    {OQS_SIG_alg_snova_SNOVA_37_17_2, "snova37172"},
+    {OQS_SIG_alg_snova_SNOVA_37_17_2, "p256_snova37172"},
+    {OQS_SIG_alg_snova_SNOVA_24_5_5, "snova2455"},
+    {OQS_SIG_alg_snova_SNOVA_24_5_5, "p384_snova2455"},
+    {OQS_SIG_alg_snova_SNOVA_29_6_5, "snova2965"},
+    {OQS_SIG_alg_snova_SNOVA_29_6_5, "p521_snova2965"},
+    {OQS_SIG_alg_slh_dsa_pure_sha2_128s, "slhdsasha2128s"},
+    {OQS_SIG_alg_slh_dsa_pure_sha2_128f, "slhdsasha2128f"},
+    {OQS_SIG_alg_slh_dsa_pure_sha2_192s, "slhdsasha2192s"},
+    {OQS_SIG_alg_slh_dsa_pure_sha2_192f, "slhdsasha2192f"},
+    {OQS_SIG_alg_slh_dsa_pure_sha2_256s, "slhdsasha2256s"},
+    {OQS_SIG_alg_slh_dsa_pure_sha2_256f, "slhdsasha2256f"},
+    {OQS_SIG_alg_slh_dsa_pure_shake_128s, "slhdsashake128s"},
+    {OQS_SIG_alg_slh_dsa_pure_shake_128f, "slhdsashake128f"},
+    {OQS_SIG_alg_slh_dsa_pure_shake_192s, "slhdsashake192s"},
+    {OQS_SIG_alg_slh_dsa_pure_shake_192f, "slhdsashake192f"},
+    {OQS_SIG_alg_slh_dsa_pure_shake_256s, "slhdsashake256s"},
+    {OQS_SIG_alg_slh_dsa_pure_shake_256f, "slhdsashake256f"},
+};
+///// OQS_TEMPLATE_FRAGMENT_CTX_STR_SIG_ALGS_END
 
 ///// OQS_TEMPLATE_FRAGMENT_HYBRID_KEM_ALGS_START
 
@@ -127,6 +199,18 @@ int is_signature_algorithm_hybrid(const char *_alg_) {
 int is_kem_algorithm_hybrid(const char *_alg_) {
     return is_string_in_list(kHybridKEMAlgorithms, _alg_);
 }
+
+#if defined OQS_VERSION_MINOR &&                                               \
+    (OQS_VERSION_MAJOR > 0 || OQS_VERSION_MINOR >= 14)
+int does_signature_algorithm_support_ctx_str(const char *_alg_) {
+    for (unsigned int i = 0; i < SIGS_DICT_LEN; i++) {
+        if (strcmp(kOQSNameMapSignatureAlgorithms[i].alg_name, _alg_) == 0)
+            return OQS_SIG_supports_ctx_str(
+                kOQSNameMapSignatureAlgorithms[i].oqsname);
+    }
+    return 0;
+}
+#endif
 
 int get_param_octet_string(const EVP_PKEY *key, const char *param_name,
                            uint8_t **buf, size_t *buf_len) {

--- a/test/test_common.c
+++ b/test/test_common.c
@@ -34,7 +34,7 @@ typedef struct {
 
 #define SIGS_DICT_LEN 56
 
-/** \brief List of signature algorithms with support for context strings. */
+/** \brief Mapping of signature algorithm with PQ naming in liboqs */
 oqs_naming_dict kOQSNameMapSignatureAlgorithms[SIGS_DICT_LEN] = {
 
     {OQS_SIG_alg_ml_dsa_44, "mldsa44"},

--- a/test/test_common.h
+++ b/test/test_common.h
@@ -59,6 +59,16 @@ void load_oqs_provider(OSSL_LIB_CTX *libctx, const char *modulename,
  * \returns 1 if hybrid, else 0. */
 int is_signature_algorithm_hybrid(const char *_alg_);
 
+#if defined OQS_VERSION_MINOR &&                                               \
+    (OQS_VERSION_MAJOR > 0 || OQS_VERSION_MINOR >= 14)
+/** \brief Indicates if a signature algorithm supports context strings.
+ *
+ * \param alg Algorithm name.
+ *
+ * \returns 1 if it does, else 0. */
+int does_signature_algorithm_support_ctx_str(const char *_alg_);
+#endif
+
 /** \brief Indicates if an kem algorithm is hybrid or not.
  *
  * \param alg Algorithm name.


### PR DESCRIPTION
Includes C testing for signature's context string functionality. Fixes #725.

This is done by exploiting `OQS_SIG_supports_ctx_str` API from `liboqs`, available from 0.14.0 onwards. It does not make any modification to `generate.yml`. 
