### PR TITLE
Fix memory leak on oqsx_genkey

### DIFF
--- a/oqsprov/oqsprov_keys.c
+++ b/oqsprov/oqsprov_keys.c
@@ -1587,6 +1587,7 @@ err_gen:
     if (ret) {
         EVP_PKEY_free(pkey);
         key->classical_pkey = NULL;
+        oqsx_key_free(key);
     }
     return ret;
 }


### PR DESCRIPTION
Thanks for great project!

<!-- Please give a brief explanation of the purpose of this pull request. -->
This PR fixes memory leak on oqsx_genkey.
This leak found by Coverity Scan of SoftEtherVPN. I don't think it will happen often in practice.

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->
