### PR TITLE
Preserve property string for KEMs.

### DIFF
--- a/oqsprov/oqs_kmgmt.c
+++ b/oqsprov/oqs_kmgmt.c
@@ -497,6 +497,13 @@ static int oqsx_get_params(void *key, OSSL_PARAM params[]) {
     if (oqsx_get_hybrid_params(oqsxk, params))
         return 0;
 
+    if ((p = OSSL_PARAM_locate(params, OSSL_PKEY_PARAM_PROPERTIES)) != NULL) {
+        const char *pq = oqsxk->propq != NULL ? oqsxk->propq : "";
+
+        if (!OSSL_PARAM_set_utf8_string(p, pq))
+            return 0;
+    }
+
     // not passing in params to respond to is no error
     return 1;
 }
@@ -506,6 +513,7 @@ static const OSSL_PARAM oqsx_gettable_params[] = {
     OSSL_PARAM_int(OSSL_PKEY_PARAM_SECURITY_BITS, NULL),
     OSSL_PARAM_int(OSSL_PKEY_PARAM_MAX_SIZE, NULL),
     OSSL_PARAM_octet_string(OSSL_PKEY_PARAM_ENCODED_PUBLIC_KEY, NULL, 0),
+    OSSL_PARAM_utf8_string(OSSL_PKEY_PARAM_PROPERTIES, NULL, 0),
     OQS_KEY_TYPES(),
     OSSL_PARAM_END};
 

