### PR TITLE
Fix clang-formatting errors from PR #779

### DIFF
--- a/oqsprov/oqsdecoders.inc
+++ b/oqsprov/oqsdecoders.inc
@@ -21,17 +21,13 @@
 
 /* Arguments are prefixed with '_' to avoid build breaks on certain platforms */
 #define DECODER(_name, _input, _output)                                        \
-    {                                                                          \
-        _name, "provider=" DECODER_PROVIDER ",input=" #_input,                 \
-            (oqs_##_input##_to_##_output##_decoder_functions)                  \
-    }
+    {_name, "provider=" DECODER_PROVIDER ",input=" #_input,                    \
+     (oqs_##_input##_to_##_output##_decoder_functions)}
 #define DECODER_w_structure(_name, _input, _structure, _output)                \
-    {                                                                          \
-        _name,                                                                 \
-            "provider=" DECODER_PROVIDER ",input=" #_input                     \
-            ",structure=" DECODER_STRUCTURE_##_structure,                      \
-            (oqs_##_structure##_##_input##_to_##_output##_decoder_functions)   \
-    }
+    {_name,                                                                    \
+     "provider=" DECODER_PROVIDER ",input=" #_input                            \
+     ",structure=" DECODER_STRUCTURE_##_structure,                             \
+     (oqs_##_structure##_##_input##_to_##_output##_decoder_functions)}
 
 ///// OQS_TEMPLATE_FRAGMENT_MAKE_START
 #ifdef OQS_KEM_ENCODERS

--- a/oqsprov/oqsencoders.inc
+++ b/oqsprov/oqsencoders.inc
@@ -24,23 +24,17 @@
 
 /* Arguments are prefixed with '_' to avoid build breaks on certain platforms */
 #define ENCODER_TEXT(_name, _sym)                                              \
-    {                                                                          \
-        _name, "provider=" ENCODER_PROVIDER ",output=text",                    \
-            (oqs_##_sym##_to_text_encoder_functions)                           \
-    }
+    {_name, "provider=" ENCODER_PROVIDER ",output=text",                       \
+     (oqs_##_sym##_to_text_encoder_functions)}
 #define ENCODER(_name, _sym, _fips, _output)                                   \
-    {                                                                          \
-        _name, "provider=" ENCODER_PROVIDER ",output=" #_output,               \
-            (oqs_##_sym##_to_##_output##_encoder_functions)                    \
-    }
+    {_name, "provider=" ENCODER_PROVIDER ",output=" #_output,                  \
+     (oqs_##_sym##_to_##_output##_encoder_functions)}
 
 #define ENCODER_w_structure(_name, _sym, _output, _structure)                  \
-    {                                                                          \
-        _name,                                                                 \
-            "provider=" ENCODER_PROVIDER ",output=" #_output                   \
-            ",structure=" ENCODER_STRUCTURE_##_structure,                      \
-            (oqs_##_sym##_to_##_structure##_##_output##_encoder_functions)     \
-    }
+    {_name,                                                                    \
+     "provider=" ENCODER_PROVIDER ",output=" #_output                          \
+     ",structure=" ENCODER_STRUCTURE_##_structure,                             \
+     (oqs_##_sym##_to_##_structure##_##_output##_encoder_functions)}
 
 /*
  * Entries for human text "encoders"

--- a/oqsprov/oqsprov.c
+++ b/oqsprov/oqsprov.c
@@ -569,10 +569,7 @@ int oqs_patch_oids(void) {
 }
 
 #define SIGALG(NAMES, SECBITS, FUNC)                                           \
-    {                                                                          \
-        NAMES, "provider=oqsprovider,oqsprovider.security_bits=" #SECBITS "",  \
-            FUNC                                                               \
-    }
+    {NAMES, "provider=oqsprovider,oqsprovider.security_bits=" #SECBITS "", FUNC}
 #define KEMBASEALG(NAMES, SECBITS)                                             \
     {"" #NAMES "",                                                             \
      "provider=oqsprovider,oqsprovider.security_bits=" #SECBITS "",            \

--- a/oqsprov/oqsprov_capabilities.c
+++ b/oqsprov/oqsprov_capabilities.c
@@ -117,29 +117,27 @@ static OQS_GROUP_CONSTANTS oqs_group_list[] = {
 
 // Adds entries for tlsname, `ecx`_tlsname, `ecbp`_tlsname and `ecp`_tlsname
 #define OQS_GROUP_ENTRY(tlsname, realname, algorithm, idx)                     \
-    {                                                                          \
-        OSSL_PARAM_utf8_string(OSSL_CAPABILITY_TLS_GROUP_NAME, #tlsname,       \
-                               sizeof(#tlsname)),                              \
-            OSSL_PARAM_utf8_string(OSSL_CAPABILITY_TLS_GROUP_NAME_INTERNAL,    \
-                                   #realname, sizeof(#realname)),              \
-            OSSL_PARAM_utf8_string(OSSL_CAPABILITY_TLS_GROUP_ALG, #algorithm,  \
-                                   sizeof(#algorithm)),                        \
-            OSSL_PARAM_uint(OSSL_CAPABILITY_TLS_GROUP_ID,                      \
-                            (unsigned int *)&oqs_group_list[idx].group_id),    \
-            OSSL_PARAM_uint(OSSL_CAPABILITY_TLS_GROUP_SECURITY_BITS,           \
-                            (unsigned int *)&oqs_group_list[idx].secbits),     \
-            OSSL_PARAM_int(OSSL_CAPABILITY_TLS_GROUP_MIN_TLS,                  \
-                           (unsigned int *)&oqs_group_list[idx].mintls),       \
-            OSSL_PARAM_int(OSSL_CAPABILITY_TLS_GROUP_MAX_TLS,                  \
-                           (unsigned int *)&oqs_group_list[idx].maxtls),       \
-            OSSL_PARAM_int(OSSL_CAPABILITY_TLS_GROUP_MIN_DTLS,                 \
-                           (unsigned int *)&oqs_group_list[idx].mindtls),      \
-            OSSL_PARAM_int(OSSL_CAPABILITY_TLS_GROUP_MAX_DTLS,                 \
-                           (unsigned int *)&oqs_group_list[idx].maxdtls),      \
-            OSSL_PARAM_int(OSSL_CAPABILITY_TLS_GROUP_IS_KEM,                   \
-                           (unsigned int *)&oqs_group_list[idx].is_kem),       \
-            OSSL_PARAM_END                                                     \
-    }
+    {OSSL_PARAM_utf8_string(OSSL_CAPABILITY_TLS_GROUP_NAME, #tlsname,          \
+                            sizeof(#tlsname)),                                 \
+     OSSL_PARAM_utf8_string(OSSL_CAPABILITY_TLS_GROUP_NAME_INTERNAL,           \
+                            #realname, sizeof(#realname)),                     \
+     OSSL_PARAM_utf8_string(OSSL_CAPABILITY_TLS_GROUP_ALG, #algorithm,         \
+                            sizeof(#algorithm)),                               \
+     OSSL_PARAM_uint(OSSL_CAPABILITY_TLS_GROUP_ID,                             \
+                     (unsigned int *)&oqs_group_list[idx].group_id),           \
+     OSSL_PARAM_uint(OSSL_CAPABILITY_TLS_GROUP_SECURITY_BITS,                  \
+                     (unsigned int *)&oqs_group_list[idx].secbits),            \
+     OSSL_PARAM_int(OSSL_CAPABILITY_TLS_GROUP_MIN_TLS,                         \
+                    (unsigned int *)&oqs_group_list[idx].mintls),              \
+     OSSL_PARAM_int(OSSL_CAPABILITY_TLS_GROUP_MAX_TLS,                         \
+                    (unsigned int *)&oqs_group_list[idx].maxtls),              \
+     OSSL_PARAM_int(OSSL_CAPABILITY_TLS_GROUP_MIN_DTLS,                        \
+                    (unsigned int *)&oqs_group_list[idx].mindtls),             \
+     OSSL_PARAM_int(OSSL_CAPABILITY_TLS_GROUP_MAX_DTLS,                        \
+                    (unsigned int *)&oqs_group_list[idx].maxdtls),             \
+     OSSL_PARAM_int(OSSL_CAPABILITY_TLS_GROUP_IS_KEM,                          \
+                    (unsigned int *)&oqs_group_list[idx].is_kem),              \
+     OSSL_PARAM_END}
 
 static const OSSL_PARAM oqs_param_group_list[][11] = {
 ///// OQS_TEMPLATE_FRAGMENT_GROUP_NAMES_START
@@ -697,23 +695,21 @@ static int oqs_group_capability(OSSL_CALLBACK *cb, void *arg) {
 
 #ifdef OSSL_CAPABILITY_TLS_SIGALG_NAME
 #define OQS_SIGALG_ENTRY(tlsname, realname, algorithm, oid, idx)               \
-    {                                                                          \
-        OSSL_PARAM_utf8_string(OSSL_CAPABILITY_TLS_SIGALG_IANA_NAME, #tlsname, \
-                               sizeof(#tlsname)),                              \
-            OSSL_PARAM_utf8_string(OSSL_CAPABILITY_TLS_SIGALG_NAME, #tlsname,  \
-                                   sizeof(#tlsname)),                          \
-            OSSL_PARAM_utf8_string(OSSL_CAPABILITY_TLS_SIGALG_OID, #oid,       \
-                                   sizeof(#oid)),                              \
-            OSSL_PARAM_uint(OSSL_CAPABILITY_TLS_SIGALG_CODE_POINT,             \
-                            (unsigned int *)&oqs_sigalg_list[idx].code_point), \
-            OSSL_PARAM_uint(OSSL_CAPABILITY_TLS_SIGALG_SECURITY_BITS,          \
-                            (unsigned int *)&oqs_sigalg_list[idx].secbits),    \
-            OSSL_PARAM_int(OSSL_CAPABILITY_TLS_SIGALG_MIN_TLS,                 \
-                           (unsigned int *)&oqs_sigalg_list[idx].mintls),      \
-            OSSL_PARAM_int(OSSL_CAPABILITY_TLS_SIGALG_MAX_TLS,                 \
-                           (unsigned int *)&oqs_sigalg_list[idx].maxtls),      \
-            OSSL_PARAM_END                                                     \
-    }
+    {OSSL_PARAM_utf8_string(OSSL_CAPABILITY_TLS_SIGALG_IANA_NAME, #tlsname,    \
+                            sizeof(#tlsname)),                                 \
+     OSSL_PARAM_utf8_string(OSSL_CAPABILITY_TLS_SIGALG_NAME, #tlsname,         \
+                            sizeof(#tlsname)),                                 \
+     OSSL_PARAM_utf8_string(OSSL_CAPABILITY_TLS_SIGALG_OID, #oid,              \
+                            sizeof(#oid)),                                     \
+     OSSL_PARAM_uint(OSSL_CAPABILITY_TLS_SIGALG_CODE_POINT,                    \
+                     (unsigned int *)&oqs_sigalg_list[idx].code_point),        \
+     OSSL_PARAM_uint(OSSL_CAPABILITY_TLS_SIGALG_SECURITY_BITS,                 \
+                     (unsigned int *)&oqs_sigalg_list[idx].secbits),           \
+     OSSL_PARAM_int(OSSL_CAPABILITY_TLS_SIGALG_MIN_TLS,                        \
+                    (unsigned int *)&oqs_sigalg_list[idx].mintls),             \
+     OSSL_PARAM_int(OSSL_CAPABILITY_TLS_SIGALG_MAX_TLS,                        \
+                    (unsigned int *)&oqs_sigalg_list[idx].maxtls),             \
+     OSSL_PARAM_END}
 
 static const OSSL_PARAM oqs_param_sigalg_list[][12] = {
 ///// OQS_TEMPLATE_FRAGMENT_SIGALG_NAMES_START


### PR DESCRIPTION
Fixes clang-formatting errors in current main branch, which I believe to be a result of PR #779. To be honest, I don't fully grasp why this happened, and also why I had to install locally the same clang-format version, as using the docker in order to simulate the version did not work either.

Anyway, I believe these are the changes that PR #778 is asking for.
