### PR TITLE
ci: Harden GitHub Actions workflows

### DIFF
--- a/.github/workflows/check_workflows.yml
+++ b/.github/workflows/check_workflows.yml
@@ -17,6 +17,15 @@ jobs:
           persist-credentials: false
       - name: Ensure GitHub actions are valid
         run: actionlint -shellcheck "" # run *without* shellcheck
+
+  zizmor:
+    name: Audit GitHub actions security with zizmor
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - name: Audit GitHub actions security with zizmor
         uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7
         with:

--- a/.github/workflows/check_workflows.yml
+++ b/.github/workflows/check_workflows.yml
@@ -12,7 +12,7 @@ jobs:
     container: openquantumsafe/ci-ubuntu-latest@sha256:52c9f9c763619c6495b34948c03b613ef1300deba8e615a26ea603d5ab0cfc47
     steps:
       - name: Checkout code
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - name: Ensure GitHub actions are valid

--- a/.github/workflows/check_workflows.yml
+++ b/.github/workflows/check_workflows.yml
@@ -2,13 +2,22 @@ name: Check GitHub workflows
 
 on: [pull_request, push, workflow_call]
 
+permissions:
+  contents: read
+
 jobs:
   workflowcheck:
     name: Check validity of GitHub workflows
     runs-on: ubuntu-latest
-    container: openquantumsafe/ci-ubuntu-latest:latest
+    container: openquantumsafe/ci-ubuntu-latest@sha256:52c9f9c763619c6495b34948c03b613ef1300deba8e615a26ea603d5ab0cfc47
     steps:
       - name: Checkout code
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # pin@v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          persist-credentials: false
       - name: Ensure GitHub actions are valid
         run: actionlint -shellcheck "" # run *without* shellcheck
+      - name: Audit GitHub actions security with zizmor
+        uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7
+        with:
+          advanced-security: false

--- a/.github/workflows/coding_style.yml
+++ b/.github/workflows/coding_style.yml
@@ -17,7 +17,7 @@ jobs:
         run: apt-get update && apt-get install -y clang-format
 
       - name: Checkout code
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/coding_style.yml
+++ b/.github/workflows/coding_style.yml
@@ -1,6 +1,9 @@
 name: Coding style tests
 on: [workflow_call]
 
+permissions:
+  contents: read
+
 jobs:
   check_clang_format:
     name: "Coding style"
@@ -8,13 +11,15 @@ jobs:
     strategy:
       fail-fast: false
     container:
-      image: openquantumsafe/ci-ubuntu-latest:latest
+      image: openquantumsafe/ci-ubuntu-latest@sha256:52c9f9c763619c6495b34948c03b613ef1300deba8e615a26ea603d5ab0cfc47
     steps:
       - name: Install dependencies
         run: apt-get update && apt-get install -y clang-format
 
       - name: Checkout code
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # pin@v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          persist-credentials: false
 
       - name: Check coding style using clang-format
         run: ./scripts/do_code_format.sh
@@ -31,4 +36,3 @@ jobs:
           ./scripts/do_code_format.sh --no-dry-run && \
           git diff && \
           ! git status | grep modified
