### PR TITLE
Include back OpenSSL master testing onto CI

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ossl-branch: [openssl-3.4.1, openssl-3.5.0, openssl-4.0.1] # retain openssl-3.4.1 to test non-OpenSSL PQ alg implementations
+        ossl-branch: [openssl-3.4.1, openssl-3.5.0, openssl-4.0.1, master] # retain openssl-3.4.1 to test non-OpenSSL PQ alg implementations
         cmake-params: [ "", "-DOQS_KEM_ENCODERS=ON" ]
         libjade-build:
           - "ON" 


### PR DESCRIPTION
Include back testing against OpenSSL master as part of CI jobs, while maintaining testing against a fixed OpenSSL 4.X version.
 
Fixes #791.
