### PR TITLE
Preserve the property query string

### DIFF
--- a/oqsprov/oqs_kmgmt.c
+++ b/oqsprov/oqs_kmgmt.c
@@ -498,6 +498,13 @@ static int oqsx_get_params(void *key, OSSL_PARAM params[]) {
     if (oqsx_get_hybrid_params(oqsxk, params))
         return 0;
 
+    if ((p = OSSL_PARAM_locate(params, OSSL_PKEY_PARAM_PROPERTIES)) != NULL) {
+        const char *pq = oqsxk->propq != NULL ? oqsxk->propq : "";
+
+        if (!OSSL_PARAM_set_utf8_string(p, pq))
+            return 0;
+    }
+
     // not passing in params to respond to is no error
     return 1;
 }
@@ -507,6 +514,7 @@ static const OSSL_PARAM oqsx_gettable_params[] = {
     OSSL_PARAM_int(OSSL_PKEY_PARAM_SECURITY_BITS, NULL),
     OSSL_PARAM_int(OSSL_PKEY_PARAM_MAX_SIZE, NULL),
     OSSL_PARAM_octet_string(OSSL_PKEY_PARAM_ENCODED_PUBLIC_KEY, NULL, 0),
+    OSSL_PARAM_utf8_string(OSSL_PKEY_PARAM_PROPERTIES, NULL, 0),
     OQS_KEY_TYPES(),
     OSSL_PARAM_END};
 

