### PR TITLE
Remove algs that cannot be used in TLS from `openssl list -tls-signature-algorithms`

### DIFF
--- a/oqsprov/oqsprov_capabilities.c
+++ b/oqsprov/oqsprov_capabilities.c
@@ -944,6 +944,11 @@ static int oqs_sigalg_capability(OSSL_CALLBACK *cb, void *arg) {
     // liboqs:
     assert(OSSL_NELEM(oqs_param_sigalg_list) <= OSSL_NELEM(oqs_sigalg_list));
     for (i = 0; i < OSSL_NELEM(oqs_param_sigalg_list); i++) {
+        // do not advertise algorithms that cannot be used in TLS handshakes
+        // (mintls == -1), so they are not listed as TLS signature algorithms
+        const int *mintls = (const int *)oqs_param_sigalg_list[i][5].data;
+        if (mintls != NULL && *mintls < 0)
+            continue;
         // do not register algorithms disabled at runtime
         if (sk_OPENSSL_STRING_find(oqsprov_get_rt_disabled_algs(),
                                    (char *)oqs_param_sigalg_list[i][1].data) <

--- a/test/oqs_test_tlssig.c
+++ b/test/oqs_test_tlssig.c
@@ -117,9 +117,17 @@ static int test_signature(const OSSL_PARAM params[], void *data) {
 
     mintls = (int *)p->data;
     if (*mintls == -1) {
-        fprintf(stderr,
-                cYELLOW "  TLS-SIG handshake test skipped: %s" cNORM "\n",
-                sigalg_name);
+        /* Regression test for #784: the provider must not advertise sigalgs
+           that cannot be used in TLS (min_tls == -1) in its TLS-SIGALG
+           capability list. */
+        fprintf(
+            stderr,
+            cRED
+            "  TLS-SIG capability wrongly advertised (min_tls == -1): %s" cNORM
+            "\n",
+            sigalg_name);
+        (*errcnt)++;
+        ret = -1;
         goto err;
     }
 


### PR DESCRIPTION
According to the [openssl-list man page](https://man.archlinux.org/man/openssl-list.1ssl#tls~2), every alg shown in `-tls-signature-algorithms` should be available for TLS handshakes. This is not true at the moment when called with `-provider oqsprovider`. For example, if enabled, `OV_Is_pkc` is listed there, even though it cannot be used in TLS.

As suggested in https://github.com/open-quantum-safe/oqs-provider/issues/784#issuecomment-4671473029 this PR skips sig algs whose `OSSL_CAPABILITY_TLS_SIGALG_MIN_TLS` is `-1`.

Fixes: #784