### PR TITLE
Include property query for classical SIGs

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -5,6 +5,9 @@ Support for OpenSSL's sign/verify message API added.
 
 Includes both variants of FrodoKEM algorithm. Previous `frodokem` variants are what now are referred to as **ephemeral** variants (i.e. `efrodokem`), while current `frodokem` are the new **salted** variants.
 
+Classical algorithms now retain the property queries established from the hybrid PQ algorithm that they correspond to. This means
+that the use of the property query 'provider=oqsprovider' without any additional query will make hybrid schemes fail.
+
 Previous Release Notes
 ======================
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,7 +6,7 @@ Support for OpenSSL's sign/verify message API added.
 Includes both variants of FrodoKEM algorithm. Previous `frodokem` variants are what now are referred to as **ephemeral** variants (i.e. `efrodokem`), while current `frodokem` are the new **salted** variants.
 
 Classical algorithms now retain the property queries established from the hybrid PQ algorithm that they correspond to. This means
-that the use of the property query 'provider=oqsprovider' without any additional query will make hybrid schemes fail.
+that the use of the property query 'provider=oqsprovider' without any additional property query, as `oqsprovider` alone does not implement classical crypto which is required for hybrid schemes to work, will make hybrid schemes fail.
 
 Previous Release Notes
 ======================