--- a/oqsprov/oqsprov_keys.c
+++ b/oqsprov/oqsprov_keys.c
@@ -609,7 +609,6 @@ static const int oqshybkem_init_ecp(char *tls_name, OQSX_EVP_CTX *evp_ctx,
                                     OSSL_LIB_CTX *libctx, const char *propq) {
     int ret = 1;
     const OQSX_EVP_INFO *evp_info = NULL;
-    (void)(propq);
 
     for (int i = 0; i < OSSL_NELEM(OQSX_ECP_NAMES); i++) {
         if (!strncasecmp(tls_name, OQSX_ECP_NAMES[i],
@@ -626,7 +625,7 @@ static const int oqshybkem_init_ecp(char *tls_name, OQSX_EVP_CTX *evp_ctx,
     evp_ctx->evp_info = evp_info;
 
     evp_ctx->ctx = EVP_PKEY_CTX_new_from_name(
-        libctx, OBJ_nid2sn(evp_ctx->evp_info->keytype), NULL);
+        libctx, OBJ_nid2sn(evp_ctx->evp_info->keytype), propq);
     ON_ERR_GOTO(!evp_ctx->ctx, err_init_ecp);
 
     ret = EVP_PKEY_paramgen_init(evp_ctx->ctx);
@@ -647,7 +646,6 @@ static const int oqshybkem_init_ecbp(char *tls_name, OQSX_EVP_CTX *evp_ctx,
                                      OSSL_LIB_CTX *libctx, const char *propq) {
     int ret = 1;
     const OQSX_EVP_INFO *evp_info = NULL;
-    (void)(propq);
 
     for (int i = 0; i < OSSL_NELEM(OQSX_ECBP_NAMES); i++) {
         if (!strncasecmp(tls_name, OQSX_ECBP_NAMES[i],
@@ -665,7 +663,7 @@ static const int oqshybkem_init_ecbp(char *tls_name, OQSX_EVP_CTX *evp_ctx,
     evp_ctx->evp_info = evp_info;
 
     evp_ctx->ctx = EVP_PKEY_CTX_new_from_name(
-        libctx, OBJ_nid2sn(evp_ctx->evp_info->keytype), NULL);
+        libctx, OBJ_nid2sn(evp_ctx->evp_info->keytype), propq);
     ON_ERR_GOTO(!evp_ctx->ctx, err_init_ecbp);
 
     ret = EVP_PKEY_paramgen_init(evp_ctx->ctx);

--- a/oqsprov/oqsprov_keys.c
+++ b/oqsprov/oqsprov_keys.c
@@ -606,9 +606,10 @@ err_init:
 }
 
 static const int oqshybkem_init_ecp(char *tls_name, OQSX_EVP_CTX *evp_ctx,
-                                    OSSL_LIB_CTX *libctx) {
+                                    OSSL_LIB_CTX *libctx, const char *propq) {
     int ret = 1;
     const OQSX_EVP_INFO *evp_info = NULL;
+    (void)(propq);
 
     for (int i = 0; i < OSSL_NELEM(OQSX_ECP_NAMES); i++) {
         if (!strncasecmp(tls_name, OQSX_ECP_NAMES[i],
@@ -643,9 +644,10 @@ err_init_ecp:
 }
 
 static const int oqshybkem_init_ecbp(char *tls_name, OQSX_EVP_CTX *evp_ctx,
-                                     OSSL_LIB_CTX *libctx) {
+                                     OSSL_LIB_CTX *libctx, const char *propq) {
     int ret = 1;
     const OQSX_EVP_INFO *evp_info = NULL;
+    (void)(propq);
 
     for (int i = 0; i < OSSL_NELEM(OQSX_ECBP_NAMES); i++) {
         if (!strncasecmp(tls_name, OQSX_ECBP_NAMES[i],
@@ -681,7 +683,7 @@ err_init_ecbp:
 }
 
 static const int oqshybkem_init_ecx(char *tls_name, OQSX_EVP_CTX *evp_ctx,
-                                    OSSL_LIB_CTX *libctx) {
+                                    OSSL_LIB_CTX *libctx, const char *propq) {
     int ret = 1;
     const OQSX_EVP_INFO *evp_info = NULL;
 
@@ -705,7 +707,7 @@ static const int oqshybkem_init_ecx(char *tls_name, OQSX_EVP_CTX *evp_ctx,
     ret = EVP_PKEY_set_type(evp_ctx->keyParam, evp_ctx->evp_info->keytype);
     ON_ERR_SET_GOTO(ret <= 0, ret, -1, err_init_ecx);
 
-    evp_ctx->ctx = EVP_PKEY_CTX_new_from_pkey(libctx, evp_ctx->keyParam, NULL);
+    evp_ctx->ctx = EVP_PKEY_CTX_new_from_pkey(libctx, evp_ctx->keyParam, propq);
     ON_ERR_SET_GOTO(!evp_ctx->ctx, ret, -1, err_init_ecx);
 
 err_init_ecx:
@@ -1003,7 +1005,8 @@ OQSX_KEY *oqsx_key_from_pkcs8(const PKCS8_PRIV_KEY_INFO *p8inf,
     return oqsx;
 }
 
-static const int (*init_kex_fun[])(char *, OQSX_EVP_CTX *, OSSL_LIB_CTX *) = {
+static const int (*init_kex_fun[])(char *, OQSX_EVP_CTX *, OSSL_LIB_CTX *,
+                                   const char *) = {
     oqshybkem_init_ecp, oqshybkem_init_ecbp, oqshybkem_init_ecx};
 extern const char *oqs_oid_alg_list[];
 
@@ -1092,7 +1095,7 @@ OQSX_KEY *oqsx_key_new(OSSL_LIB_CTX *libctx, char *oqs_name, char *tls_name,
         ON_ERR_GOTO(!evp_ctx, err);
 
         ret2 = (init_kex_fun[primitive - KEY_TYPE_ECP_HYB_KEM])(
-            tls_name, evp_ctx, libctx);
+            tls_name, evp_ctx, libctx, propq);
         ON_ERR_GOTO(ret2 <= 0 || !evp_ctx->keyParam || !evp_ctx->ctx, err);
 
         ret->numkeys = 2;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -166,7 +166,7 @@ set_tests_properties(oqs_evp_pkey_params
 endif()
 
 add_test(
-    NAME oqs_test_prop_str
+    NAME oqs_prop_str
     COMMAND oqs_test_prop_str
             "oqsprovider"
             "${CMAKE_CURRENT_SOURCE_DIR}/oqs.cnf"
@@ -174,11 +174,11 @@ add_test(
 # openssl under MSVC seems to have a bug registering NIDs:
 # It only works when setting OPENSSL_CONF, not when loading the same cnf file:
 if (MSVC)
-set_tests_properties(oqs_test_prop_str
+set_tests_properties(oqs_prop_str
     PROPERTIES ENVIRONMENT "OPENSSL_MODULES=${OQS_PROV_BINARY_DIR};OPENSSL_CONF=${CMAKE_CURRENT_SOURCE_DIR}/openssl-ca.cnf"
 )
 else()
-set_tests_properties(oqs_test_prop_str
+set_tests_properties(oqs_prop_str
     PROPERTIES ENVIRONMENT "OPENSSL_MODULES=${OQS_PROV_BINARY_DIR}"
 )
 endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -165,10 +165,6 @@ set_tests_properties(oqs_evp_pkey_params
 )
 endif()
 
-add_executable(oqs_test_prop_str oqs_test_prop_str.c test_common.c)
-target_include_directories(oqs_test_prop_str PRIVATE "../oqsprov")
-target_link_libraries(oqs_test_prop_str PRIVATE ${OPENSSL_CRYPTO_LIBRARY} ${OQS_ADDL_SOCKET_LIBS} ${REQ_LIBS_T})
-
 add_test(
     NAME oqs_test_prop_str
     COMMAND oqs_test_prop_str
@@ -186,6 +182,10 @@ set_tests_properties(oqs_test_prop_str
     PROPERTIES ENVIRONMENT "OPENSSL_MODULES=${OQS_PROV_BINARY_DIR}"
 )
 endif()
+
+add_executable(oqs_test_prop_str oqs_test_prop_str.c test_common.c)
+target_include_directories(oqs_test_prop_str PRIVATE "../oqsprov")
+target_link_libraries(oqs_test_prop_str PRIVATE ${OPENSSL_CRYPTO_LIBRARY} ${OQS_ADDL_SOCKET_LIBS} ${REQ_LIBS_T})
 
 if (OQS_PROVIDER_BUILD_STATIC)
   targets_set_static_provider(oqs_test_signatures

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -165,6 +165,28 @@ set_tests_properties(oqs_evp_pkey_params
 )
 endif()
 
+add_executable(oqs_test_prop_str oqs_test_prop_str.c test_common.c)
+target_include_directories(oqs_test_prop_str PRIVATE "../oqsprov")
+target_link_libraries(oqs_test_prop_str PRIVATE ${OPENSSL_CRYPTO_LIBRARY} ${OQS_ADDL_SOCKET_LIBS} ${REQ_LIBS_T})
+
+add_test(
+    NAME oqs_test_prop_str
+    COMMAND oqs_test_prop_str
+            "oqsprovider"
+            "${CMAKE_CURRENT_SOURCE_DIR}/oqs.cnf"
+)
+# openssl under MSVC seems to have a bug registering NIDs:
+# It only works when setting OPENSSL_CONF, not when loading the same cnf file:
+if (MSVC)
+set_tests_properties(oqs_test_prop_str
+    PROPERTIES ENVIRONMENT "OPENSSL_MODULES=${OQS_PROV_BINARY_DIR};OPENSSL_CONF=${CMAKE_CURRENT_SOURCE_DIR}/openssl-ca.cnf"
+)
+else()
+set_tests_properties(oqs_test_prop_str
+    PROPERTIES ENVIRONMENT "OPENSSL_MODULES=${OQS_PROV_BINARY_DIR}"
+)
+endif()
+
 if (OQS_PROVIDER_BUILD_STATIC)
   targets_set_static_provider(oqs_test_signatures
     oqs_test_kems
@@ -173,5 +195,6 @@ if (OQS_PROVIDER_BUILD_STATIC)
     oqs_test_tlssig
     oqs_test_endecode
     oqs_test_evp_pkey_params
+    oqs_test_prop_str
   )
 endif()

--- a/test/oqs_test_kems.c
+++ b/test/oqs_test_kems.c
@@ -12,6 +12,8 @@ static OSSL_LIB_CTX *libctx = NULL;
 static char *modulename = NULL;
 static char *configfile = NULL;
 
+#define OQSPROV_PROPQ_MISSING "provider=the-missing-link"
+
 static int test_oqs_kems(const char *kemalg_name) {
     EVP_MD_CTX *mdctx = NULL;
     EVP_PKEY_CTX *ctx = NULL;
@@ -133,6 +135,165 @@ err:
     return testresult;
 }
 
+/*
+ * Runs keygen + encapsulate + decapsulate for one hybrid KEM with the given
+ * property query string. Returns 1 on success, 0 on failure.
+ */
+static int test_oqs_hybrid_kems_with_propq(const char *kemalg_name,
+                                           const char *propq) {
+    EVP_PKEY_CTX *ctx = NULL;
+    EVP_PKEY *key = NULL, *peer = NULL;
+    unsigned char *out = NULL;
+    unsigned char *secenc = NULL;
+    unsigned char *secdec = NULL;
+    unsigned char *pubkey = NULL;
+    size_t outlen, seclen, publen;
+    int testresult = 0;
+
+    if (!OSSL_PROVIDER_available(libctx, "default"))
+        return 0;
+
+    ctx = EVP_PKEY_CTX_new_from_name(libctx, kemalg_name, propq);
+    if (ctx == NULL)
+        return 0;
+    if (!EVP_PKEY_keygen_init(ctx) || !EVP_PKEY_generate(ctx, &key)) {
+        EVP_PKEY_CTX_free(ctx);
+        return 0;
+    }
+    EVP_PKEY_CTX_free(ctx);
+    ctx = NULL;
+
+    ctx = EVP_PKEY_CTX_new_from_pkey(libctx, key, propq);
+    if (ctx == NULL)
+        goto err;
+    if (!EVP_PKEY_encapsulate_init(ctx, NULL) ||
+        !EVP_PKEY_encapsulate(ctx, NULL, &outlen, NULL, &seclen))
+        goto err;
+    out = OPENSSL_malloc(outlen);
+    secenc = OPENSSL_malloc(seclen);
+    secdec = OPENSSL_malloc(seclen);
+    if (out == NULL || secenc == NULL || secdec == NULL)
+        goto err;
+    memset(secenc, 0x11, seclen);
+    memset(secdec, 0xff, seclen);
+    if (!EVP_PKEY_encapsulate(ctx, out, &outlen, secenc, &seclen))
+        goto err;
+    if (!EVP_PKEY_decapsulate_init(ctx, NULL) ||
+        !EVP_PKEY_decapsulate(ctx, secdec, &seclen, out, outlen))
+        goto err;
+    if (memcmp(secenc, secdec, seclen) != 0)
+        goto err;
+
+    if (!EVP_PKEY_get_octet_string_param(key, OSSL_PKEY_PARAM_PUB_KEY, NULL, 0,
+                                         &publen))
+        goto err;
+    pubkey = OPENSSL_malloc(publen);
+    if (pubkey == NULL ||
+        !EVP_PKEY_get_octet_string_param(key, OSSL_PKEY_PARAM_PUB_KEY, pubkey,
+                                         publen, NULL))
+        goto err;
+    peer = EVP_PKEY_new_raw_public_key_ex(libctx, kemalg_name, propq, pubkey,
+                                          publen);
+    if (peer == NULL)
+        goto err;
+    EVP_PKEY_CTX_free(ctx);
+    ctx = NULL;
+    OPENSSL_free(out);
+    out = NULL;
+    OPENSSL_free(secenc);
+    secenc = NULL;
+
+    ctx = EVP_PKEY_CTX_new_from_pkey(libctx, peer, propq);
+    if (ctx == NULL)
+        goto err;
+    if (!EVP_PKEY_encapsulate_init(ctx, NULL) ||
+        !EVP_PKEY_encapsulate(ctx, NULL, &outlen, NULL, &seclen))
+        goto err;
+    out = OPENSSL_malloc(outlen);
+    secenc = OPENSSL_malloc(seclen);
+    if (out == NULL || secenc == NULL)
+        goto err;
+    memset(secenc, 0x11, seclen);
+    if (!EVP_PKEY_encapsulate(ctx, out, &outlen, secenc, &seclen))
+        goto err;
+    EVP_PKEY_CTX_free(ctx);
+    ctx = NULL;
+    OPENSSL_free(secdec);
+    secdec = NULL;
+
+    ctx = EVP_PKEY_CTX_new_from_pkey(libctx, key, propq);
+    if (ctx == NULL)
+        goto err;
+    secdec = OPENSSL_malloc(seclen);
+    if (secdec == NULL)
+        goto err;
+    memset(secdec, 0xff, seclen);
+    if (!EVP_PKEY_decapsulate_init(ctx, NULL) ||
+        !EVP_PKEY_decapsulate(ctx, secdec, &seclen, out, outlen))
+        goto err;
+    if (memcmp(secenc, secdec, seclen) != 0)
+        goto err;
+
+    testresult = 1;
+err:
+    EVP_PKEY_free(key);
+    EVP_PKEY_free(peer);
+    EVP_PKEY_CTX_free(ctx);
+    OPENSSL_free(pubkey);
+    OPENSSL_free(out);
+    OPENSSL_free(secenc);
+    OPENSSL_free(secdec);
+    return testresult;
+}
+
+/*
+ * Test hybrid KEMs only. For each enabled hybrid algorithm:
+ * - With OQSPROV_PROPQ: expect success.
+ * - With NULL propq: expect success (when default provider is available).
+ * - With "provider=the-missing-link": expect failure (no such provider).
+ */
+static int test_oqs_hybrid_kems(const char *kemalg_name) {
+    int testresult = 1;
+
+    if (!is_kem_algorithm_hybrid(kemalg_name))
+        return 1; /* skip non-hybrid */
+
+    if (!alg_is_enabled(kemalg_name)) {
+        fprintf(stderr, "Not testing disabled hybrid KEM %s.\n", kemalg_name);
+        return 1;
+    }
+
+    if (!OSSL_PROVIDER_available(libctx, "default")) {
+        fprintf(stderr,
+                "Skipping hybrid KEM test (default provider not loaded): %s.\n",
+                kemalg_name);
+        return 1;
+    }
+
+    /* Must succeed with OQSPROV_PROPQ */
+    if (!test_oqs_hybrid_kems_with_propq(kemalg_name, OQSPROV_PROPQ)) {
+        fprintf(stderr, "Hybrid KEM failed with OQSPROV_PROPQ: %s\n",
+                kemalg_name);
+        testresult = 0;
+    }
+
+    /* Must succeed with NULL propq (default provider resolves) */
+    if (!test_oqs_hybrid_kems_with_propq(kemalg_name, NULL)) {
+        fprintf(stderr, "Hybrid KEM failed with NULL propq: %s\n", kemalg_name);
+        testresult = 0;
+    }
+
+    /* Must fail with non-existent provider (propq is applied) */
+    if (test_oqs_hybrid_kems_with_propq(kemalg_name, OQSPROV_PROPQ_MISSING)) {
+        fprintf(stderr,
+                "Hybrid KEM unexpectedly succeeded with missing provider: %s\n",
+                kemalg_name);
+        testresult = 0;
+    }
+
+    return testresult;
+}
+
 #define nelem(a) (sizeof(a) / sizeof((a)[0]))
 
 int main(int argc, char *argv[]) {
@@ -154,14 +315,29 @@ int main(int argc, char *argv[]) {
         OSSL_PROVIDER_query_operation(oqsprov, OSSL_OP_KEM, &query_nocache);
     if (kemalgs) {
         for (; kemalgs->algorithm_names != NULL; kemalgs++) {
-            if (test_oqs_kems(kemalgs->algorithm_names)) {
-                fprintf(stderr, cGREEN "  KEM test succeeded: %s" cNORM "\n",
-                        kemalgs->algorithm_names);
+            const char *name = kemalgs->algorithm_names;
+            if (is_kem_algorithm_hybrid(name)) {
+                if (test_oqs_hybrid_kems(name)) {
+                    fprintf(stderr,
+                            cGREEN "  Hybrid KEM test succeeded: %s" cNORM "\n",
+                            name);
+                } else {
+                    fprintf(stderr,
+                            cRED "  Hybrid KEM test failed: %s" cNORM "\n",
+                            name);
+                    ERR_print_errors_fp(stderr);
+                    errcnt++;
+                }
             } else {
-                fprintf(stderr, cRED "  KEM test failed: %s" cNORM "\n",
-                        kemalgs->algorithm_names);
-                ERR_print_errors_fp(stderr);
-                errcnt++;
+                if (test_oqs_kems(name)) {
+                    fprintf(stderr,
+                            cGREEN "  KEM test succeeded: %s" cNORM "\n", name);
+                } else {
+                    fprintf(stderr, cRED "  KEM test failed: %s" cNORM "\n",
+                            name);
+                    ERR_print_errors_fp(stderr);
+                    errcnt++;
+                }
             }
         }
     }

--- a/test/oqs_test_kems.c
+++ b/test/oqs_test_kems.c
@@ -12,8 +12,6 @@ static OSSL_LIB_CTX *libctx = NULL;
 static char *modulename = NULL;
 static char *configfile = NULL;
 
-#define OQSPROV_PROPQ_MISSING "provider=the-missing-link"
-
 static int test_oqs_kems(const char *kemalg_name) {
     EVP_MD_CTX *mdctx = NULL;
     EVP_PKEY_CTX *ctx = NULL;
@@ -135,165 +133,6 @@ err:
     return testresult;
 }
 
-/*
- * Runs keygen + encapsulate + decapsulate for one hybrid KEM with the given
- * property query string. Returns 1 on success, 0 on failure.
- */
-static int test_oqs_hybrid_kems_with_propq(const char *kemalg_name,
-                                           const char *propq) {
-    EVP_PKEY_CTX *ctx = NULL;
-    EVP_PKEY *key = NULL, *peer = NULL;
-    unsigned char *out = NULL;
-    unsigned char *secenc = NULL;
-    unsigned char *secdec = NULL;
-    unsigned char *pubkey = NULL;
-    size_t outlen, seclen, publen;
-    int testresult = 0;
-
-    if (!OSSL_PROVIDER_available(libctx, "default"))
-        return 0;
-
-    ctx = EVP_PKEY_CTX_new_from_name(libctx, kemalg_name, propq);
-    if (ctx == NULL)
-        return 0;
-    if (!EVP_PKEY_keygen_init(ctx) || !EVP_PKEY_generate(ctx, &key)) {
-        EVP_PKEY_CTX_free(ctx);
-        return 0;
-    }
-    EVP_PKEY_CTX_free(ctx);
-    ctx = NULL;
-
-    ctx = EVP_PKEY_CTX_new_from_pkey(libctx, key, propq);
-    if (ctx == NULL)
-        goto err;
-    if (!EVP_PKEY_encapsulate_init(ctx, NULL) ||
-        !EVP_PKEY_encapsulate(ctx, NULL, &outlen, NULL, &seclen))
-        goto err;
-    out = OPENSSL_malloc(outlen);
-    secenc = OPENSSL_malloc(seclen);
-    secdec = OPENSSL_malloc(seclen);
-    if (out == NULL || secenc == NULL || secdec == NULL)
-        goto err;
-    memset(secenc, 0x11, seclen);
-    memset(secdec, 0xff, seclen);
-    if (!EVP_PKEY_encapsulate(ctx, out, &outlen, secenc, &seclen))
-        goto err;
-    if (!EVP_PKEY_decapsulate_init(ctx, NULL) ||
-        !EVP_PKEY_decapsulate(ctx, secdec, &seclen, out, outlen))
-        goto err;
-    if (memcmp(secenc, secdec, seclen) != 0)
-        goto err;
-
-    if (!EVP_PKEY_get_octet_string_param(key, OSSL_PKEY_PARAM_PUB_KEY, NULL, 0,
-                                         &publen))
-        goto err;
-    pubkey = OPENSSL_malloc(publen);
-    if (pubkey == NULL ||
-        !EVP_PKEY_get_octet_string_param(key, OSSL_PKEY_PARAM_PUB_KEY, pubkey,
-                                         publen, NULL))
-        goto err;
-    peer = EVP_PKEY_new_raw_public_key_ex(libctx, kemalg_name, propq, pubkey,
-                                          publen);
-    if (peer == NULL)
-        goto err;
-    EVP_PKEY_CTX_free(ctx);
-    ctx = NULL;
-    OPENSSL_free(out);
-    out = NULL;
-    OPENSSL_free(secenc);
-    secenc = NULL;
-
-    ctx = EVP_PKEY_CTX_new_from_pkey(libctx, peer, propq);
-    if (ctx == NULL)
-        goto err;
-    if (!EVP_PKEY_encapsulate_init(ctx, NULL) ||
-        !EVP_PKEY_encapsulate(ctx, NULL, &outlen, NULL, &seclen))
-        goto err;
-    out = OPENSSL_malloc(outlen);
-    secenc = OPENSSL_malloc(seclen);
-    if (out == NULL || secenc == NULL)
-        goto err;
-    memset(secenc, 0x11, seclen);
-    if (!EVP_PKEY_encapsulate(ctx, out, &outlen, secenc, &seclen))
-        goto err;
-    EVP_PKEY_CTX_free(ctx);
-    ctx = NULL;
-    OPENSSL_free(secdec);
-    secdec = NULL;
-
-    ctx = EVP_PKEY_CTX_new_from_pkey(libctx, key, propq);
-    if (ctx == NULL)
-        goto err;
-    secdec = OPENSSL_malloc(seclen);
-    if (secdec == NULL)
-        goto err;
-    memset(secdec, 0xff, seclen);
-    if (!EVP_PKEY_decapsulate_init(ctx, NULL) ||
-        !EVP_PKEY_decapsulate(ctx, secdec, &seclen, out, outlen))
-        goto err;
-    if (memcmp(secenc, secdec, seclen) != 0)
-        goto err;
-
-    testresult = 1;
-err:
-    EVP_PKEY_free(key);
-    EVP_PKEY_free(peer);
-    EVP_PKEY_CTX_free(ctx);
-    OPENSSL_free(pubkey);
-    OPENSSL_free(out);
-    OPENSSL_free(secenc);
-    OPENSSL_free(secdec);
-    return testresult;
-}
-
-/*
- * Test hybrid KEMs only. For each enabled hybrid algorithm:
- * - With OQSPROV_PROPQ: expect success.
- * - With NULL propq: expect success (when default provider is available).
- * - With "provider=the-missing-link": expect failure (no such provider).
- */
-static int test_oqs_hybrid_kems(const char *kemalg_name) {
-    int testresult = 1;
-
-    if (!is_kem_algorithm_hybrid(kemalg_name))
-        return 1; /* skip non-hybrid */
-
-    if (!alg_is_enabled(kemalg_name)) {
-        fprintf(stderr, "Not testing disabled hybrid KEM %s.\n", kemalg_name);
-        return 1;
-    }
-
-    if (!OSSL_PROVIDER_available(libctx, "default")) {
-        fprintf(stderr,
-                "Skipping hybrid KEM test (default provider not loaded): %s.\n",
-                kemalg_name);
-        return 1;
-    }
-
-    /* Must succeed with OQSPROV_PROPQ */
-    if (!test_oqs_hybrid_kems_with_propq(kemalg_name, OQSPROV_PROPQ)) {
-        fprintf(stderr, "Hybrid KEM failed with OQSPROV_PROPQ: %s\n",
-                kemalg_name);
-        testresult = 0;
-    }
-
-    /* Must succeed with NULL propq (default provider resolves) */
-    if (!test_oqs_hybrid_kems_with_propq(kemalg_name, NULL)) {
-        fprintf(stderr, "Hybrid KEM failed with NULL propq: %s\n", kemalg_name);
-        testresult = 0;
-    }
-
-    /* Must fail with non-existent provider (propq is applied) */
-    if (test_oqs_hybrid_kems_with_propq(kemalg_name, OQSPROV_PROPQ_MISSING)) {
-        fprintf(stderr,
-                "Hybrid KEM unexpectedly succeeded with missing provider: %s\n",
-                kemalg_name);
-        testresult = 0;
-    }
-
-    return testresult;
-}
-
 #define nelem(a) (sizeof(a) / sizeof((a)[0]))
 
 int main(int argc, char *argv[]) {
@@ -315,29 +154,14 @@ int main(int argc, char *argv[]) {
         OSSL_PROVIDER_query_operation(oqsprov, OSSL_OP_KEM, &query_nocache);
     if (kemalgs) {
         for (; kemalgs->algorithm_names != NULL; kemalgs++) {
-            const char *name = kemalgs->algorithm_names;
-            if (is_kem_algorithm_hybrid(name)) {
-                if (test_oqs_hybrid_kems(name)) {
-                    fprintf(stderr,
-                            cGREEN "  Hybrid KEM test succeeded: %s" cNORM "\n",
-                            name);
-                } else {
-                    fprintf(stderr,
-                            cRED "  Hybrid KEM test failed: %s" cNORM "\n",
-                            name);
-                    ERR_print_errors_fp(stderr);
-                    errcnt++;
-                }
+            if (test_oqs_kems(kemalgs->algorithm_names)) {
+                fprintf(stderr, cGREEN "  KEM test succeeded: %s" cNORM "\n",
+                        kemalgs->algorithm_names);
             } else {
-                if (test_oqs_kems(name)) {
-                    fprintf(stderr,
-                            cGREEN "  KEM test succeeded: %s" cNORM "\n", name);
-                } else {
-                    fprintf(stderr, cRED "  KEM test failed: %s" cNORM "\n",
-                            name);
-                    ERR_print_errors_fp(stderr);
-                    errcnt++;
-                }
+                fprintf(stderr, cRED "  KEM test failed: %s" cNORM "\n",
+                        kemalgs->algorithm_names);
+                ERR_print_errors_fp(stderr);
+                errcnt++;
             }
         }
     }

--- a/test/oqs_test_prop_str.c
+++ b/test/oqs_test_prop_str.c
@@ -1,0 +1,268 @@
+// SPDX-License-Identifier: Apache-2.0 AND MIT
+//
+// Verifies the OQS keymgmt stores the property query on KEM keys by
+// reading OSSL_PKEY_PARAM_PROPERTIES via EVP.
+//
+// Expected property string: OQS_TST_PROPQ (provider=default,
+// provider=oqsprovider, fips=no). Override at compile time with
+// -DOQS_TST_PROPQ=...
+//
+// Usage: oqs_test_prop_str <modulename> <config_file>
+
+#include <openssl/core_names.h>
+#include <openssl/err.h>
+#include <openssl/evp.h>
+#include <openssl/objects.h>
+#include <openssl/params.h>
+#include <openssl/provider.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "test_common.h"
+
+#ifndef OQS_TST_PROPQ
+#define OQS_TST_PROPQ "provider=default,provider=oqsprovider,fips=no"
+#endif
+
+#ifdef _MSC_VER
+#define strtok_r strtok_s
+#endif
+
+static int test_propq_on_pkey(OSSL_LIB_CTX *libctx, const char *algname,
+                              int expect_null_propq) {
+    EVP_PKEY_CTX *ctx = NULL;
+    EVP_PKEY *pkey = NULL;
+    char buf[512];
+    size_t got_len = 0;
+    int ok = 0;
+
+    /*
+     * The third argument only affects EVP_KEYMGMT_fetch; OpenSSL does not pass
+     * it into keygen.  To record the query on the key, set
+     * OSSL_PKEY_PARAM_PROPERTIES on the genctx after EVP_PKEY_keygen_init().
+     */
+    ctx = EVP_PKEY_CTX_new_from_name(libctx, algname, OQS_TST_PROPQ);
+    if (ctx == NULL) {
+        fprintf(stderr, "EVP_PKEY_CTX_new_from_name(%s) failed\n", algname);
+        ERR_print_errors_fp(stderr);
+        return 0;
+    }
+    if (EVP_PKEY_keygen_init(ctx) <= 0) {
+        fprintf(stderr, "EVP_PKEY_keygen_init failed for %s\n", algname);
+        ERR_print_errors_fp(stderr);
+        EVP_PKEY_CTX_free(ctx);
+        return 0;
+    }
+    if (!expect_null_propq) {
+        OSSL_PARAM props[2];
+
+        props[0] = OSSL_PARAM_construct_utf8_string(OSSL_PKEY_PARAM_PROPERTIES,
+                                                    (char *)OQS_TST_PROPQ, 0);
+        props[1] = OSSL_PARAM_construct_end();
+        if (EVP_PKEY_CTX_set_params(ctx, props) <= 0) {
+            fprintf(stderr,
+                    "EVP_PKEY_CTX_set_params(PROPERTIES) failed for %s\n",
+                    algname);
+            ERR_print_errors_fp(stderr);
+            EVP_PKEY_CTX_free(ctx);
+            return 0;
+        }
+    }
+    if (EVP_PKEY_keygen(ctx, &pkey) <= 0) {
+        fprintf(stderr, "EVP_PKEY_keygen failed for %s\n", algname);
+        ERR_print_errors_fp(stderr);
+        EVP_PKEY_CTX_free(ctx);
+        return 0;
+    }
+    EVP_PKEY_CTX_free(ctx);
+    ctx = NULL;
+
+    if (!EVP_PKEY_get_utf8_string_param(pkey, OSSL_PKEY_PARAM_PROPERTIES, buf,
+                                        sizeof(buf), &got_len)) {
+        fprintf(stderr,
+                "EVP_PKEY_get_utf8_string_param(PROPERTIES) failed "
+                "for %s\n",
+                algname);
+        ERR_print_errors_fp(stderr);
+        EVP_PKEY_free(pkey);
+        return 0;
+    }
+
+    if (expect_null_propq) {
+        if (got_len != 0) {
+            fprintf(stderr,
+                    "expected empty PROPERTIES on key for %s, got len %zu\n",
+                    algname, got_len);
+            ok = 0;
+        } else {
+            ok = 1;
+        }
+    } else {
+        if (got_len != strlen(OQS_TST_PROPQ) ||
+            strcmp(buf, OQS_TST_PROPQ) != 0) {
+            fprintf(stderr,
+                    "PROPERTIES mismatch for %s: got \"%s\" (len %zu), "
+                    "expected \"%s\" (OQS_TST_PROPQ)\n",
+                    algname, buf, got_len, OQS_TST_PROPQ);
+            ok = 0;
+        } else {
+            ok = 1;
+        }
+    }
+
+    EVP_PKEY_free(pkey);
+    return ok;
+}
+
+int main(int argc, char *argv[]) {
+    const OSSL_ALGORITHM *algs;
+    OSSL_LIB_CTX *libctx = NULL;
+    OSSL_PROVIDER *oqsprov = NULL;
+    int query_nocache = 0;
+    int errcnt = 0;
+    int kem_runs = 0;
+    int sig_runs = 0;
+    int ret;
+
+    if (argc != 3) {
+        fprintf(stderr, "usage: %s <modulename> <config_file>\n", argv[0]);
+        return 1;
+    }
+
+    libctx = OSSL_LIB_CTX_new();
+    if (libctx == NULL) {
+        fprintf(stderr, "OSSL_LIB_CTX_new failed\n");
+        return 1;
+    }
+
+    load_default_provider(libctx);
+    load_oqs_provider(libctx, argv[1], argv[2]);
+
+    oqsprov = OSSL_PROVIDER_load(libctx, argv[1]);
+    if (oqsprov == NULL) {
+        fprintf(stderr, "OSSL_PROVIDER_load(%s) failed\n", argv[1]);
+        OSSL_LIB_CTX_free(libctx);
+        return 1;
+    }
+
+    algs = OSSL_PROVIDER_query_operation(oqsprov, OSSL_OP_KEM, &query_nocache);
+    if (algs) {
+        for (; algs->algorithm_names != NULL; algs++) {
+            char buf[256];
+            char *saveptr = NULL;
+            char *tok;
+
+            OPENSSL_strlcpy(buf, algs->algorithm_names, sizeof(buf));
+            for (tok = strtok_r(buf, ",", &saveptr); tok != NULL;
+                 tok = strtok_r(NULL, ",", &saveptr)) {
+                while (*tok == ' ')
+                    tok++;
+
+                if (!alg_is_enabled(tok)) {
+                    fprintf(stderr, "Not testing disabled KEM %s.\n", tok);
+                    continue;
+                }
+
+                fprintf(stderr, "testing KEM \"%s\" (PROPERTIES / propq)\n",
+                        tok);
+
+                {
+                    int ok1 = test_propq_on_pkey(libctx, tok, 0);
+                    int ok2 = test_propq_on_pkey(libctx, tok, 1);
+
+                    if (!ok1)
+                        errcnt++;
+                    if (!ok2)
+                        errcnt++;
+                    kem_runs++;
+                    if (ok1 && ok2) {
+                        fprintf(stderr,
+                                cGREEN "  KEM PROPERTIES checks "
+                                       "passed: %s" cNORM "\n",
+                                tok);
+                    } else {
+                        fprintf(stderr,
+                                cRED "  KEM PROPERTIES checks failed: "
+                                     "%s" cNORM "\n",
+                                tok);
+                    }
+                }
+            }
+        }
+    }
+
+    if (kem_runs == 0) {
+        fprintf(stderr, "warning: no enabled KEM was exercised "
+                        "(none registered or all skipped)\n");
+    }
+
+    algs = OSSL_PROVIDER_query_operation(oqsprov, OSSL_OP_SIGNATURE,
+                                         &query_nocache);
+    if (algs) {
+        for (; algs->algorithm_names != NULL; algs++) {
+            char buf[256];
+            char *saveptr = NULL;
+            char *tok;
+
+            OPENSSL_strlcpy(buf, algs->algorithm_names, sizeof(buf));
+            for (tok = strtok_r(buf, ",", &saveptr); tok != NULL;
+                 tok = strtok_r(NULL, ",", &saveptr)) {
+                while (*tok == ' ')
+                    tok++;
+
+                /* User asked for PQ signatures; skip hybrids here. */
+                if (is_signature_algorithm_hybrid(tok))
+                    continue;
+
+                if (!alg_is_enabled(tok)) {
+                    fprintf(stderr, "Not testing disabled PQ signature %s.\n",
+                            tok);
+                    continue;
+                }
+
+                fprintf(stderr,
+                        "testing PQ signature \"%s\" (PROPERTIES / propq)\n",
+                        tok);
+
+                {
+                    int ok1 = test_propq_on_pkey(libctx, tok, 0);
+                    int ok2 = test_propq_on_pkey(libctx, tok, 1);
+
+                    if (!ok1)
+                        errcnt++;
+                    if (!ok2)
+                        errcnt++;
+                    sig_runs++;
+                    if (ok1 && ok2) {
+                        fprintf(stderr,
+                                cGREEN "  PQ signature PROPERTIES checks "
+                                       "passed: %s" cNORM "\n",
+                                tok);
+                    } else {
+                        fprintf(stderr,
+                                cRED "  PQ signature PROPERTIES checks failed: "
+                                     "%s" cNORM "\n",
+                                tok);
+                    }
+                }
+            }
+        }
+    }
+
+    if (sig_runs == 0) {
+        fprintf(stderr, "warning: no enabled PQ signature was exercised "
+                        "(none registered or all skipped)\n");
+    }
+
+    ret = errcnt != 0 ? 1 : 0;
+    if (ret == 0) {
+        fprintf(stderr,
+                cGREEN "OQS KEM/PQ-signature PROPERTIES (propq) EVP tests "
+                       "finished "
+                       "without failures" cNORM "\n");
+    }
+
+    OSSL_PROVIDER_unload(oqsprov);
+    OSSL_LIB_CTX_free(libctx);
+    return ret;
+}

--- a/test/oqs_test_prop_str.c
+++ b/test/oqs_test_prop_str.c
@@ -135,7 +135,6 @@ int main(int argc, char *argv[]) {
         return 1;
     }
 
-    load_default_provider(libctx);
     load_oqs_provider(libctx, argv[1], argv[2]);
 
     oqsprov = OSSL_PROVIDER_load(libctx, argv[1]);


### PR DESCRIPTION
Preserve the query string. Useful in cases where there is a desire to filter on classical algs that are FIPS approved. 

<!-- Please give a brief explanation of the purpose of this pull request. -->

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->
