### PR TITLE
Enhance DTLS1.3 support to handle the case when DTLS1.3 is disabled.

### DIFF
--- a/test/oqs_test_groups.c
+++ b/test/oqs_test_groups.c
@@ -129,7 +129,7 @@ static int test_group(const OSSL_PARAM params[], void *data) {
         (*errcnt)++;
     }
 
-#ifdef DTLS1_3_VERSION
+#if !defined(OPENSSL_NO_DTLS1_3) && defined(DTLS1_3_VERSION)
     ret = test_oqs_groups(group_name, 1);
 
     if (ret >= 0) {

--- a/test/oqs_test_tlssig.c
+++ b/test/oqs_test_tlssig.c
@@ -139,7 +139,7 @@ static int test_signature(const OSSL_PARAM params[], void *data) {
         (*errcnt)++;
     }
 
-#ifdef DTLS1_3_VERSION
+#if !defined(OPENSSL_NO_DTLS1_3) && defined(DTLS1_3_VERSION)
     ret = test_oqs_tlssig(sigalg_name, 1);
 
     if (ret >= 0) {

--- a/test/tlstest_helpers.c
+++ b/test/tlstest_helpers.c
@@ -65,7 +65,7 @@ int create_tls1_3_ctx_pair(OSSL_LIB_CTX *libctx, SSL_CTX **sctx, SSL_CTX **cctx,
 
     SSL_CTX_set_options(serverctx, SSL_OP_ALLOW_CLIENT_RENEGOTIATION);
     if (dtls_flag) {
-#ifdef DTLS1_3_VERSION
+#if !defined(OPENSSL_NO_DTLS1_3) && defined(DTLS1_3_VERSION)
         if (!SSL_CTX_set_min_proto_version(serverctx, DTLS1_3_VERSION) ||
             !SSL_CTX_set_max_proto_version(serverctx, DTLS1_3_VERSION) ||
             !SSL_CTX_set_min_proto_version(clientctx, DTLS1_3_VERSION) ||


### PR DESCRIPTION
In preparation for DTLS 1.3.
Enhance DTLS1.3 support to handle the case when DTLS1.3 is disabled.

<!-- Please give a brief explanation of the purpose of this pull request. -->

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->