--- a/oqsprov/oqsprov_keys.c
+++ b/oqsprov/oqsprov_keys.c
@@ -540,7 +540,8 @@ static const OQSX_EVP_INFO nids_ecx[] = {
 };
 
 static int oqsx_hybsig_init(int bit_security, OQSX_EVP_CTX *evp_ctx,
-                            OSSL_LIB_CTX *libctx, char *algname) {
+                            OSSL_LIB_CTX *libctx, char *algname,
+                            const char *propq) {
     int ret = 1;
     int idx = (bit_security - 128) / 64;
     ON_ERR_GOTO(idx < 0 || idx > 5, err_init);
@@ -573,13 +574,13 @@ static int oqsx_hybsig_init(int bit_security, OQSX_EVP_CTX *evp_ctx,
         ON_ERR_SET_GOTO(ret <= 0, ret, -1, err_init);
 
         evp_ctx->ctx =
-            EVP_PKEY_CTX_new_from_pkey(libctx, evp_ctx->keyParam, NULL);
+            EVP_PKEY_CTX_new_from_pkey(libctx, evp_ctx->keyParam, propq);
         ON_ERR_SET_GOTO(!evp_ctx->ctx, ret, -1, err_init);
     } else {
         evp_ctx->evp_info = &nids_sig[idx];
 
         evp_ctx->ctx = EVP_PKEY_CTX_new_from_name(
-            libctx, OBJ_nid2sn(evp_ctx->evp_info->keytype), NULL);
+            libctx, OBJ_nid2sn(evp_ctx->evp_info->keytype), propq);
         ON_ERR_GOTO(!evp_ctx->ctx, err_init);
 
         if (idx < 5) { // EC
@@ -1134,7 +1135,7 @@ OQSX_KEY *oqsx_key_new(OSSL_LIB_CTX *libctx, char *oqs_name, char *tls_name,
         evp_ctx = OPENSSL_zalloc(sizeof(OQSX_EVP_CTX));
         ON_ERR_GOTO(!evp_ctx, err);
 
-        ret2 = oqsx_hybsig_init(bit_security, evp_ctx, libctx, tls_name);
+        ret2 = oqsx_hybsig_init(bit_security, evp_ctx, libctx, tls_name, propq);
         ON_ERR_GOTO(ret2 <= 0 || !evp_ctx->ctx, err);
 
         ret->numkeys = 2;

--- a/test/oqs_test_prop_str.c
+++ b/test/oqs_test_prop_str.c
@@ -11,6 +11,8 @@
 // The narrow propq (OQS_TST_PROPQ_2) case:
 // - KEM hybrids: keygen using only "provider=oqsprovider" is expected to fail.
 // because the classical algorithms are not implemented in the OQS provider.
+// - SIG hybrids: keygen using only "provider=oqsprovider" is expected to fail.
+// because the classical algorithms are not implemented in the OQS provider.
 //
 // Usage: oqs_test_prop_str <modulename> <config_file>
 
@@ -122,8 +124,7 @@ int main(int argc, char *argv[]) {
     const OSSL_ALGORITHM *sig_algs;
     OSSL_LIB_CTX *libctx = NULL;
     OSSL_PROVIDER *oqsprov = NULL;
-    int query_nocache = 0, errcnt = 0, kem_runs = 0, sig_runs = 0,
-        kem2_runs = 0, sig2_runs = 0;
+    int query_nocache = 0, errcnt = 0, ok1, ok2, hybrid;
     int ret;
 
     if (argc != 3) {
@@ -158,17 +159,14 @@ int main(int argc, char *argv[]) {
             }
 
             {
-                int ok1 =
-                    test_propq_on_pkey_ex(libctx, algname, 0, OQS_TST_PROPQ);
-                int ok2 =
-                    test_propq_on_pkey_ex(libctx, algname, 1, OQS_TST_PROPQ);
-                int hybrid = is_kem_algorithm_hybrid(algname);
+                ok1 = test_propq_on_pkey_ex(libctx, algname, 0, OQS_TST_PROPQ);
+                ok2 = test_propq_on_pkey_ex(libctx, algname, 1, OQS_TST_PROPQ);
+                hybrid = is_kem_algorithm_hybrid(algname);
 
                 if (!ok1)
                     errcnt++;
                 if (!ok2)
                     errcnt++;
-                kem_runs++;
                 if (ok1 && ok2) {
                     fprintf(stderr,
                             cGREEN "  KEM PROPERTIES checks "
@@ -190,19 +188,18 @@ int main(int argc, char *argv[]) {
                     if (!test_propq_on_pkey_ex(libctx, algname, 0,
                                                OQS_TST_PROPQ_2)) {
                         fprintf(stderr,
-                                cGREEN "  KEM hybrid OQS_TST_PROPQ_2 "
+                                cGREEN "  KEM hybrid %s "
                                        "check passed (expected failure): "
                                        "%s" cNORM "\n",
-                                algname);
+                                OQS_TST_PROPQ_2, algname);
                     } else {
                         fprintf(stderr,
-                                cRED "  KEM hybrid OQS_TST_PROPQ_2 check "
+                                cRED "  KEM hybrid %s check "
                                      "failed (unexpected success): %s" cNORM
                                      "\n",
-                                algname);
+                                OQS_TST_PROPQ_2, algname);
                         errcnt++;
                     }
-                    kem2_runs++;
                 }
             }
         }
@@ -219,16 +216,14 @@ int main(int argc, char *argv[]) {
             }
 
             {
-                int ok1 =
-                    test_propq_on_pkey_ex(libctx, algname, 0, OQS_TST_PROPQ);
-                int ok2 =
-                    test_propq_on_pkey_ex(libctx, algname, 1, OQS_TST_PROPQ);
+                ok1 = test_propq_on_pkey_ex(libctx, algname, 0, OQS_TST_PROPQ);
+                ok2 = test_propq_on_pkey_ex(libctx, algname, 1, OQS_TST_PROPQ);
+                hybrid = is_signature_algorithm_hybrid(algname);
 
                 if (!ok1)
                     errcnt++;
                 if (!ok2)
                     errcnt++;
-                sig_runs++;
                 if (ok1 && ok2) {
                     fprintf(stderr,
                             cGREEN "  PQ signature PROPERTIES checks "
@@ -241,24 +236,27 @@ int main(int argc, char *argv[]) {
                             algname);
                 }
 
-                {
-                    int ok3 = test_propq_on_pkey_ex(libctx, algname, 0,
-                                                    OQS_TST_PROPQ_2);
-                    int ok4 = test_propq_on_pkey_ex(libctx, algname, 1,
-                                                    OQS_TST_PROPQ_2);
-                    if (ok3 && ok4) {
+                /*
+                 * Third check: in the narrow OQS_TST_PROPQ_2 case, hybrid SIGs
+                 * are expected to fail keygen because the OQS provider does
+                 * not implement the classical algorithms.
+                 */
+                if (hybrid) {
+                    if (!test_propq_on_pkey_ex(libctx, algname, 0,
+                                               OQS_TST_PROPQ_2)) {
                         fprintf(stderr,
-                                cGREEN "  SIG (OQS_TST_PROPQ_2) "
-                                       "passed: %s (got %d,%d)" cNORM "\n",
-                                algname, ok3, ok4);
+                                cGREEN "  SIG hybrid %s "
+                                       "check passed (expected failure): "
+                                       "%s" cNORM "\n",
+                                OQS_TST_PROPQ_2, algname);
                     } else {
                         fprintf(stderr,
-                                cRED "  SIG (OQS_TST_PROPQ_2) "
-                                     "failed: %s (got %d,%d)" cNORM "\n",
-                                algname, ok3, ok4);
+                                cRED "  SIG hybrid %s check "
+                                     "failed (unexpected success): %s" cNORM
+                                     "\n",
+                                OQS_TST_PROPQ_2, algname);
                         errcnt++;
                     }
-                    sig2_runs++;
                 }
             }
         }


### PR DESCRIPTION
Classical SIG algorithms now retain the property query of the PQ hybrid algorithm they correspond to. Fixes #753.