-

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -27,7 +27,7 @@ jobs:
       LIBOQS_BRANCH: "main"
     steps:
       - name: Checkout code
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - name: Full build
@@ -61,7 +61,7 @@ jobs:
       LIBOQS_BRANCH: "main"
     steps:
       - name: Checkout code
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - name: Add safe directory exception
@@ -85,7 +85,7 @@ jobs:
         run: cpack -C DebPack
         working-directory: _build
       - name: Retain .deb installer
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ matrix.ossl-branch }} ${{ matrix.cmake-params }} ${{ matrix.libjade-build }} oqsprovider-x64
           path: _build/*.deb
@@ -112,7 +112,7 @@ jobs:
       OPENSSL_BRANCH: "openssl-3.5.0"
     steps:
       - name: Checkout code
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
@@ -188,7 +188,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
@@ -260,7 +260,7 @@ jobs:
             dpkg -I oqs-provider-*.deb | grep -q "Architecture: arm64"
 
       - name: Retain .deb installer
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: oqsprovider-aarch64
           path: build/*.deb

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
   coding_style_tests:
     uses: ./.github/workflows/coding_style.yml
@@ -18,13 +21,15 @@ jobs:
         cmake-params: [ "" ]
         libjade-build: ["ON", "OFF"]
     container:
-      image: openquantumsafe/ci-ubuntu-jammy:latest
+      image: openquantumsafe/ci-ubuntu-jammy@sha256:a4195181536916bb79e0e309b57fd5d9df20a3eee8f500da6caae9e355ba8807
     env:
       MAKE_PARAMS: "-j 18"
       LIBOQS_BRANCH: "main"
     steps:
       - name: Checkout code
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # pin@v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          persist-credentials: false
       - name: Full build
         run: OQSPROV_CMAKE_PARAMS=${{ matrix.cmake-params}} OQS_LIBJADE_BUILD=${{ matrix.libjade-build }} ./scripts/fullbuild.sh
       - name: Test
@@ -43,12 +48,12 @@ jobs:
           - "OFF"
         include:
           - name: alpine
-            container: openquantumsafe/ci-alpine-amd64:latest
+            container: openquantumsafe/ci-alpine-amd64@sha256:ed0c927d3c54b68cdb74d734073def77bfa4d510f35b8d4ace8acfb150016378
 # focal test done on CircleCI - save the compute cycles here until CCI is dropped
 #          - name: focal
 #            container: openquantumsafe/ci-ubuntu-focal-x86_64:latest
           - name: jammy
-            container: openquantumsafe/ci-ubuntu-jammy:latest
+            container: openquantumsafe/ci-ubuntu-jammy@sha256:a4195181536916bb79e0e309b57fd5d9df20a3eee8f500da6caae9e355ba8807
     container:
       image: ${{ matrix.container }}
     env:
@@ -56,7 +61,9 @@ jobs:
       LIBOQS_BRANCH: "main"
     steps:
       - name: Checkout code
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # pin@v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          persist-credentials: false
       - name: Add safe directory exception
         run: git config --global --add safe.directory /__w/oqs-provider/oqs-provider
       - name: Full build
@@ -78,7 +85,7 @@ jobs:
         run: cpack -C DebPack
         working-directory: _build
       - name: Retain .deb installer
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ${{ matrix.ossl-branch }} ${{ matrix.cmake-params }} ${{ matrix.libjade-build }} oqsprovider-x64
           path: _build/*.deb
@@ -96,7 +103,7 @@ jobs:
     strategy:
       fail-fast: false
     container:
-      image: openquantumsafe/ci-ubuntu-jammy:latest
+      image: openquantumsafe/ci-ubuntu-jammy@sha256:a4195181536916bb79e0e309b57fd5d9df20a3eee8f500da6caae9e355ba8807
     env:
       CC: "clang"
       CXX: "clang++"
@@ -105,7 +112,9 @@ jobs:
       OPENSSL_BRANCH: "openssl-3.5.0"
     steps:
       - name: Checkout code
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # pin@v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          persist-credentials: false
 
       - name: Install dependencies
         run: apt-get update && apt-get install -y clang llvm ninja-build git cmake libclang-14-dev libclang-common-14-dev
@@ -171,7 +180,7 @@ jobs:
     strategy:
       fail-fast: false
     container:
-      image: openquantumsafe/ci-ubuntu-jammy:latest
+      image: openquantumsafe/ci-ubuntu-jammy@sha256:a4195181536916bb79e0e309b57fd5d9df20a3eee8f500da6caae9e355ba8807
     env:
       OPENSSL_BRANCH: "openssl-4.0.1"
       INSTALL_DIR: "/opt/install"
@@ -179,7 +188,9 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # pin@v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          persist-credentials: false
 
       - name: Install dependencies
         run: apt-get update && apt-get install -y ninja-build git cmake nodejs gcc-aarch64-linux-gnu libc6-dev-arm64-cross qemu-user
@@ -249,8 +260,7 @@ jobs:
             dpkg -I oqs-provider-*.deb | grep -q "Architecture: arm64"
 
       - name: Retain .deb installer
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: oqsprovider-aarch64
           path: build/*.deb
-

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -27,18 +27,18 @@ jobs:
       MAKE_PARAMS: -j 4
     steps:
       - name: Checkout provider
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - name: Checkout openssl
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
           set-safe-directory: true
           repository: openssl/openssl
           path: openssl
       - name: checkout liboqs
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
           set-safe-directory: true
@@ -47,7 +47,7 @@ jobs:
           path: liboqs
       - name: Retrieve OpenSSL32 from cache
         id: cache-openssl32
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
         with:
           path: .localopenssl32
           key: ${{ runner.os }}-openssl32
@@ -58,7 +58,7 @@ jobs:
       - name: Save OpenSSL
         id: cache-openssl-save
         if: steps.cache-openssl32.outputs.cache-hit != 'true'
-        uses: actions/cache/save@6f8efc29b200d32929f49075959781ed54ec270c # v3
+        uses: actions/cache/save@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
         with:
           path: |
             .localopenssl32
@@ -88,7 +88,7 @@ jobs:
             fi'
         working-directory: scripts
       - name: Retain oqsprovider.dylib
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: oqs-provider-${{matrix.os}}-x64
           path: _build/lib/oqsprovider.dylib

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -27,23 +27,27 @@ jobs:
       MAKE_PARAMS: -j 4
     steps:
       - name: Checkout provider
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # pin@v4
-      - name: Checkout openssl
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # pin@v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
+          persist-credentials: false
+      - name: Checkout openssl
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          persist-credentials: false
           set-safe-directory: true
           repository: openssl/openssl
           path: openssl
       - name: checkout liboqs
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # pin@v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
+          persist-credentials: false
           set-safe-directory: true
           repository: open-quantum-safe/liboqs
           ref: main
           path: liboqs
       - name: Retrieve OpenSSL32 from cache
         id: cache-openssl32
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: .localopenssl32
           key: ${{ runner.os }}-openssl32
@@ -54,7 +58,7 @@ jobs:
       - name: Save OpenSSL
         id: cache-openssl-save
         if: steps.cache-openssl32.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@6f8efc29b200d32929f49075959781ed54ec270c # v3
         with:
           path: |
             .localopenssl32
@@ -84,7 +88,7 @@ jobs:
             fi'
         working-directory: scripts
       - name: Retain oqsprovider.dylib
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: oqs-provider-${{matrix.os}}-x64
           path: _build/lib/oqsprovider.dylib

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,13 +47,13 @@ jobs:
             && echo "provider_ref=$provider_ref" >> "$GITHUB_ENV" \
             || echo "provider_ref=main" >> "$GITHUB_ENV"
       - name: Checkout oqs-provider on requested ref if it exists; otherwise, fall back to main
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
           ref: ${{ env.provider_ref }}
       # This is designed to be triggered automatically from liboqs CI, so don't bother validating the liboqs ref.
       - name: Checkout liboqs at requested ref
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
           repository: open-quantum-safe/liboqs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ on:
   repository_dispatch:
     types: [ "liboqs-release" ]
 
+permissions:
+  contents: read
+
 # To trigger this job, generate a GitHub personal access token and run the following command:
 #
 # curl --request POST \
@@ -23,7 +26,7 @@ jobs:
   release-test:
     runs-on: ubuntu-latest
     container:
-      image: openquantumsafe/ci-ubuntu-jammy:latest
+      image: openquantumsafe/ci-ubuntu-jammy@sha256:a4195181536916bb79e0e309b57fd5d9df20a3eee8f500da6caae9e355ba8807
 
     steps:
       - name: Check if requested ref exists
@@ -44,13 +47,15 @@ jobs:
             && echo "provider_ref=$provider_ref" >> "$GITHUB_ENV" \
             || echo "provider_ref=main" >> "$GITHUB_ENV"
       - name: Checkout oqs-provider on requested ref if it exists; otherwise, fall back to main
-        uses: actions/checkout@v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
+          persist-credentials: false
           ref: ${{ env.provider_ref }}
       # This is designed to be triggered automatically from liboqs CI, so don't bother validating the liboqs ref.
       - name: Checkout liboqs at requested ref
-        uses: actions/checkout@v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
+          persist-credentials: false
           repository: open-quantum-safe/liboqs
           path: liboqs
           ref: ${{ github.event.client_payload.liboqs_ref }}

--- a/.github/workflows/standalone.yml
+++ b/.github/workflows/standalone.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
   coding_style_tests:
     uses: ./.github/workflows/coding_style.yml
@@ -18,7 +21,9 @@ jobs:
       - name: Install prerequisites
         run: brew install liboqs
       - name: Checkout oqsprovider code
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # pin@v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          persist-credentials: false
       - name: Build and test oqsprovider
         # try this only if brew'd liboqs knows about ML-KEM:
         run: |
@@ -37,7 +42,7 @@ jobs:
       matrix:
         include:
           - name: ubuntu-latest
-            container: ubuntu:latest
+            container: ubuntu@sha256:53958ec7b67c2c9355df922dd08dbf0360611f8c3cdb656875e81873db9ffdba
     container:
       image: ${{ matrix.container }}
     env:
@@ -46,9 +51,10 @@ jobs:
       - name: Update container
         run: apt update && apt install -y cmake ninja-build gcc libssl-dev git
       - name: Checkout code
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # pin@v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          persist-credentials: false
       - name: Full build
         run: LIBOQS_BRANCH=main ./scripts/fullbuild.sh
       - name: Test
         run: ./scripts/runtests.sh -V
-

--- a/.github/workflows/standalone.yml
+++ b/.github/workflows/standalone.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install prerequisites
         run: brew install liboqs
       - name: Checkout oqsprovider code
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - name: Build and test oqsprovider
@@ -51,7 +51,7 @@ jobs:
       - name: Update container
         run: apt update && apt install -y cmake ninja-build gcc libssl-dev git
       - name: Checkout code
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - name: Full build

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -30,28 +30,32 @@ jobs:
       MAKE_PARAMS: -j 4
     steps:
       - name: Checkout provider
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # pin@v4
-      - name: Checkout openssl
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # pin@v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
+          persist-credentials: false
+      - name: Checkout openssl
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          persist-credentials: false
           set-safe-directory: true
           repository: openssl/openssl
           path: openssl
           ref: master
       - name: checkout liboqs
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # pin@v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
+          persist-credentials: false
           set-safe-directory: true
           repository: open-quantum-safe/liboqs
           ref: main
           path: liboqs
       - name: Install cygwin
-        uses: cygwin/cygwin-install-action@master
+        uses: cygwin/cygwin-install-action@a3d72946b163026bbd0fa9a88379ccbda4bd86bb # master
         with:
           packages: perl git ninja gcc-core cmake make python3 python3-devel python3-setuptools python3-exceptiongroup
       - name: Retrieve OpenSSL32 from cache
         id: cache-openssl32
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: c:\cygwin\opt\openssl32
           key: ${{ runner.os }}-cygwinopenssl32
@@ -64,7 +68,7 @@ jobs:
       - name: Save OpenSSL
         id: cache-openssl-save
         if: steps.cache-openssl32.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@6f8efc29b200d32929f49075959781ed54ec270c # v3
         with:
           path: |
             c:\cygwin\opt\openssl32
@@ -73,20 +77,24 @@ jobs:
         run: |
            echo "IP=$(cygpath -u $PWD)/.local" >> "$env:GITHUB_ENV"
       - name: build liboqs
+        env:
+          IP: ${{ env.IP }}
         run: |
            which cmake
            cmake --version
            gcc --version
            mkdir _build
            cd _build
-           cmake -GNinja -DOPENSSL_ROOT_DIR=/opt/openssl32 -DCMAKE_INSTALL_PREFIX="${{ env.IP }}" ${{ matrix.platform.oqsconfig }} -DCMAKE_C_COMPILER=gcc ..
+           cmake -GNinja -DOPENSSL_ROOT_DIR=/opt/openssl32 -DCMAKE_INSTALL_PREFIX="$IP" ${{ matrix.platform.oqsconfig }} -DCMAKE_C_COMPILER=gcc ..
            ninja
            ninja install
            pip install pytest psutil pytest-xdist pyyaml
            # TODO: as "autoprocesses" not recognized, don't run ninja run_tests
         working-directory: liboqs
       - name: build oqs-provider
-        run: bash -c "git config --global --add safe.directory $(cygpath -u $PWD) && liboqs_DIR='${{ env.IP }}' cmake -GNinja -DCMAKE_C_COMPILER=gcc -DOPENSSL_ROOT_DIR=/opt/openssl32 -S . -B _build && cd _build && ninja && cd .."
+        env:
+          IP: ${{ env.IP }}
+        run: bash -c "git config --global --add safe.directory $(cygpath -u $PWD) && liboqs_DIR='$IP' cmake -GNinja -DCMAKE_C_COMPILER=gcc -DOPENSSL_ROOT_DIR=/opt/openssl32 -S . -B _build && cd _build && ninja && cd .."
       - name: Check Openssl providers
         run: bash -c "OPENSSL_MODULES=_build/lib /opt/openssl32/bin/openssl list -providers -provider oqsprovider -provider default"
       - name: Check Openssl provider signature algorithms
@@ -97,7 +105,7 @@ jobs:
         run: bash -c "echo $PATH && PATH=/opt/openssl32/bin:/usr/bin ctest -V"
         working-directory: _build
       - name: Retain oqsprovider.dll
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ${{matrix.os}} ${{matrix.platform.arch}} oqs-provider-cygwin
           path: D:/a/oqs-provider/oqs-provider/_build/bin/oqsprovider.dll
@@ -121,34 +129,38 @@ jobs:
     steps:
       - name: Restore OpenSSL32 cache
         id: cache-openssl32
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: c:\openssl32
           key: ${{ runner.os }}-msvcopenssl32
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # pin@v4
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          persist-credentials: false
       - name: Checkout OpenSSL master
         if: steps.cache-openssl32.outputs.cache-hit != 'true'
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # pin@v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
+          persist-credentials: false
           set-safe-directory: true
           repository: openssl/openssl
           path: openssl
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # pin@v4
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
+          persist-credentials: false
           set-safe-directory: true
           repository: open-quantum-safe/liboqs
           ref: main
           path: liboqs
-      - uses: ilammy/msvc-dev-cmd@v1
+      - uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1
         with:
           arch: ${{ matrix.platform.arch }}
       - name: Setup nasm for OpenSSL build
-        uses: ilammy/setup-nasm@v1
+        uses: ilammy/setup-nasm@72793074d3c8cdda771dba85f6deafe00623038b # v1
         if: steps.cache-openssl32.outputs.cache-hit != 'true'
         with:
           platform: ${{ matrix.platform.arch }}
       - name: Setup perl for OpenSSl build
-        uses: shogo82148/actions-setup-perl@v1
+        uses: shogo82148/actions-setup-perl@a198315ec4e9244f206879ea7b63078003aec8a6 # v1
         if: steps.cache-openssl32.outputs.cache-hit != 'true'
 # OQS_USE_OPENSSL=OFF by default on Win32
 # if cmake --build fails, try explicit
@@ -193,7 +205,7 @@ jobs:
       - name: Save OpenSSL
         id: cache-openssl-save
         if: steps.cache-openssl32.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@6f8efc29b200d32929f49075959781ed54ec270c # v3
         with:
           path: |
             c:\openssl32
@@ -207,7 +219,7 @@ jobs:
         run: |
           ctest -V --test-dir _build
       - name: Retain oqsprovider.dll
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ${{matrix.os}} ${{matrix.platform.arch}} oqs-provider-msvc
           path: D:/a/oqs-provider/oqs-provider/_build/lib/oqsprovider.dll
@@ -234,39 +246,43 @@ jobs:
     steps:
         - name: Restore native OpenSSL32 cache
           id: cache-openssl32n
-          uses: actions/cache@v4
+          uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
           with:
             path: c:\openssl32n
             key: ${{ runner.os }}-msvcopenssl32n
-        - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # pin@v4
+        - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+          with:
+            persist-credentials: false
         - name: Checkout OpenSSL master
           if: steps.cache-openssl32n.outputs.cache-hit != 'true'
-          uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # pin@v4
+          uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
           with:
+            persist-credentials: false
             set-safe-directory: true
             repository: openssl/openssl
             path: openssl
-        - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # pin@v4
+        - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
           with:
+            persist-credentials: false
             set-safe-directory: true
             repository: open-quantum-safe/liboqs
             ref: main
             path: liboqs
-        - uses: ilammy/msvc-dev-cmd@v1
+        - uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1
           with:
             arch: ${{ matrix.platform.arch }}
         - name: Add msbuild to PATH
-          uses: microsoft/setup-msbuild@v1
+          uses: microsoft/setup-msbuild@ede762b26a2de8d110bb5a3db4d7e0e080c0e917 # v1
           with:
             msbuild-architecture: ${{matrix.msarch}}
             vs-version: '[16.10,]'
         - name: Setup nasm for OpenSSL build
-          uses: ilammy/setup-nasm@v1
+          uses: ilammy/setup-nasm@72793074d3c8cdda771dba85f6deafe00623038b # v1
           if: steps.cache-openssl32n.outputs.cache-hit != 'true'
           with:
             platform: ${{ matrix.platform.arch }}
         - name: Setup perl for OpenSSL build
-          uses: shogo82148/actions-setup-perl@v1
+          uses: shogo82148/actions-setup-perl@a198315ec4e9244f206879ea7b63078003aec8a6 # v1
           if: steps.cache-openssl32n.outputs.cache-hit != 'true'
         - name: build liboqs
           run: |
@@ -299,7 +315,7 @@ jobs:
         - name: Save OpenSSL
           id: cache-openssl-save
           if: steps.cache-openssl32n.outputs.cache-hit != 'true'
-          uses: actions/cache/save@v3
+          uses: actions/cache/save@6f8efc29b200d32929f49075959781ed54ec270c # v3
           with:
             path: |
               c:\openssl32n
@@ -312,8 +328,7 @@ jobs:
           run: |
             ctest -V --test-dir _build -C ${{ matrix.type }}
         - name: Retain oqsprovider.dll
-          uses: actions/upload-artifact@v4
+          uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
           with:
             name: ${{matrix.os}} ${{matrix.platform.arch}} oqs-provider-msvc
             path: D:/a/oqs-provider/oqs-provider/_build/lib/oqsprovider.dll
-

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -30,11 +30,11 @@ jobs:
       MAKE_PARAMS: -j 4
     steps:
       - name: Checkout provider
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - name: Checkout openssl
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
           set-safe-directory: true
@@ -42,7 +42,7 @@ jobs:
           path: openssl
           ref: master
       - name: checkout liboqs
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
           set-safe-directory: true
@@ -50,12 +50,12 @@ jobs:
           ref: main
           path: liboqs
       - name: Install cygwin
-        uses: cygwin/cygwin-install-action@a3d72946b163026bbd0fa9a88379ccbda4bd86bb # master
+        uses: cygwin/cygwin-install-action@d2090847213be12ce5ccfd44de18e482a134d735 # v6.1
         with:
           packages: perl git ninja gcc-core cmake make python3 python3-devel python3-setuptools python3-exceptiongroup
       - name: Retrieve OpenSSL32 from cache
         id: cache-openssl32
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
         with:
           path: c:\cygwin\opt\openssl32
           key: ${{ runner.os }}-cygwinopenssl32
@@ -68,7 +68,7 @@ jobs:
       - name: Save OpenSSL
         id: cache-openssl-save
         if: steps.cache-openssl32.outputs.cache-hit != 'true'
-        uses: actions/cache/save@6f8efc29b200d32929f49075959781ed54ec270c # v3
+        uses: actions/cache/save@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
         with:
           path: |
             c:\cygwin\opt\openssl32
@@ -105,7 +105,7 @@ jobs:
         run: bash -c "echo $PATH && PATH=/opt/openssl32/bin:/usr/bin ctest -V"
         working-directory: _build
       - name: Retain oqsprovider.dll
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{matrix.os}} ${{matrix.platform.arch}} oqs-provider-cygwin
           path: D:/a/oqs-provider/oqs-provider/_build/bin/oqsprovider.dll
@@ -129,38 +129,38 @@ jobs:
     steps:
       - name: Restore OpenSSL32 cache
         id: cache-openssl32
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
         with:
           path: c:\openssl32
           key: ${{ runner.os }}-msvcopenssl32
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - name: Checkout OpenSSL master
         if: steps.cache-openssl32.outputs.cache-hit != 'true'
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
           set-safe-directory: true
           repository: openssl/openssl
           path: openssl
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
           set-safe-directory: true
           repository: open-quantum-safe/liboqs
           ref: main
           path: liboqs
-      - uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1
+      - uses: ilammy/msvc-dev-cmd@a102174a2b586eec2ea151a69e6fd14404a8ce7c # v1.13.0
         with:
           arch: ${{ matrix.platform.arch }}
       - name: Setup nasm for OpenSSL build
-        uses: ilammy/setup-nasm@72793074d3c8cdda771dba85f6deafe00623038b # v1
+        uses: ilammy/setup-nasm@e77cc62a22a374a4d0668286007cc3e3b4c17760 # v1.5.2
         if: steps.cache-openssl32.outputs.cache-hit != 'true'
         with:
           platform: ${{ matrix.platform.arch }}
       - name: Setup perl for OpenSSl build
-        uses: shogo82148/actions-setup-perl@a198315ec4e9244f206879ea7b63078003aec8a6 # v1
+        uses: shogo82148/actions-setup-perl@a198315ec4e9244f206879ea7b63078003aec8a6 # v1.41.1
         if: steps.cache-openssl32.outputs.cache-hit != 'true'
 # OQS_USE_OPENSSL=OFF by default on Win32
 # if cmake --build fails, try explicit
@@ -205,7 +205,7 @@ jobs:
       - name: Save OpenSSL
         id: cache-openssl-save
         if: steps.cache-openssl32.outputs.cache-hit != 'true'
-        uses: actions/cache/save@6f8efc29b200d32929f49075959781ed54ec270c # v3
+        uses: actions/cache/save@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
         with:
           path: |
             c:\openssl32
@@ -219,7 +219,7 @@ jobs:
         run: |
           ctest -V --test-dir _build
       - name: Retain oqsprovider.dll
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{matrix.os}} ${{matrix.platform.arch}} oqs-provider-msvc
           path: D:/a/oqs-provider/oqs-provider/_build/lib/oqsprovider.dll
@@ -246,43 +246,43 @@ jobs:
     steps:
         - name: Restore native OpenSSL32 cache
           id: cache-openssl32n
-          uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+          uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
           with:
             path: c:\openssl32n
             key: ${{ runner.os }}-msvcopenssl32n
-        - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
           with:
             persist-credentials: false
         - name: Checkout OpenSSL master
           if: steps.cache-openssl32n.outputs.cache-hit != 'true'
-          uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+          uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
           with:
             persist-credentials: false
             set-safe-directory: true
             repository: openssl/openssl
             path: openssl
-        - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
           with:
             persist-credentials: false
             set-safe-directory: true
             repository: open-quantum-safe/liboqs
             ref: main
             path: liboqs
-        - uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1
+        - uses: ilammy/msvc-dev-cmd@a102174a2b586eec2ea151a69e6fd14404a8ce7c # v1.13.0
           with:
             arch: ${{ matrix.platform.arch }}
         - name: Add msbuild to PATH
-          uses: microsoft/setup-msbuild@ede762b26a2de8d110bb5a3db4d7e0e080c0e917 # v1
+          uses: microsoft/setup-msbuild@30375c66a4eea26614e0d39710365f22f8b0af57 # v3.0.0
           with:
             msbuild-architecture: ${{matrix.msarch}}
             vs-version: '[16.10,]'
         - name: Setup nasm for OpenSSL build
-          uses: ilammy/setup-nasm@72793074d3c8cdda771dba85f6deafe00623038b # v1
+          uses: ilammy/setup-nasm@e77cc62a22a374a4d0668286007cc3e3b4c17760 # v1.5.2
           if: steps.cache-openssl32n.outputs.cache-hit != 'true'
           with:
             platform: ${{ matrix.platform.arch }}
         - name: Setup perl for OpenSSL build
-          uses: shogo82148/actions-setup-perl@a198315ec4e9244f206879ea7b63078003aec8a6 # v1
+          uses: shogo82148/actions-setup-perl@a198315ec4e9244f206879ea7b63078003aec8a6 # v1.41.1
           if: steps.cache-openssl32n.outputs.cache-hit != 'true'
         - name: build liboqs
           run: |
@@ -315,7 +315,7 @@ jobs:
         - name: Save OpenSSL
           id: cache-openssl-save
           if: steps.cache-openssl32n.outputs.cache-hit != 'true'
-          uses: actions/cache/save@6f8efc29b200d32929f49075959781ed54ec270c # v3
+          uses: actions/cache/save@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
           with:
             path: |
               c:\openssl32n
@@ -328,7 +328,7 @@ jobs:
           run: |
             ctest -V --test-dir _build -C ${{ matrix.type }}
         - name: Retain oqsprovider.dll
-          uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+          uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
           with:
             name: ${{matrix.os}} ${{matrix.platform.arch}} oqs-provider-msvc
             path: D:/a/oqs-provider/oqs-provider/_build/lib/oqsprovider.dll

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -77,24 +77,20 @@ jobs:
         run: |
            echo "IP=$(cygpath -u $PWD)/.local" >> "$env:GITHUB_ENV"
       - name: build liboqs
-        env:
-          IP: ${{ env.IP }}
         run: |
            which cmake
            cmake --version
            gcc --version
            mkdir _build
            cd _build
-           cmake -GNinja -DOPENSSL_ROOT_DIR=/opt/openssl32 -DCMAKE_INSTALL_PREFIX="$IP" ${{ matrix.platform.oqsconfig }} -DCMAKE_C_COMPILER=gcc ..
+           cmake -GNinja -DOPENSSL_ROOT_DIR=/opt/openssl32 -DCMAKE_INSTALL_PREFIX="$env:IP" ${{ matrix.platform.oqsconfig }} -DCMAKE_C_COMPILER=gcc ..
            ninja
            ninja install
            pip install pytest psutil pytest-xdist pyyaml
            # TODO: as "autoprocesses" not recognized, don't run ninja run_tests
         working-directory: liboqs
       - name: build oqs-provider
-        env:
-          IP: ${{ env.IP }}
-        run: bash -c "git config --global --add safe.directory $(cygpath -u $PWD) && liboqs_DIR='$IP' cmake -GNinja -DCMAKE_C_COMPILER=gcc -DOPENSSL_ROOT_DIR=/opt/openssl32 -S . -B _build && cd _build && ninja && cd .."
+        run: bash -c "git config --global --add safe.directory $(cygpath -u $PWD) && liboqs_DIR='$env:IP' cmake -GNinja -DCMAKE_C_COMPILER=gcc -DOPENSSL_ROOT_DIR=/opt/openssl32 -S . -B _build && cd _build && ninja && cd .."
       - name: Check Openssl providers
         run: bash -c "OPENSSL_MODULES=_build/lib /opt/openssl32/bin/openssl list -providers -provider oqsprovider -provider default"
       - name: Check Openssl provider signature algorithms

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -50,7 +50,7 @@ jobs:
           ref: main
           path: liboqs
       - name: Install cygwin
-        uses: cygwin/cygwin-install-action@d2090847213be12ce5ccfd44de18e482a134d735 # v6.1
+        uses: cygwin/cygwin-install-action@3f0a3f9f988f7e96b8c18098ae05eaec175f5b52 # v6.1
         with:
           packages: perl git ninja gcc-core cmake make python3 python3-devel python3-setuptools python3-exceptiongroup
       - name: Retrieve OpenSSL32 from cache
@@ -151,11 +151,11 @@ jobs:
           repository: open-quantum-safe/liboqs
           ref: main
           path: liboqs
-      - uses: ilammy/msvc-dev-cmd@a102174a2b586eec2ea151a69e6fd14404a8ce7c # v1.13.0
+      - uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
         with:
           arch: ${{ matrix.platform.arch }}
       - name: Setup nasm for OpenSSL build
-        uses: ilammy/setup-nasm@e77cc62a22a374a4d0668286007cc3e3b4c17760 # v1.5.2
+        uses: ilammy/setup-nasm@72793074d3c8cdda771dba85f6deafe00623038b # v1.5.2
         if: steps.cache-openssl32.outputs.cache-hit != 'true'
         with:
           platform: ${{ matrix.platform.arch }}
@@ -268,7 +268,7 @@ jobs:
             repository: open-quantum-safe/liboqs
             ref: main
             path: liboqs
-        - uses: ilammy/msvc-dev-cmd@a102174a2b586eec2ea151a69e6fd14404a8ce7c # v1.13.0
+        - uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
           with:
             arch: ${{ matrix.platform.arch }}
         - name: Add msbuild to PATH
@@ -277,7 +277,7 @@ jobs:
             msbuild-architecture: ${{matrix.msarch}}
             vs-version: '[16.10,]'
         - name: Setup nasm for OpenSSL build
-          uses: ilammy/setup-nasm@e77cc62a22a374a4d0668286007cc3e3b4c17760 # v1.5.2
+          uses: ilammy/setup-nasm@72793074d3c8cdda771dba85f6deafe00623038b # v1.5.2
           if: steps.cache-openssl32n.outputs.cache-hit != 'true'
           with:
             platform: ${{ matrix.platform.arch }}


### PR DESCRIPTION
This PR hardens the GitHub Actions CI workflows, primarily by integrating [zizmor](https://github.com/zizmorcore/zizmor) as a security audit step to check_workflows.

An initial-run list of remediations is also implemented:

- Pin container images and remaining actions to immutable SHA digests
- Add least-privilege `permissions: contents: read` to workflows
- Set `persist-credentials: false` on all checkout steps
- Avoid template injection risk in windows.yml when passing IP

Follow-on work from the Zizmor integration in this PR has been to version-bump most of the consumed GitHub Actions and associated hashes, landed in this PR as part of a CI tidy.
 - actions/checkout -> v7.0.0
 - actions/upload-artifact -> v7.0.1
 - actions/cache and actions/cache/save -> v6.0.0
 - cygwin/cygwin-install-action -> v6.1
 - ilammy/msvc-dev-cmd -> v1.13.0
 - ilammy/setup-nasm -> v1.5.2
 - microsoft/setup-msbuild -> v3.0.0
 - shogo82148/actions-setup-perl -> v1.41.1
