### PR TITLE
Fix import parameters based on 'OSSL_KEYMGMT_SELECT_KEYPAIR'

### DIFF
--- a/oqsprov/oqs_kmgmt.c
+++ b/oqsprov/oqs_kmgmt.c
@@ -230,7 +230,8 @@ static int oqsx_import(void *keydata, int selection,
     }
 
     if (((selection & OSSL_KEYMGMT_SELECT_KEYPAIR) != 0) &&
-        (oqsx_key_fromdata(key, params, selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY)))
+        (oqsx_key_fromdata(key, params,
+                           selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY)))
         ok = 1;
     return ok;
 }

--- a/oqsprov/oqs_kmgmt.c
+++ b/oqsprov/oqs_kmgmt.c
@@ -229,8 +229,8 @@ static int oqsx_import(void *keydata, int selection,
         return ok;
     }
 
-    if (((selection & OSSL_KEYMGMT_SELECT_ALL_PARAMETERS) != 0) &&
-        (oqsx_key_fromdata(key, params, 1)))
+    if (((selection & OSSL_KEYMGMT_SELECT_KEYPAIR) != 0) &&
+        (oqsx_key_fromdata(key, params, selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY)))
         ok = 1;
     return ok;
 }

--- a/oqsprov/oqs_kmgmt.c
+++ b/oqsprov/oqs_kmgmt.c
@@ -221,7 +221,7 @@ static int oqsx_match(const void *keydata1, const void *keydata2,
 static int oqsx_import(void *keydata, int selection,
                        const OSSL_PARAM params[]) {
     OQSX_KEY *key = keydata;
-    int ok = 0;
+    int ok = 0, include_private;
 
     OQS_KM_PRINTF("OQSKEYMGMT: import called \n");
     if (key == NULL) {
@@ -229,9 +229,9 @@ static int oqsx_import(void *keydata, int selection,
         return ok;
     }
 
+    include_private = ((selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY) != 0);
     if (((selection & OSSL_KEYMGMT_SELECT_KEYPAIR) != 0) &&
-        (oqsx_key_fromdata(key, params,
-                           selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY)))
+        (oqsx_key_fromdata(key, params, include_private)))
         ok = 1;
     return ok;
 }

--- a/oqsprov/oqsprov_keys.c
+++ b/oqsprov/oqsprov_keys.c
@@ -1280,7 +1280,7 @@ int oqsx_key_fromdata(OQSX_KEY *key, const OSSL_PARAM params[],
         ERR_raise(ERR_LIB_USER, OQSPROV_R_WRONG_PARAMETERS);
         return 0;
     }
-    if (pp1 != NULL) {
+    if (pp1 != NULL && include_private) {
         if (pp1->data_type != OSSL_PARAM_OCTET_STRING) {
             ERR_raise(ERR_LIB_USER, OQSPROV_R_INVALID_ENCODING);
             return 0;


### PR DESCRIPTION
Fix the parameter selection for import key material from `OSSL_KEYMGMT_SELECT_ALL_PARAMETERS` to `OSSL_KEYMGMT_SELECT_KEYPAIR`. Fixes #745.

The bug was making invalid an import with parameter selection `OSSL_KEYMGMT_SELECT_KEYPAIR`, even when elements pertaining to the key pair were imported.

This means a behavior change for users employing a selection for key material import with value `& OSSL_KEYMGMT_SELECT_KEYPAIR = 0`. Furthermore, the procedure `oqsx_key_fromdata` is enforcing the parameter `include_private`.