--- a/oqsprov/oqsprov_keys.c
+++ b/oqsprov/oqsprov_keys.c
@@ -606,7 +606,7 @@ err_init:
 }
 
 static const int oqshybkem_init_ecp(char *tls_name, OQSX_EVP_CTX *evp_ctx,
-                                    OSSL_LIB_CTX *libctx) {
+                                    OSSL_LIB_CTX *libctx, const char *propq) {
     int ret = 1;
     const OQSX_EVP_INFO *evp_info = NULL;
 
@@ -625,7 +625,7 @@ static const int oqshybkem_init_ecp(char *tls_name, OQSX_EVP_CTX *evp_ctx,
     evp_ctx->evp_info = evp_info;
 
     evp_ctx->ctx = EVP_PKEY_CTX_new_from_name(
-        libctx, OBJ_nid2sn(evp_ctx->evp_info->keytype), NULL);
+        libctx, OBJ_nid2sn(evp_ctx->evp_info->keytype), propq);
     ON_ERR_GOTO(!evp_ctx->ctx, err_init_ecp);
 
     ret = EVP_PKEY_paramgen_init(evp_ctx->ctx);
@@ -643,7 +643,7 @@ err_init_ecp:
 }
 
 static const int oqshybkem_init_ecbp(char *tls_name, OQSX_EVP_CTX *evp_ctx,
-                                     OSSL_LIB_CTX *libctx) {
+                                     OSSL_LIB_CTX *libctx, const char *propq) {
     int ret = 1;
     const OQSX_EVP_INFO *evp_info = NULL;
 
@@ -663,7 +663,7 @@ static const int oqshybkem_init_ecbp(char *tls_name, OQSX_EVP_CTX *evp_ctx,
     evp_ctx->evp_info = evp_info;
 
     evp_ctx->ctx = EVP_PKEY_CTX_new_from_name(
-        libctx, OBJ_nid2sn(evp_ctx->evp_info->keytype), NULL);
+        libctx, OBJ_nid2sn(evp_ctx->evp_info->keytype), propq);
     ON_ERR_GOTO(!evp_ctx->ctx, err_init_ecbp);
 
     ret = EVP_PKEY_paramgen_init(evp_ctx->ctx);
@@ -681,7 +681,7 @@ err_init_ecbp:
 }
 
 static const int oqshybkem_init_ecx(char *tls_name, OQSX_EVP_CTX *evp_ctx,
-                                    OSSL_LIB_CTX *libctx) {
+                                    OSSL_LIB_CTX *libctx, const char *propq) {
     int ret = 1;
     const OQSX_EVP_INFO *evp_info = NULL;
 
@@ -705,7 +705,7 @@ static const int oqshybkem_init_ecx(char *tls_name, OQSX_EVP_CTX *evp_ctx,
     ret = EVP_PKEY_set_type(evp_ctx->keyParam, evp_ctx->evp_info->keytype);
     ON_ERR_SET_GOTO(ret <= 0, ret, -1, err_init_ecx);
 
-    evp_ctx->ctx = EVP_PKEY_CTX_new_from_pkey(libctx, evp_ctx->keyParam, NULL);
+    evp_ctx->ctx = EVP_PKEY_CTX_new_from_pkey(libctx, evp_ctx->keyParam, propq);
     ON_ERR_SET_GOTO(!evp_ctx->ctx, ret, -1, err_init_ecx);
 
 err_init_ecx:
@@ -1003,7 +1003,8 @@ OQSX_KEY *oqsx_key_from_pkcs8(const PKCS8_PRIV_KEY_INFO *p8inf,
     return oqsx;
 }
 
-static const int (*init_kex_fun[])(char *, OQSX_EVP_CTX *, OSSL_LIB_CTX *) = {
+static const int (*init_kex_fun[])(char *, OQSX_EVP_CTX *, OSSL_LIB_CTX *,
+                                   const char *) = {
     oqshybkem_init_ecp, oqshybkem_init_ecbp, oqshybkem_init_ecx};
 extern const char *oqs_oid_alg_list[];
 
@@ -1092,7 +1093,7 @@ OQSX_KEY *oqsx_key_new(OSSL_LIB_CTX *libctx, char *oqs_name, char *tls_name,
         ON_ERR_GOTO(!evp_ctx, err);
 
         ret2 = (init_kex_fun[primitive - KEY_TYPE_ECP_HYB_KEM])(
-            tls_name, evp_ctx, libctx);
+            tls_name, evp_ctx, libctx, propq);
         ON_ERR_GOTO(ret2 <= 0 || !evp_ctx->keyParam || !evp_ctx->ctx, err);
 
         ret->numkeys = 2;

--- a/oqsprov/oqsprov_keys.c
+++ b/oqsprov/oqsprov_keys.c
@@ -600,6 +600,10 @@ static int oqsx_hybsig_init(int bit_security, OQSX_EVP_CTX *evp_ctx,
 free_evp_ctx:
     EVP_PKEY_CTX_free(evp_ctx->ctx);
     evp_ctx->ctx = NULL;
+    if (evp_ctx->keyParam) {
+        EVP_PKEY_free(evp_ctx->keyParam);
+        evp_ctx->keyParam = NULL;
+    }
 
 err_init:
     return ret;
@@ -1176,6 +1180,10 @@ err:
         OPENSSL_free(ret->propq);
         OPENSSL_free(ret->comp_privkey);
         OPENSSL_free(ret->comp_pubkey);
+        OQS_KEM_free(ret->oqsx_provider_ctx.oqsx_qs_ctx.kem);
+        ret->oqsx_provider_ctx.oqsx_qs_ctx.kem = NULL;
+        OQS_SIG_free(ret->oqsx_provider_ctx.oqsx_qs_ctx.sig);
+        ret->oqsx_provider_ctx.oqsx_qs_ctx.sig = NULL;
     }
     OPENSSL_free(ret);
     return NULL;

--- a/oqsprov/oqsprov_keys.c
+++ b/oqsprov/oqsprov_keys.c
@@ -711,8 +711,13 @@ static const int oqshybkem_init_ecx(char *tls_name, OQSX_EVP_CTX *evp_ctx,
 
     evp_ctx->ctx = EVP_PKEY_CTX_new_from_pkey(libctx, evp_ctx->keyParam, propq);
     ON_ERR_SET_GOTO(!evp_ctx->ctx, ret, -1, err_init_ecx);
+    return ret;
 
 err_init_ecx:
+    if (evp_ctx->keyParam) {
+        EVP_PKEY_free(evp_ctx->keyParam);
+        evp_ctx->keyParam = NULL;
+    }
     return ret;
 }
 
@@ -1175,6 +1180,21 @@ err:
     if (ret->lock)
         CRYPTO_THREAD_lock_free(ret->lock);
 #endif
+
+    if (ret->oqsx_provider_ctx.oqsx_evp_ctx) {
+        EVP_PKEY_CTX_free(ret->oqsx_provider_ctx.oqsx_evp_ctx->ctx);
+        ret->oqsx_provider_ctx.oqsx_evp_ctx->ctx = NULL;
+        EVP_PKEY_free(ret->oqsx_provider_ctx.oqsx_evp_ctx->keyParam);
+        ret->oqsx_provider_ctx.oqsx_evp_ctx->keyParam = NULL;
+        OPENSSL_free(ret->oqsx_provider_ctx.oqsx_evp_ctx);
+        ret->oqsx_provider_ctx.oqsx_evp_ctx = NULL;
+    }
+
+    if (evp_ctx) {
+        OPENSSL_free(evp_ctx);
+        evp_ctx = NULL;
+    }
+
     if (ret) {
         OPENSSL_free(ret->tls_name);
         OPENSSL_free(ret->propq);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -165,6 +165,28 @@ set_tests_properties(oqs_evp_pkey_params
 )
 endif()
 
+add_test(
+    NAME oqs_prop_str
+    COMMAND oqs_test_prop_str
+            "oqsprovider"
+            "${CMAKE_CURRENT_SOURCE_DIR}/oqs.cnf"
+)
+# openssl under MSVC seems to have a bug registering NIDs:
+# It only works when setting OPENSSL_CONF, not when loading the same cnf file:
+if (MSVC)
+set_tests_properties(oqs_prop_str
+    PROPERTIES ENVIRONMENT "OPENSSL_MODULES=${OQS_PROV_BINARY_DIR};OPENSSL_CONF=${CMAKE_CURRENT_SOURCE_DIR}/openssl-ca.cnf"
+)
+else()
+set_tests_properties(oqs_prop_str
+    PROPERTIES ENVIRONMENT "OPENSSL_MODULES=${OQS_PROV_BINARY_DIR}"
+)
+endif()
+
+add_executable(oqs_test_prop_str oqs_test_prop_str.c test_common.c)
+target_include_directories(oqs_test_prop_str PRIVATE "../oqsprov")
+target_link_libraries(oqs_test_prop_str PRIVATE ${OPENSSL_CRYPTO_LIBRARY} ${OQS_ADDL_SOCKET_LIBS} ${REQ_LIBS_T})
+
 if (OQS_PROVIDER_BUILD_STATIC)
   targets_set_static_provider(oqs_test_signatures
     oqs_test_kems
@@ -173,5 +195,6 @@ if (OQS_PROVIDER_BUILD_STATIC)
     oqs_test_tlssig
     oqs_test_endecode
     oqs_test_evp_pkey_params
+    oqs_test_prop_str
   )
 endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -185,7 +185,7 @@ endif()
 
 add_executable(oqs_test_prop_str oqs_test_prop_str.c test_common.c)
 target_include_directories(oqs_test_prop_str PRIVATE "../oqsprov")
-target_link_libraries(oqs_test_prop_str PRIVATE ${OPENSSL_CRYPTO_LIBRARY} ${OQS_ADDL_SOCKET_LIBS} ${REQ_LIBS_T})
+target_link_libraries(oqs_test_prop_str PRIVATE ${OPENSSL_CRYPTO_LIBRARY} OQS::oqs ${OQS_ADDL_SOCKET_LIBS} ${REQ_LIBS_T})
 
 if (OQS_PROVIDER_BUILD_STATIC)
   targets_set_static_provider(oqs_test_signatures

--- a/test/oqs_test_prop_str.c
+++ b/test/oqs_test_prop_str.c
@@ -8,10 +8,12 @@
 // (default: provider=oqsprovider). Override at compile time with
 // -DOQS_TST_PROPQ=... / -DOQS_TST_PROPQ_2=...
 //
-// The narrow propq (OQS_TST_PROPQ_2) case: non-hybrid KEMs and all signature
-// algorithms should pass both sub-tests. Hybrid KEMs should not pass both: with
-// only "provider=oqsprovider" they typically fail (e.g. keygen) or otherwise do
-// not complete both checks successfully.
+// The narrow propq (OQS_TST_PROPQ_2) case:
+// - KEM hybrids: keygen using only "provider=oqsprovider" is expected to fail.
+// because the classical algorithms are not implemented in the OQS provider.
+// - Signature hybrids: keygen using only "provider=oqsprovider" is expected to
+// fail because the classical algorithms are not implemented in the
+// OQS provider.
 //
 // Usage: oqs_test_prop_str <modulename> <config_file>
 
@@ -117,48 +119,14 @@ cleanup:
     return ok;
 }
 
-/* KEM: non-hybrids must get ok1&&ok2; hybrid KEMs must not get both. */
-/* SIG: every enabled algorithm must get ok1&&ok2. */
-static void acc_propq2_narrow(int ok1, int ok2, int is_kem, int is_kem_hybrid,
-                              const char *label, const char *algname,
-                              int *errcnt, int *runs) {
-    int pass;
-    if (is_kem)
-        pass = is_kem_hybrid ? !(ok1 && ok2) : (ok1 && ok2);
-    else
-        pass = (ok1 && ok2);
-
-    if (pass) {
-        fprintf(
-            stderr,
-            cGREEN
-            "  %s (OQS_TST_PROPQ_2) kem_hybrid=%d: passed: %s (got %d,%d)" cNORM
-            "\n",
-            label, is_kem ? is_kem_hybrid : 0, algname, ok1, ok2);
-    } else {
-        fprintf(
-            stderr,
-            cRED
-            "  %s (OQS_TST_PROPQ_2) kem_hybrid=%d: failed: %s (got %d,%d)" cNORM
-            "\n",
-            label, is_kem ? is_kem_hybrid : 0, algname, ok1, ok2);
-        (*errcnt)++;
-    }
-    (*runs)++;
-}
-
 int main(int argc, char *argv[]) {
     const OSSL_ALGORITHM *algs;
     const OSSL_ALGORITHM *kem_algs;
     const OSSL_ALGORITHM *sig_algs;
     OSSL_LIB_CTX *libctx = NULL;
     OSSL_PROVIDER *oqsprov = NULL;
-    int query_nocache = 0;
-    int errcnt = 0;
-    int kem_runs = 0;
-    int sig_runs = 0;
-    int kem2_runs = 0;
-    int sig2_runs = 0;
+    int query_nocache = 0, errcnt = 0, kem_runs = 0, sig_runs = 0,
+        kem2_runs = 0, sig2_runs = 0;
     int ret;
 
     if (argc != 3) {
@@ -200,6 +168,7 @@ int main(int argc, char *argv[]) {
                     test_propq_on_pkey_ex(libctx, algname, 0, OQS_TST_PROPQ);
                 int ok2 =
                     test_propq_on_pkey_ex(libctx, algname, 1, OQS_TST_PROPQ);
+                int hybrid = is_kem_algorithm_hybrid(algname);
 
                 if (!ok1)
                     errcnt++;
@@ -217,6 +186,30 @@ int main(int argc, char *argv[]) {
                                  "%s" cNORM "\n",
                             algname);
                 }
+
+                /*
+                 * Third check: in the narrow OQS_TST_PROPQ_2 case, hybrid KEMs
+                 * are expected to fail keygen because the OQS provider does
+                 * not implement the classical algorithms.
+                 */
+                if (hybrid) {
+                    if (!test_propq_on_pkey_ex(libctx, algname, 0,
+                                               OQS_TST_PROPQ_2)) {
+                        fprintf(stderr,
+                                cGREEN "  KEM hybrid OQS_TST_PROPQ_2 "
+                                       "check passed (expected failure): "
+                                       "%s" cNORM "\n",
+                                algname);
+                    } else {
+                        fprintf(stderr,
+                                cRED "  KEM hybrid OQS_TST_PROPQ_2 check "
+                                     "failed (unexpected success): %s" cNORM
+                                     "\n",
+                                algname);
+                        errcnt++;
+                    }
+                    kem2_runs++;
+                }
             }
         }
     }
@@ -225,35 +218,9 @@ int main(int argc, char *argv[]) {
         fprintf(stderr, "No KEM algs tested for OQS_TST_PROPQ.\n");
     }
 
-    if (kem_algs) {
-        for (algs = kem_algs; algs->algorithm_names != NULL; algs++) {
-            const char *algname = algs->algorithm_names;
-            int hybrid = is_kem_algorithm_hybrid(algname);
-
-            if (!alg_is_enabled(algname)) {
-                fprintf(stderr, "Skip disabled KEM %s (OQS_TST_PROPQ_2).\n",
-                        algname);
-                continue;
-            }
-
-            fprintf(stderr,
-                    "testing KEM \"%s\" (OQS_TST_PROPQ_2, hybrid check)\n",
-                    algname);
-
-            {
-                int ok1 =
-                    test_propq_on_pkey_ex(libctx, algname, 0, OQS_TST_PROPQ_2);
-                int ok2 =
-                    test_propq_on_pkey_ex(libctx, algname, 1, OQS_TST_PROPQ_2);
-
-                acc_propq2_narrow(ok1, ok2, 1, hybrid, "KEM", algname, &errcnt,
-                                  &kem2_runs);
-            }
-        }
-    }
-
     if (kem2_runs == 0) {
-        fprintf(stderr, "No KEM algs tested for OQS_TST_PROPQ_2.\n");
+        fprintf(stderr,
+                "No hybrid KEM algs tested for OQS_TST_PROPQ_2 third check.\n");
     }
 
     sig_algs = OSSL_PROVIDER_query_operation(oqsprov, OSSL_OP_SIGNATURE,
@@ -268,7 +235,8 @@ int main(int argc, char *argv[]) {
             }
 
             fprintf(stderr,
-                    "testing PQ signature \"%s\" (PROPERTIES / propq)\n",
+                    "testing PQ signature \"%s\" "
+                    "(PROPERTIES / propq + OQS_TST_PROPQ_2)\n",
                     algname);
 
             {
@@ -293,38 +261,32 @@ int main(int argc, char *argv[]) {
                                  "%s" cNORM "\n",
                             algname);
                 }
+
+                {
+                    int ok3 = test_propq_on_pkey_ex(libctx, algname, 0,
+                                                    OQS_TST_PROPQ_2);
+                    int ok4 = test_propq_on_pkey_ex(libctx, algname, 1,
+                                                    OQS_TST_PROPQ_2);
+                    if (ok3 && ok4) {
+                        fprintf(stderr,
+                                cGREEN "  SIG (OQS_TST_PROPQ_2) "
+                                       "passed: %s (got %d,%d)" cNORM "\n",
+                                algname, ok3, ok4);
+                    } else {
+                        fprintf(stderr,
+                                cRED "  SIG (OQS_TST_PROPQ_2) "
+                                     "failed: %s (got %d,%d)" cNORM "\n",
+                                algname, ok3, ok4);
+                        errcnt++;
+                    }
+                    sig2_runs++;
+                }
             }
         }
     }
 
     if (sig_runs == 0) {
         fprintf(stderr, "No PQ signature algs tested for OQS_TST_PROPQ.\n");
-    }
-
-    if (sig_algs) {
-        for (algs = sig_algs; algs->algorithm_names != NULL; algs++) {
-            const char *algname = algs->algorithm_names;
-
-            if (!alg_is_enabled(algname)) {
-                fprintf(stderr,
-                        "Skip disabled signature %s (OQS_TST_PROPQ_2).\n",
-                        algname);
-                continue;
-            }
-
-            fprintf(stderr, "testing signature \"%s\" (OQS_TST_PROPQ_2)\n",
-                    algname);
-
-            {
-                int ok1 =
-                    test_propq_on_pkey_ex(libctx, algname, 0, OQS_TST_PROPQ_2);
-                int ok2 =
-                    test_propq_on_pkey_ex(libctx, algname, 1, OQS_TST_PROPQ_2);
-
-                acc_propq2_narrow(ok1, ok2, 0, 0, "SIG", algname, &errcnt,
-                                  &sig2_runs);
-            }
-        }
     }
 
     if (sig2_runs == 0) {

--- a/test/oqs_test_prop_str.c
+++ b/test/oqs_test_prop_str.c
@@ -262,10 +262,6 @@ int main(int argc, char *argv[]) {
         for (algs = sig_algs; algs->algorithm_names != NULL; algs++) {
             const char *algname = algs->algorithm_names;
 
-            /* User asked for PQ signatures; skip hybrids here. */
-            if (is_signature_algorithm_hybrid(algname))
-                continue;
-
             if (!alg_is_enabled(algname)) {
                 fprintf(stderr, "Skip disabled PQ signature %s.\n", algname);
                 continue;

--- a/test/oqs_test_prop_str.c
+++ b/test/oqs_test_prop_str.c
@@ -71,6 +71,8 @@ static int test_propq_on_pkey_ex(OSSL_LIB_CTX *libctx, const char *algname,
     }
     if (EVP_PKEY_keygen(ctx, &pkey) <= 0) {
         fprintf(stderr, "EVP_PKEY_keygen failed for %s\n", algname);
+        EVP_PKEY_free(pkey);
+        pkey = NULL;
         goto err;
     }
     EVP_PKEY_CTX_free(ctx);

--- a/test/oqs_test_prop_str.c
+++ b/test/oqs_test_prop_str.c
@@ -229,8 +229,7 @@ int main(int argc, char *argv[]) {
             int hybrid = is_kem_algorithm_hybrid(algname);
 
             if (!alg_is_enabled(algname)) {
-                fprintf(stderr,
-                        "Skip disabled KEM %s (OQS_TST_PROPQ_2).\n",
+                fprintf(stderr, "Skip disabled KEM %s (OQS_TST_PROPQ_2).\n",
                         algname);
                 continue;
             }
@@ -252,8 +251,7 @@ int main(int argc, char *argv[]) {
     }
 
     if (kem2_runs == 0) {
-        fprintf(stderr,
-                "No KEM algs tested for OQS_TST_PROPQ_2.\n");
+        fprintf(stderr, "No KEM algs tested for OQS_TST_PROPQ_2.\n");
     }
 
     sig_algs = OSSL_PROVIDER_query_operation(oqsprov, OSSL_OP_SIGNATURE,
@@ -267,8 +265,7 @@ int main(int argc, char *argv[]) {
                 continue;
 
             if (!alg_is_enabled(algname)) {
-                fprintf(stderr, "Skip disabled PQ signature %s.\n",
-                        algname);
+                fprintf(stderr, "Skip disabled PQ signature %s.\n", algname);
                 continue;
             }
 
@@ -311,10 +308,9 @@ int main(int argc, char *argv[]) {
             const char *algname = algs->algorithm_names;
 
             if (!alg_is_enabled(algname)) {
-                fprintf(
-                    stderr,
-                    "Skip disabled signature %s (OQS_TST_PROPQ_2).\n",
-                    algname);
+                fprintf(stderr,
+                        "Skip disabled signature %s (OQS_TST_PROPQ_2).\n",
+                        algname);
                 continue;
             }
 
@@ -334,9 +330,7 @@ int main(int argc, char *argv[]) {
     }
 
     if (sig2_runs == 0) {
-        fprintf(
-            stderr,
-            "No PQ signature algs tested for OQS_TST_PROPQ_2.\n");
+        fprintf(stderr, "No PQ signature algs tested for OQS_TST_PROPQ_2.\n");
     }
 
     ret = errcnt != 0 ? 1 : 0;

--- a/test/oqs_test_prop_str.c
+++ b/test/oqs_test_prop_str.c
@@ -1,0 +1,267 @@
+// SPDX-License-Identifier: Apache-2.0 AND MIT
+//
+// Verifies the OQS keymgmt stores the property query on KEM keys by
+// reading OSSL_PKEY_PARAM_PROPERTIES via EVP.
+//
+// Expected property string: OQS_TST_PROPQ (provider=default,
+// provider=oqsprovider, fips=no). Override at compile time with
+// -DOQS_TST_PROPQ=...
+//
+// Usage: oqs_test_prop_str <modulename> <config_file>
+
+#include <openssl/core_names.h>
+#include <openssl/err.h>
+#include <openssl/evp.h>
+#include <openssl/objects.h>
+#include <openssl/params.h>
+#include <openssl/provider.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "test_common.h"
+
+#ifndef OQS_TST_PROPQ
+#define OQS_TST_PROPQ "provider=default,provider=oqsprovider,fips=no"
+#endif
+
+#ifdef _MSC_VER
+#define strtok_r strtok_s
+#endif
+
+static int test_propq_on_pkey(OSSL_LIB_CTX *libctx, const char *algname,
+                              int expect_null_propq) {
+    EVP_PKEY_CTX *ctx = NULL;
+    EVP_PKEY *pkey = NULL;
+    char buf[512];
+    size_t got_len = 0;
+    int ok = 0;
+
+    /*
+     * The third argument only affects EVP_KEYMGMT_fetch; OpenSSL does not pass
+     * it into keygen.  To record the query on the key, set
+     * OSSL_PKEY_PARAM_PROPERTIES on the genctx after EVP_PKEY_keygen_init().
+     */
+    ctx = EVP_PKEY_CTX_new_from_name(libctx, algname, OQS_TST_PROPQ);
+    if (ctx == NULL) {
+        fprintf(stderr, "EVP_PKEY_CTX_new_from_name(%s) failed\n", algname);
+        ERR_print_errors_fp(stderr);
+        return 0;
+    }
+    if (EVP_PKEY_keygen_init(ctx) <= 0) {
+        fprintf(stderr, "EVP_PKEY_keygen_init failed for %s\n", algname);
+        ERR_print_errors_fp(stderr);
+        EVP_PKEY_CTX_free(ctx);
+        return 0;
+    }
+    if (!expect_null_propq) {
+        OSSL_PARAM props[2];
+
+        props[0] = OSSL_PARAM_construct_utf8_string(OSSL_PKEY_PARAM_PROPERTIES,
+                                                    (char *)OQS_TST_PROPQ, 0);
+        props[1] = OSSL_PARAM_construct_end();
+        if (EVP_PKEY_CTX_set_params(ctx, props) <= 0) {
+            fprintf(stderr,
+                    "EVP_PKEY_CTX_set_params(PROPERTIES) failed for %s\n",
+                    algname);
+            ERR_print_errors_fp(stderr);
+            EVP_PKEY_CTX_free(ctx);
+            return 0;
+        }
+    }
+    if (EVP_PKEY_keygen(ctx, &pkey) <= 0) {
+        fprintf(stderr, "EVP_PKEY_keygen failed for %s\n", algname);
+        ERR_print_errors_fp(stderr);
+        EVP_PKEY_CTX_free(ctx);
+        return 0;
+    }
+    EVP_PKEY_CTX_free(ctx);
+    ctx = NULL;
+
+    if (!EVP_PKEY_get_utf8_string_param(pkey, OSSL_PKEY_PARAM_PROPERTIES, buf,
+                                        sizeof(buf), &got_len)) {
+        fprintf(stderr,
+                "EVP_PKEY_get_utf8_string_param(PROPERTIES) failed "
+                "for %s\n",
+                algname);
+        ERR_print_errors_fp(stderr);
+        EVP_PKEY_free(pkey);
+        return 0;
+    }
+
+    if (expect_null_propq) {
+        if (got_len != 0) {
+            fprintf(stderr,
+                    "expected empty PROPERTIES on key for %s, got len %zu\n",
+                    algname, got_len);
+            ok = 0;
+        } else {
+            ok = 1;
+        }
+    } else {
+        if (got_len != strlen(OQS_TST_PROPQ) ||
+            strcmp(buf, OQS_TST_PROPQ) != 0) {
+            fprintf(stderr,
+                    "PROPERTIES mismatch for %s: got \"%s\" (len %zu), "
+                    "expected \"%s\" (OQS_TST_PROPQ)\n",
+                    algname, buf, got_len, OQS_TST_PROPQ);
+            ok = 0;
+        } else {
+            ok = 1;
+        }
+    }
+
+    EVP_PKEY_free(pkey);
+    return ok;
+}
+
+int main(int argc, char *argv[]) {
+    const OSSL_ALGORITHM *algs;
+    OSSL_LIB_CTX *libctx = NULL;
+    OSSL_PROVIDER *oqsprov = NULL;
+    int query_nocache = 0;
+    int errcnt = 0;
+    int kem_runs = 0;
+    int sig_runs = 0;
+    int ret;
+
+    if (argc != 3) {
+        fprintf(stderr, "usage: %s <modulename> <config_file>\n", argv[0]);
+        return 1;
+    }
+
+    libctx = OSSL_LIB_CTX_new();
+    if (libctx == NULL) {
+        fprintf(stderr, "OSSL_LIB_CTX_new failed\n");
+        return 1;
+    }
+
+    load_oqs_provider(libctx, argv[1], argv[2]);
+
+    oqsprov = OSSL_PROVIDER_load(libctx, argv[1]);
+    if (oqsprov == NULL) {
+        fprintf(stderr, "OSSL_PROVIDER_load(%s) failed\n", argv[1]);
+        OSSL_LIB_CTX_free(libctx);
+        return 1;
+    }
+
+    algs = OSSL_PROVIDER_query_operation(oqsprov, OSSL_OP_KEM, &query_nocache);
+    if (algs) {
+        for (; algs->algorithm_names != NULL; algs++) {
+            char buf[256];
+            char *saveptr = NULL;
+            char *tok;
+
+            OPENSSL_strlcpy(buf, algs->algorithm_names, sizeof(buf));
+            for (tok = strtok_r(buf, ",", &saveptr); tok != NULL;
+                 tok = strtok_r(NULL, ",", &saveptr)) {
+                while (*tok == ' ')
+                    tok++;
+
+                if (!alg_is_enabled(tok)) {
+                    fprintf(stderr, "Not testing disabled KEM %s.\n", tok);
+                    continue;
+                }
+
+                fprintf(stderr, "testing KEM \"%s\" (PROPERTIES / propq)\n",
+                        tok);
+
+                {
+                    int ok1 = test_propq_on_pkey(libctx, tok, 0);
+                    int ok2 = test_propq_on_pkey(libctx, tok, 1);
+
+                    if (!ok1)
+                        errcnt++;
+                    if (!ok2)
+                        errcnt++;
+                    kem_runs++;
+                    if (ok1 && ok2) {
+                        fprintf(stderr,
+                                cGREEN "  KEM PROPERTIES checks "
+                                       "passed: %s" cNORM "\n",
+                                tok);
+                    } else {
+                        fprintf(stderr,
+                                cRED "  KEM PROPERTIES checks failed: "
+                                     "%s" cNORM "\n",
+                                tok);
+                    }
+                }
+            }
+        }
+    }
+
+    if (kem_runs == 0) {
+        fprintf(stderr, "warning: no enabled KEM was exercised "
+                        "(none registered or all skipped)\n");
+    }
+
+    algs = OSSL_PROVIDER_query_operation(oqsprov, OSSL_OP_SIGNATURE,
+                                         &query_nocache);
+    if (algs) {
+        for (; algs->algorithm_names != NULL; algs++) {
+            char buf[256];
+            char *saveptr = NULL;
+            char *tok;
+
+            OPENSSL_strlcpy(buf, algs->algorithm_names, sizeof(buf));
+            for (tok = strtok_r(buf, ",", &saveptr); tok != NULL;
+                 tok = strtok_r(NULL, ",", &saveptr)) {
+                while (*tok == ' ')
+                    tok++;
+
+                /* User asked for PQ signatures; skip hybrids here. */
+                if (is_signature_algorithm_hybrid(tok))
+                    continue;
+
+                if (!alg_is_enabled(tok)) {
+                    fprintf(stderr, "Not testing disabled PQ signature %s.\n",
+                            tok);
+                    continue;
+                }
+
+                fprintf(stderr,
+                        "testing PQ signature \"%s\" (PROPERTIES / propq)\n",
+                        tok);
+
+                {
+                    int ok1 = test_propq_on_pkey(libctx, tok, 0);
+                    int ok2 = test_propq_on_pkey(libctx, tok, 1);
+
+                    if (!ok1)
+                        errcnt++;
+                    if (!ok2)
+                        errcnt++;
+                    sig_runs++;
+                    if (ok1 && ok2) {
+                        fprintf(stderr,
+                                cGREEN "  PQ signature PROPERTIES checks "
+                                       "passed: %s" cNORM "\n",
+                                tok);
+                    } else {
+                        fprintf(stderr,
+                                cRED "  PQ signature PROPERTIES checks failed: "
+                                     "%s" cNORM "\n",
+                                tok);
+                    }
+                }
+            }
+        }
+    }
+
+    if (sig_runs == 0) {
+        fprintf(stderr, "warning: no enabled PQ signature was exercised "
+                        "(none registered or all skipped)\n");
+    }
+
+    ret = errcnt != 0 ? 1 : 0;
+    if (ret == 0) {
+        fprintf(stderr,
+                cGREEN "OQS KEM/PQ-signature PROPERTIES (propq) EVP tests "
+                       "finished "
+                       "without failures" cNORM "\n");
+    }
+
+    OSSL_PROVIDER_unload(oqsprov);
+    OSSL_LIB_CTX_free(libctx);
+    return ret;
+}

--- a/test/oqs_test_prop_str.c
+++ b/test/oqs_test_prop_str.c
@@ -1,11 +1,17 @@
 // SPDX-License-Identifier: Apache-2.0 AND MIT
 //
-// Verifies the OQS keymgmt stores the property query on KEM keys by
-// reading OSSL_PKEY_PARAM_PROPERTIES via EVP.
+// Verifies the OQS keymgmt stores the property query on KEM and signature
+// keys by reading OSSL_PKEY_PARAM_PROPERTIES via EVP.
 //
-// Expected property string: OQS_TST_PROPQ (provider=default,
-// provider=oqsprovider, fips=no). Override at compile time with
-// -DOQS_TST_PROPQ=...
+// Expected property strings: OQS_TST_PROPQ (default:
+// provider=default,provider=oqsprovider,fips=no) and OQS_TST_PROPQ_2
+// (default: provider=oqsprovider). Override at compile time with
+// -DOQS_TST_PROPQ=... / -DOQS_TST_PROPQ_2=...
+//
+// The narrow propq (OQS_TST_PROPQ_2) case: non-hybrid KEMs and all signature
+// algorithms should pass both sub-tests. Hybrid KEMs should not pass both: with
+// only "provider=oqsprovider" they typically fail (e.g. keygen) or otherwise do
+// not complete both checks successfully.
 //
 // Usage: oqs_test_prop_str <modulename> <config_file>
 
@@ -24,12 +30,12 @@
 #define OQS_TST_PROPQ "provider=default,provider=oqsprovider,fips=no"
 #endif
 
-#ifdef _MSC_VER
-#define strtok_r strtok_s
+#ifndef OQS_TST_PROPQ_2
+#define OQS_TST_PROPQ_2 "provider=oqsprovider"
 #endif
 
-static int test_propq_on_pkey(OSSL_LIB_CTX *libctx, const char *algname,
-                              int expect_null_propq) {
+static int test_propq_on_pkey_ex(OSSL_LIB_CTX *libctx, const char *algname,
+                                 int expect_null_propq, const char *propq) {
     EVP_PKEY_CTX *ctx = NULL;
     EVP_PKEY *pkey = NULL;
     char buf[512];
@@ -41,38 +47,31 @@ static int test_propq_on_pkey(OSSL_LIB_CTX *libctx, const char *algname,
      * it into keygen.  To record the query on the key, set
      * OSSL_PKEY_PARAM_PROPERTIES on the genctx after EVP_PKEY_keygen_init().
      */
-    ctx = EVP_PKEY_CTX_new_from_name(libctx, algname, OQS_TST_PROPQ);
+    ctx = EVP_PKEY_CTX_new_from_name(libctx, algname, propq);
     if (ctx == NULL) {
         fprintf(stderr, "EVP_PKEY_CTX_new_from_name(%s) failed\n", algname);
-        ERR_print_errors_fp(stderr);
-        return 0;
+        goto err;
     }
     if (EVP_PKEY_keygen_init(ctx) <= 0) {
         fprintf(stderr, "EVP_PKEY_keygen_init failed for %s\n", algname);
-        ERR_print_errors_fp(stderr);
-        EVP_PKEY_CTX_free(ctx);
-        return 0;
+        goto err;
     }
     if (!expect_null_propq) {
         OSSL_PARAM props[2];
 
         props[0] = OSSL_PARAM_construct_utf8_string(OSSL_PKEY_PARAM_PROPERTIES,
-                                                    (char *)OQS_TST_PROPQ, 0);
+                                                    (char *)propq, 0);
         props[1] = OSSL_PARAM_construct_end();
         if (EVP_PKEY_CTX_set_params(ctx, props) <= 0) {
             fprintf(stderr,
                     "EVP_PKEY_CTX_set_params(PROPERTIES) failed for %s\n",
                     algname);
-            ERR_print_errors_fp(stderr);
-            EVP_PKEY_CTX_free(ctx);
-            return 0;
+            goto err;
         }
     }
     if (EVP_PKEY_keygen(ctx, &pkey) <= 0) {
         fprintf(stderr, "EVP_PKEY_keygen failed for %s\n", algname);
-        ERR_print_errors_fp(stderr);
-        EVP_PKEY_CTX_free(ctx);
-        return 0;
+        goto err;
     }
     EVP_PKEY_CTX_free(ctx);
     ctx = NULL;
@@ -83,9 +82,7 @@ static int test_propq_on_pkey(OSSL_LIB_CTX *libctx, const char *algname,
                 "EVP_PKEY_get_utf8_string_param(PROPERTIES) failed "
                 "for %s\n",
                 algname);
-        ERR_print_errors_fp(stderr);
-        EVP_PKEY_free(pkey);
-        return 0;
+        goto err;
     }
 
     if (expect_null_propq) {
@@ -98,30 +95,68 @@ static int test_propq_on_pkey(OSSL_LIB_CTX *libctx, const char *algname,
             ok = 1;
         }
     } else {
-        if (got_len != strlen(OQS_TST_PROPQ) ||
-            strcmp(buf, OQS_TST_PROPQ) != 0) {
+        if (got_len != strlen(propq) || strcmp(buf, propq) != 0) {
             fprintf(stderr,
                     "PROPERTIES mismatch for %s: got \"%s\" (len %zu), "
-                    "expected \"%s\" (OQS_TST_PROPQ)\n",
-                    algname, buf, got_len, OQS_TST_PROPQ);
+                    "expected \"%s\" (propq)\n",
+                    algname, buf, got_len, propq);
             ok = 0;
         } else {
             ok = 1;
         }
     }
+    goto cleanup;
 
+err:
+    ERR_print_errors_fp(stderr);
+cleanup:
+    EVP_PKEY_CTX_free(ctx);
     EVP_PKEY_free(pkey);
     return ok;
 }
 
+/* KEM: non-hybrids must get ok1&&ok2; hybrid KEMs must not get both. */
+/* SIG: every enabled algorithm must get ok1&&ok2. */
+static void acc_propq2_narrow(int ok1, int ok2, int is_kem, int is_kem_hybrid,
+                              const char *label, const char *algname,
+                              int *errcnt, int *runs) {
+    int pass;
+    if (is_kem)
+        pass = is_kem_hybrid ? !(ok1 && ok2) : (ok1 && ok2);
+    else
+        pass = (ok1 && ok2);
+
+    if (pass) {
+        fprintf(
+            stderr,
+            cGREEN
+            "  %s (OQS_TST_PROPQ_2) kem_hybrid=%d: passed: %s (got %d,%d)" cNORM
+            "\n",
+            label, is_kem ? is_kem_hybrid : 0, algname, ok1, ok2);
+    } else {
+        fprintf(
+            stderr,
+            cRED
+            "  %s (OQS_TST_PROPQ_2) kem_hybrid=%d: failed: %s (got %d,%d)" cNORM
+            "\n",
+            label, is_kem ? is_kem_hybrid : 0, algname, ok1, ok2);
+        (*errcnt)++;
+    }
+    (*runs)++;
+}
+
 int main(int argc, char *argv[]) {
     const OSSL_ALGORITHM *algs;
+    const OSSL_ALGORITHM *kem_algs;
+    const OSSL_ALGORITHM *sig_algs;
     OSSL_LIB_CTX *libctx = NULL;
     OSSL_PROVIDER *oqsprov = NULL;
     int query_nocache = 0;
     int errcnt = 0;
     int kem_runs = 0;
     int sig_runs = 0;
+    int kem2_runs = 0;
+    int sig2_runs = 0;
     int ret;
 
     if (argc != 3) {
@@ -144,121 +179,171 @@ int main(int argc, char *argv[]) {
         return 1;
     }
 
-    algs = OSSL_PROVIDER_query_operation(oqsprov, OSSL_OP_KEM, &query_nocache);
-    if (algs) {
-        for (; algs->algorithm_names != NULL; algs++) {
-            char buf[256];
-            char *saveptr = NULL;
-            char *tok;
+    kem_algs =
+        OSSL_PROVIDER_query_operation(oqsprov, OSSL_OP_KEM, &query_nocache);
+    if (kem_algs) {
+        for (algs = kem_algs; algs->algorithm_names != NULL; algs++) {
+            const char *algname = algs->algorithm_names;
 
-            OPENSSL_strlcpy(buf, algs->algorithm_names, sizeof(buf));
-            for (tok = strtok_r(buf, ",", &saveptr); tok != NULL;
-                 tok = strtok_r(NULL, ",", &saveptr)) {
-                while (*tok == ' ')
-                    tok++;
+            if (!alg_is_enabled(algname)) {
+                fprintf(stderr, "Skip disabled KEM %s.\n", algname);
+                continue;
+            }
 
-                if (!alg_is_enabled(tok)) {
-                    fprintf(stderr, "Not testing disabled KEM %s.\n", tok);
-                    continue;
-                }
+            fprintf(stderr, "testing KEM \"%s\" (PROPERTIES / propq)\n",
+                    algname);
 
-                fprintf(stderr, "testing KEM \"%s\" (PROPERTIES / propq)\n",
-                        tok);
+            {
+                int ok1 =
+                    test_propq_on_pkey_ex(libctx, algname, 0, OQS_TST_PROPQ);
+                int ok2 =
+                    test_propq_on_pkey_ex(libctx, algname, 1, OQS_TST_PROPQ);
 
-                {
-                    int ok1 = test_propq_on_pkey(libctx, tok, 0);
-                    int ok2 = test_propq_on_pkey(libctx, tok, 1);
-
-                    if (!ok1)
-                        errcnt++;
-                    if (!ok2)
-                        errcnt++;
-                    kem_runs++;
-                    if (ok1 && ok2) {
-                        fprintf(stderr,
-                                cGREEN "  KEM PROPERTIES checks "
-                                       "passed: %s" cNORM "\n",
-                                tok);
-                    } else {
-                        fprintf(stderr,
-                                cRED "  KEM PROPERTIES checks failed: "
-                                     "%s" cNORM "\n",
-                                tok);
-                    }
+                if (!ok1)
+                    errcnt++;
+                if (!ok2)
+                    errcnt++;
+                kem_runs++;
+                if (ok1 && ok2) {
+                    fprintf(stderr,
+                            cGREEN "  KEM PROPERTIES checks "
+                                   "passed: %s" cNORM "\n",
+                            algname);
+                } else {
+                    fprintf(stderr,
+                            cRED "  KEM PROPERTIES checks failed: "
+                                 "%s" cNORM "\n",
+                            algname);
                 }
             }
         }
     }
 
     if (kem_runs == 0) {
-        fprintf(stderr, "warning: no enabled KEM was exercised "
-                        "(none registered or all skipped)\n");
+        fprintf(stderr, "No KEM algs tested for OQS_TST_PROPQ.\n");
     }
 
-    algs = OSSL_PROVIDER_query_operation(oqsprov, OSSL_OP_SIGNATURE,
-                                         &query_nocache);
-    if (algs) {
-        for (; algs->algorithm_names != NULL; algs++) {
-            char buf[256];
-            char *saveptr = NULL;
-            char *tok;
+    if (kem_algs) {
+        for (algs = kem_algs; algs->algorithm_names != NULL; algs++) {
+            const char *algname = algs->algorithm_names;
+            int hybrid = is_kem_algorithm_hybrid(algname);
 
-            OPENSSL_strlcpy(buf, algs->algorithm_names, sizeof(buf));
-            for (tok = strtok_r(buf, ",", &saveptr); tok != NULL;
-                 tok = strtok_r(NULL, ",", &saveptr)) {
-                while (*tok == ' ')
-                    tok++;
-
-                /* User asked for PQ signatures; skip hybrids here. */
-                if (is_signature_algorithm_hybrid(tok))
-                    continue;
-
-                if (!alg_is_enabled(tok)) {
-                    fprintf(stderr, "Not testing disabled PQ signature %s.\n",
-                            tok);
-                    continue;
-                }
-
+            if (!alg_is_enabled(algname)) {
                 fprintf(stderr,
-                        "testing PQ signature \"%s\" (PROPERTIES / propq)\n",
-                        tok);
+                        "Skip disabled KEM %s (OQS_TST_PROPQ_2).\n",
+                        algname);
+                continue;
+            }
 
-                {
-                    int ok1 = test_propq_on_pkey(libctx, tok, 0);
-                    int ok2 = test_propq_on_pkey(libctx, tok, 1);
+            fprintf(stderr,
+                    "testing KEM \"%s\" (OQS_TST_PROPQ_2, hybrid check)\n",
+                    algname);
 
-                    if (!ok1)
-                        errcnt++;
-                    if (!ok2)
-                        errcnt++;
-                    sig_runs++;
-                    if (ok1 && ok2) {
-                        fprintf(stderr,
-                                cGREEN "  PQ signature PROPERTIES checks "
-                                       "passed: %s" cNORM "\n",
-                                tok);
-                    } else {
-                        fprintf(stderr,
-                                cRED "  PQ signature PROPERTIES checks failed: "
-                                     "%s" cNORM "\n",
-                                tok);
-                    }
+            {
+                int ok1 =
+                    test_propq_on_pkey_ex(libctx, algname, 0, OQS_TST_PROPQ_2);
+                int ok2 =
+                    test_propq_on_pkey_ex(libctx, algname, 1, OQS_TST_PROPQ_2);
+
+                acc_propq2_narrow(ok1, ok2, 1, hybrid, "KEM", algname, &errcnt,
+                                  &kem2_runs);
+            }
+        }
+    }
+
+    if (kem2_runs == 0) {
+        fprintf(stderr,
+                "No KEM algs tested for OQS_TST_PROPQ_2.\n");
+    }
+
+    sig_algs = OSSL_PROVIDER_query_operation(oqsprov, OSSL_OP_SIGNATURE,
+                                             &query_nocache);
+    if (sig_algs) {
+        for (algs = sig_algs; algs->algorithm_names != NULL; algs++) {
+            const char *algname = algs->algorithm_names;
+
+            /* User asked for PQ signatures; skip hybrids here. */
+            if (is_signature_algorithm_hybrid(algname))
+                continue;
+
+            if (!alg_is_enabled(algname)) {
+                fprintf(stderr, "Skip disabled PQ signature %s.\n",
+                        algname);
+                continue;
+            }
+
+            fprintf(stderr,
+                    "testing PQ signature \"%s\" (PROPERTIES / propq)\n",
+                    algname);
+
+            {
+                int ok1 =
+                    test_propq_on_pkey_ex(libctx, algname, 0, OQS_TST_PROPQ);
+                int ok2 =
+                    test_propq_on_pkey_ex(libctx, algname, 1, OQS_TST_PROPQ);
+
+                if (!ok1)
+                    errcnt++;
+                if (!ok2)
+                    errcnt++;
+                sig_runs++;
+                if (ok1 && ok2) {
+                    fprintf(stderr,
+                            cGREEN "  PQ signature PROPERTIES checks "
+                                   "passed: %s" cNORM "\n",
+                            algname);
+                } else {
+                    fprintf(stderr,
+                            cRED "  PQ signature PROPERTIES checks failed: "
+                                 "%s" cNORM "\n",
+                            algname);
                 }
             }
         }
     }
 
     if (sig_runs == 0) {
-        fprintf(stderr, "warning: no enabled PQ signature was exercised "
-                        "(none registered or all skipped)\n");
+        fprintf(stderr, "No PQ signature algs tested for OQS_TST_PROPQ.\n");
+    }
+
+    if (sig_algs) {
+        for (algs = sig_algs; algs->algorithm_names != NULL; algs++) {
+            const char *algname = algs->algorithm_names;
+
+            if (!alg_is_enabled(algname)) {
+                fprintf(
+                    stderr,
+                    "Skip disabled signature %s (OQS_TST_PROPQ_2).\n",
+                    algname);
+                continue;
+            }
+
+            fprintf(stderr, "testing signature \"%s\" (OQS_TST_PROPQ_2)\n",
+                    algname);
+
+            {
+                int ok1 =
+                    test_propq_on_pkey_ex(libctx, algname, 0, OQS_TST_PROPQ_2);
+                int ok2 =
+                    test_propq_on_pkey_ex(libctx, algname, 1, OQS_TST_PROPQ_2);
+
+                acc_propq2_narrow(ok1, ok2, 0, 0, "SIG", algname, &errcnt,
+                                  &sig2_runs);
+            }
+        }
+    }
+
+    if (sig2_runs == 0) {
+        fprintf(
+            stderr,
+            "No PQ signature algs tested for OQS_TST_PROPQ_2.\n");
     }
 
     ret = errcnt != 0 ? 1 : 0;
     if (ret == 0) {
         fprintf(stderr,
-                cGREEN "OQS KEM/PQ-signature PROPERTIES (propq) EVP tests "
-                       "finished "
-                       "without failures" cNORM "\n");
+                cGREEN "OQS KEM/signature PROPERTIES (propq / OQS_TST_PROPQ_2) "
+                       "EVP tests finished without failures" cNORM "\n");
     }
 
     OSSL_PROVIDER_unload(oqsprov);

--- a/test/oqs_test_prop_str.c
+++ b/test/oqs_test_prop_str.c
@@ -11,9 +11,6 @@
 // The narrow propq (OQS_TST_PROPQ_2) case:
 // - KEM hybrids: keygen using only "provider=oqsprovider" is expected to fail.
 // because the classical algorithms are not implemented in the OQS provider.
-// - Signature hybrids: keygen using only "provider=oqsprovider" is expected to
-// fail because the classical algorithms are not implemented in the
-// OQS provider.
 //
 // Usage: oqs_test_prop_str <modulename> <config_file>
 
@@ -160,9 +157,6 @@ int main(int argc, char *argv[]) {
                 continue;
             }
 
-            fprintf(stderr, "testing KEM \"%s\" (PROPERTIES / propq)\n",
-                    algname);
-
             {
                 int ok1 =
                     test_propq_on_pkey_ex(libctx, algname, 0, OQS_TST_PROPQ);
@@ -214,15 +208,6 @@ int main(int argc, char *argv[]) {
         }
     }
 
-    if (kem_runs == 0) {
-        fprintf(stderr, "No KEM algs tested for OQS_TST_PROPQ.\n");
-    }
-
-    if (kem2_runs == 0) {
-        fprintf(stderr,
-                "No hybrid KEM algs tested for OQS_TST_PROPQ_2 third check.\n");
-    }
-
     sig_algs = OSSL_PROVIDER_query_operation(oqsprov, OSSL_OP_SIGNATURE,
                                              &query_nocache);
     if (sig_algs) {
@@ -230,14 +215,8 @@ int main(int argc, char *argv[]) {
             const char *algname = algs->algorithm_names;
 
             if (!alg_is_enabled(algname)) {
-                fprintf(stderr, "Skip disabled PQ signature %s.\n", algname);
                 continue;
             }
-
-            fprintf(stderr,
-                    "testing PQ signature \"%s\" "
-                    "(PROPERTIES / propq + OQS_TST_PROPQ_2)\n",
-                    algname);
 
             {
                 int ok1 =
@@ -283,14 +262,6 @@ int main(int argc, char *argv[]) {
                 }
             }
         }
-    }
-
-    if (sig_runs == 0) {
-        fprintf(stderr, "No PQ signature algs tested for OQS_TST_PROPQ.\n");
-    }
-
-    if (sig2_runs == 0) {
-        fprintf(stderr, "No PQ signature algs tested for OQS_TST_PROPQ_2.\n");
     }
 
     ret = errcnt != 0 ? 1 : 0;

--- a/test/test_common.c
+++ b/test/test_common.c
@@ -233,8 +233,8 @@ int is_kem_algorithm_hybrid(const char *_alg_) {
 int does_signature_algorithm_support_ctx_str(const char *_alg_) {
     for (unsigned int i = 0; i < SIGS_DICT_LEN; i++) {
         if (strcmp(kOQSNameMapSignatureAlgorithms[i].alg_name, _alg_) == 0)
-            return OQS_SIG_supports_ctx_str(
-                kOQSNameMapSignatureAlgorithms[i].oqsname);
+            // return OQS_SIG_supports_ctx_str(
+            //     kOQSNameMapSignatureAlgorithms[i].oqsname);
     }
     return 0;
 }

--- a/test/test_common.c
+++ b/test/test_common.c
@@ -233,8 +233,8 @@ int is_kem_algorithm_hybrid(const char *_alg_) {
 int does_signature_algorithm_support_ctx_str(const char *_alg_) {
     for (unsigned int i = 0; i < SIGS_DICT_LEN; i++) {
         if (strcmp(kOQSNameMapSignatureAlgorithms[i].alg_name, _alg_) == 0)
-        // return OQS_SIG_supports_ctx_str(
-        //     kOQSNameMapSignatureAlgorithms[i].oqsname);
+            return OQS_SIG_supports_ctx_str(
+                kOQSNameMapSignatureAlgorithms[i].oqsname);
     }
     return 0;
 }

--- a/test/test_common.c
+++ b/test/test_common.c
@@ -233,8 +233,8 @@ int is_kem_algorithm_hybrid(const char *_alg_) {
 int does_signature_algorithm_support_ctx_str(const char *_alg_) {
     for (unsigned int i = 0; i < SIGS_DICT_LEN; i++) {
         if (strcmp(kOQSNameMapSignatureAlgorithms[i].alg_name, _alg_) == 0)
-            // return OQS_SIG_supports_ctx_str(
-            //     kOQSNameMapSignatureAlgorithms[i].oqsname);
+        // return OQS_SIG_supports_ctx_str(
+        //     kOQSNameMapSignatureAlgorithms[i].oqsname);
     }
     return 0;
 }


### PR DESCRIPTION
Preserve the property query string. Useful in cases where there is a desire to filter algorithms based on a 
query string.


This PR replaces [the original](https://github.com/open-quantum-safe/oqs-provider/pull/752). #752 had branch issues (commits and outdated). A new branch made it easier to address.

<!-- Please give a brief explanation of the purpose of this pull request. -->

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->
