### PR TITLE
fix: I use OpenSSL 4.1 ASN.1 string APIs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,16 +59,25 @@ find_package(OpenSSL 3.0 REQUIRED)
 include_directories(${OPENSSL_INCLUDE_DIR})
 set(CMAKE_REQUIRED_INCLUDES ${OPENSSL_INCLUDE_DIR})
 set(CMAKE_REQUIRED_LIBRARIES ${OPENSSL_CRYPTO_LIBRARY})
+check_symbol_exists(ASN1_STRING_set1_data "openssl/asn1.h"
+                    OQSPROV_HAVE_ASN1_STRING_SET1_DATA)
 check_symbol_exists(ASN1_STRING_set_data "openssl/asn1.h"
                     OQSPROV_HAVE_ASN1_STRING_SET_DATA)
+check_symbol_exists(ASN1_STRING_get_length "openssl/asn1.h"
+                    OQSPROV_HAVE_ASN1_STRING_GET_LENGTH)
 check_symbol_exists(ASN1_STRING_length_ex "openssl/asn1.h"
                     OQSPROV_HAVE_ASN1_STRING_LENGTH_EX)
 unset(CMAKE_REQUIRED_INCLUDES)
 unset(CMAKE_REQUIRED_LIBRARIES)
-if(OQSPROV_HAVE_ASN1_STRING_SET_DATA AND
-   OQSPROV_HAVE_ASN1_STRING_LENGTH_EX)
-    add_compile_definitions(OQSPROV_HAVE_OPENSSL_4_1_ASN1_API)
-endif()
+foreach(asn1_api IN ITEMS
+        ASN1_STRING_SET1_DATA
+        ASN1_STRING_SET_DATA
+        ASN1_STRING_GET_LENGTH
+        ASN1_STRING_LENGTH_EX)
+    if(OQSPROV_HAVE_${asn1_api})
+        add_compile_definitions(OQSPROV_HAVE_${asn1_api})
+    endif()
+endforeach()
 if (WIN32)
 # get_filename_component seems to fail when facing windows paths
 # so use new(er) cmake_path instruction there

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,10 +52,23 @@ endif()
 
 include(CheckLibraryExists)
 include(CheckFunctionExists)
+include(CheckSymbolExists)
 
 # Add required includes and install locations for openssl
 find_package(OpenSSL 3.0 REQUIRED)
 include_directories(${OPENSSL_INCLUDE_DIR})
+set(CMAKE_REQUIRED_INCLUDES ${OPENSSL_INCLUDE_DIR})
+set(CMAKE_REQUIRED_LIBRARIES ${OPENSSL_CRYPTO_LIBRARY})
+check_symbol_exists(ASN1_STRING_set_data "openssl/asn1.h"
+                    OQSPROV_HAVE_ASN1_STRING_SET_DATA)
+check_symbol_exists(ASN1_STRING_length_ex "openssl/asn1.h"
+                    OQSPROV_HAVE_ASN1_STRING_LENGTH_EX)
+unset(CMAKE_REQUIRED_INCLUDES)
+unset(CMAKE_REQUIRED_LIBRARIES)
+if(OQSPROV_HAVE_ASN1_STRING_SET_DATA AND
+   OQSPROV_HAVE_ASN1_STRING_LENGTH_EX)
+    add_compile_definitions(OQSPROV_HAVE_OPENSSL_4_1_ASN1_API)
+endif()
 if (WIN32)
 # get_filename_component seems to fail when facing windows paths
 # so use new(er) cmake_path instruction there

--- a/oqsprov/oqs_encode_key2any.c
+++ b/oqsprov/oqs_encode_key2any.c
@@ -8,6 +8,7 @@
  * ToDo: Adding hybrid alg support
  */
 
+#include <limits.h>
 #include <openssl/asn1.h>
 #include <openssl/core.h>
 #include <openssl/core_dispatch.h>
@@ -61,6 +62,26 @@ typedef int key_to_der_fn(BIO *out, const void *key, int key_nid,
                           const char *pemname, key_to_paramstring_fn *p2s,
                           i2d_of_void *k2d, struct key2any_ctx_st *ctx);
 typedef int write_bio_of_void_fn(BIO *bp, const void *x);
+
+#if OPENSSL_VERSION_PREREQ(4, 1)
+static int oqsx_legacy_asn1_string_set(ASN1_STRING *str, const void *data,
+                                       int len) {
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#elif defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable : 4996)
+#endif
+    int ret = ASN1_STRING_set(str, data, len);
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#elif defined(_MSC_VER)
+#pragma warning(pop)
+#endif
+    return ret;
+}
+#endif
 
 /* Free the blob allocated during key_to_paramstring_fn */
 static void free_asn1_data(int type, void *data) {
@@ -507,6 +528,9 @@ static int oqsx_pki_priv_to_der(const void *vxkey, unsigned char **pder) {
     uint32_t buflen = 0, privkeylen = 0;
     ASN1_OCTET_STRING *oct = NULL;
     int keybloblen = -1;
+#if OPENSSL_VERSION_PREREQ(4, 1)
+    int string_set_result;
+#endif
 
     OQS_ENC_PRINTF("OQS ENC provider: oqsx_pki_priv_to_der called\n");
 
@@ -575,7 +599,14 @@ static int oqsx_pki_priv_to_der(const void *vxkey, unsigned char **pder) {
     }
 
 #if OPENSSL_VERSION_PREREQ(4, 1)
-    if (!ASN1_STRING_set_data(oct, buf, buflen)) {
+    if (OpenSSL_version_num() >= 0x40100000L) {
+        string_set_result = ASN1_STRING_set_data(oct, buf, buflen);
+    } else if (buflen <= INT_MAX) {
+        string_set_result = oqsx_legacy_asn1_string_set(oct, buf, (int)buflen);
+    } else {
+        string_set_result = 0;
+    }
+    if (!string_set_result) {
 #else
     if (!ASN1_STRING_set(oct, buf, buflen)) {
 #endif

--- a/oqsprov/oqs_encode_key2any.c
+++ b/oqsprov/oqs_encode_key2any.c
@@ -8,7 +8,6 @@
  * ToDo: Adding hybrid alg support
  */
 
-#include <limits.h>
 #include <openssl/asn1.h>
 #include <openssl/core.h>
 #include <openssl/core_dispatch.h>
@@ -62,26 +61,6 @@ typedef int key_to_der_fn(BIO *out, const void *key, int key_nid,
                           const char *pemname, key_to_paramstring_fn *p2s,
                           i2d_of_void *k2d, struct key2any_ctx_st *ctx);
 typedef int write_bio_of_void_fn(BIO *bp, const void *x);
-
-#if OPENSSL_VERSION_PREREQ(4, 1)
-static int oqsx_legacy_asn1_string_set(ASN1_STRING *str, const void *data,
-                                       int len) {
-#if defined(__GNUC__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#elif defined(_MSC_VER)
-#pragma warning(push)
-#pragma warning(disable : 4996)
-#endif
-    int ret = ASN1_STRING_set(str, data, len);
-#if defined(__GNUC__)
-#pragma GCC diagnostic pop
-#elif defined(_MSC_VER)
-#pragma warning(pop)
-#endif
-    return ret;
-}
-#endif
 
 /* Free the blob allocated during key_to_paramstring_fn */
 static void free_asn1_data(int type, void *data) {
@@ -528,9 +507,6 @@ static int oqsx_pki_priv_to_der(const void *vxkey, unsigned char **pder) {
     uint32_t buflen = 0, privkeylen = 0;
     ASN1_OCTET_STRING *oct = NULL;
     int keybloblen = -1;
-#if OPENSSL_VERSION_PREREQ(4, 1)
-    int string_set_result;
-#endif
 
     OQS_ENC_PRINTF("OQS ENC provider: oqsx_pki_priv_to_der called\n");
 
@@ -599,14 +575,7 @@ static int oqsx_pki_priv_to_der(const void *vxkey, unsigned char **pder) {
     }
 
 #if OPENSSL_VERSION_PREREQ(4, 1)
-    if (OpenSSL_version_num() >= 0x40100000L) {
-        string_set_result = ASN1_STRING_set_data(oct, buf, buflen);
-    } else if (buflen <= INT_MAX) {
-        string_set_result = oqsx_legacy_asn1_string_set(oct, buf, (int)buflen);
-    } else {
-        string_set_result = 0;
-    }
-    if (!string_set_result) {
+    if (!ASN1_STRING_set_data(oct, buf, buflen)) {
 #else
     if (!ASN1_STRING_set(oct, buf, buflen)) {
 #endif

--- a/oqsprov/oqs_encode_key2any.c
+++ b/oqsprov/oqs_encode_key2any.c
@@ -574,7 +574,7 @@ static int oqsx_pki_priv_to_der(const void *vxkey, unsigned char **pder) {
         goto done;
     }
 
-#if OPENSSL_VERSION_PREREQ(4, 1)
+#ifdef OQSPROV_HAVE_OPENSSL_4_1_ASN1_API
     if (!ASN1_STRING_set_data(oct, buf, buflen)) {
 #else
     if (!ASN1_STRING_set(oct, buf, buflen)) {

--- a/oqsprov/oqs_encode_key2any.c
+++ b/oqsprov/oqs_encode_key2any.c
@@ -574,7 +574,11 @@ static int oqsx_pki_priv_to_der(const void *vxkey, unsigned char **pder) {
         goto done;
     }
 
+#if OPENSSL_VERSION_PREREQ(4, 1)
+    if (!ASN1_STRING_set_data(oct, buf, buflen)) {
+#else
     if (!ASN1_STRING_set(oct, buf, buflen)) {
+#endif
         ERR_raise(ERR_LIB_USER, ERR_R_MALLOC_FAILURE);
         goto done;
     }

--- a/oqsprov/oqs_encode_key2any.c
+++ b/oqsprov/oqs_encode_key2any.c
@@ -574,7 +574,9 @@ static int oqsx_pki_priv_to_der(const void *vxkey, unsigned char **pder) {
         goto done;
     }
 
-#ifdef OQSPROV_HAVE_OPENSSL_4_1_ASN1_API
+#ifdef OQSPROV_HAVE_ASN1_STRING_SET1_DATA
+    if (!ASN1_STRING_set1_data(oct, buf, buflen)) {
+#elif defined(OQSPROV_HAVE_ASN1_STRING_SET_DATA)
     if (!ASN1_STRING_set_data(oct, buf, buflen)) {
 #else
     if (!ASN1_STRING_set(oct, buf, buflen)) {

--- a/oqsprov/oqs_encode_key2any.c
+++ b/oqsprov/oqs_encode_key2any.c
@@ -1374,7 +1374,8 @@ static int key2any_encode(struct key2any_ctx_st *ctx, OSSL_CORE_BIO *cout,
              (void (*)(void))impl##_to_##kind##_##output##_free_object},       \
             {OSSL_FUNC_ENCODER_ENCODE,                                         \
              (void (*)(void))impl##_to_##kind##_##output##_encode},            \
-            {0, NULL}}
+            {0, NULL}                                                          \
+        }
 
 /* ---------------------------------------------------------------------- */
 
@@ -1589,7 +1590,8 @@ key2text_encode(void *vctx, const void *key, int selection, OSSL_CORE_BIO *cout,
         {OSSL_FUNC_ENCODER_FREE_OBJECT,                                        \
          (void (*)(void))impl##2text_free_object},                             \
         {OSSL_FUNC_ENCODER_ENCODE, (void (*)(void))impl##2text_encode},        \
-        {0, NULL}}
+        {0, NULL}                                                              \
+    }
 
 /*
  * Replacements for i2d_{TYPE}PrivateKey, i2d_{TYPE}PublicKey,

--- a/oqsprov/oqsprov_keys.c
+++ b/oqsprov/oqsprov_keys.c
@@ -38,25 +38,6 @@
 
 typedef enum { KEY_OP_PUBLIC, KEY_OP_PRIVATE, KEY_OP_KEYGEN } oqsx_key_op_t;
 
-#if OPENSSL_VERSION_PREREQ(4, 1)
-static int oqsx_legacy_asn1_string_length(const ASN1_STRING *str) {
-#if defined(__GNUC__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#elif defined(_MSC_VER)
-#pragma warning(push)
-#pragma warning(disable : 4996)
-#endif
-    int ret = ASN1_STRING_length(str);
-#if defined(__GNUC__)
-#pragma GCC diagnostic pop
-#elif defined(_MSC_VER)
-#pragma warning(pop)
-#endif
-    return ret;
-}
-#endif
-
 /// NID/name table
 
 typedef struct {
@@ -1049,17 +1030,13 @@ OQSX_KEY *oqsx_key_from_pkcs8(const PKCS8_PRIV_KEY_INFO *p8inf,
     } else {
         p = ASN1_STRING_get0_data(oct);
 #if OPENSSL_VERSION_PREREQ(4, 1)
-        if (OpenSSL_version_num() >= 0x40100000L) {
-            octlen = ASN1_STRING_length_ex(oct);
-            if (octlen > INT_MAX) {
-                ASN1_OCTET_STRING_free(oct);
-                ERR_raise(ERR_LIB_USER, OQSPROV_R_INVALID_ENCODING);
-                return NULL;
-            }
-            plen = (int)octlen;
-        } else {
-            plen = oqsx_legacy_asn1_string_length(oct);
+        octlen = ASN1_STRING_length_ex(oct);
+        if (octlen > INT_MAX) {
+            ASN1_OCTET_STRING_free(oct);
+            ERR_raise(ERR_LIB_USER, OQSPROV_R_INVALID_ENCODING);
+            return NULL;
         }
+        plen = (int)octlen;
 #else
         plen = ASN1_STRING_length(oct);
 #endif

--- a/oqsprov/oqsprov_keys.c
+++ b/oqsprov/oqsprov_keys.c
@@ -38,6 +38,25 @@
 
 typedef enum { KEY_OP_PUBLIC, KEY_OP_PRIVATE, KEY_OP_KEYGEN } oqsx_key_op_t;
 
+#if OPENSSL_VERSION_PREREQ(4, 1)
+static int oqsx_legacy_asn1_string_length(const ASN1_STRING *str) {
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#elif defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable : 4996)
+#endif
+    int ret = ASN1_STRING_length(str);
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#elif defined(_MSC_VER)
+#pragma warning(pop)
+#endif
+    return ret;
+}
+#endif
+
 /// NID/name table
 
 typedef struct {
@@ -1030,13 +1049,17 @@ OQSX_KEY *oqsx_key_from_pkcs8(const PKCS8_PRIV_KEY_INFO *p8inf,
     } else {
         p = ASN1_STRING_get0_data(oct);
 #if OPENSSL_VERSION_PREREQ(4, 1)
-        octlen = ASN1_STRING_length_ex(oct);
-        if (octlen > INT_MAX) {
-            ASN1_OCTET_STRING_free(oct);
-            ERR_raise(ERR_LIB_USER, OQSPROV_R_INVALID_ENCODING);
-            return NULL;
+        if (OpenSSL_version_num() >= 0x40100000L) {
+            octlen = ASN1_STRING_length_ex(oct);
+            if (octlen > INT_MAX) {
+                ASN1_OCTET_STRING_free(oct);
+                ERR_raise(ERR_LIB_USER, OQSPROV_R_INVALID_ENCODING);
+                return NULL;
+            }
+            plen = (int)octlen;
+        } else {
+            plen = oqsx_legacy_asn1_string_length(oct);
         }
-        plen = (int)octlen;
 #else
         plen = ASN1_STRING_length(oct);
 #endif

--- a/oqsprov/oqsprov_keys.c
+++ b/oqsprov/oqsprov_keys.c
@@ -9,6 +9,7 @@
  */
 
 #include <assert.h>
+#include <limits.h>
 #include <openssl/core_names.h>
 #include <openssl/err.h>
 #include <openssl/evp.h>
@@ -1015,6 +1016,9 @@ OQSX_KEY *oqsx_key_from_pkcs8(const PKCS8_PRIV_KEY_INFO *p8inf,
     unsigned char *concat_key;
     const unsigned char *buf;
     int count, aux, i, buflen, key_diff = 0;
+#if OPENSSL_VERSION_PREREQ(4, 1)
+    size_t octlen;
+#endif
 
     if (!PKCS8_pkey_get0(NULL, &p, &plen, &palg, p8inf))
         return 0;
@@ -1025,7 +1029,17 @@ OQSX_KEY *oqsx_key_from_pkcs8(const PKCS8_PRIV_KEY_INFO *p8inf,
         plen = 0;
     } else {
         p = ASN1_STRING_get0_data(oct);
+#if OPENSSL_VERSION_PREREQ(4, 1)
+        octlen = ASN1_STRING_length_ex(oct);
+        if (octlen > INT_MAX) {
+            ASN1_OCTET_STRING_free(oct);
+            ERR_raise(ERR_LIB_USER, OQSPROV_R_INVALID_ENCODING);
+            return NULL;
+        }
+        plen = (int)octlen;
+#else
         plen = ASN1_STRING_length(oct);
+#endif
     }
 
     oqsx = oqsx_key_op(palg, p, plen + key_diff, KEY_OP_PRIVATE, libctx, propq);

--- a/oqsprov/oqsprov_keys.c
+++ b/oqsprov/oqsprov_keys.c
@@ -1016,7 +1016,7 @@ OQSX_KEY *oqsx_key_from_pkcs8(const PKCS8_PRIV_KEY_INFO *p8inf,
     unsigned char *concat_key;
     const unsigned char *buf;
     int count, aux, i, buflen, key_diff = 0;
-#if OPENSSL_VERSION_PREREQ(4, 1)
+#ifdef OQSPROV_HAVE_OPENSSL_4_1_ASN1_API
     size_t octlen;
 #endif
 
@@ -1029,7 +1029,7 @@ OQSX_KEY *oqsx_key_from_pkcs8(const PKCS8_PRIV_KEY_INFO *p8inf,
         plen = 0;
     } else {
         p = ASN1_STRING_get0_data(oct);
-#if OPENSSL_VERSION_PREREQ(4, 1)
+#ifdef OQSPROV_HAVE_OPENSSL_4_1_ASN1_API
         octlen = ASN1_STRING_length_ex(oct);
         if (octlen > INT_MAX) {
             ASN1_OCTET_STRING_free(oct);

--- a/oqsprov/oqsprov_keys.c
+++ b/oqsprov/oqsprov_keys.c
@@ -1016,7 +1016,8 @@ OQSX_KEY *oqsx_key_from_pkcs8(const PKCS8_PRIV_KEY_INFO *p8inf,
     unsigned char *concat_key;
     const unsigned char *buf;
     int count, aux, i, buflen, key_diff = 0;
-#ifdef OQSPROV_HAVE_OPENSSL_4_1_ASN1_API
+#if defined(OQSPROV_HAVE_ASN1_STRING_GET_LENGTH) ||                            \
+    defined(OQSPROV_HAVE_ASN1_STRING_LENGTH_EX)
     size_t octlen;
 #endif
 
@@ -1029,8 +1030,13 @@ OQSX_KEY *oqsx_key_from_pkcs8(const PKCS8_PRIV_KEY_INFO *p8inf,
         plen = 0;
     } else {
         p = ASN1_STRING_get0_data(oct);
-#ifdef OQSPROV_HAVE_OPENSSL_4_1_ASN1_API
+#ifdef OQSPROV_HAVE_ASN1_STRING_GET_LENGTH
+        octlen = ASN1_STRING_get_length(oct);
+#elif defined(OQSPROV_HAVE_ASN1_STRING_LENGTH_EX)
         octlen = ASN1_STRING_length_ex(oct);
+#endif
+#if defined(OQSPROV_HAVE_ASN1_STRING_GET_LENGTH) ||                            \
+    defined(OQSPROV_HAVE_ASN1_STRING_LENGTH_EX)
         if (octlen > INT_MAX) {
             ASN1_OCTET_STRING_free(oct);
             ERR_raise(ERR_LIB_USER, OQSPROV_R_INVALID_ENCODING);


### PR DESCRIPTION
## Summary

- I use the OpenSSL 4.1 `ASN1_STRING_length_ex()` and `ASN1_STRING_set_data()` APIs when they are available.
- I keep the existing ASN.1 APIs for earlier OpenSSL releases.
- I reject an ASN.1 length that cannot fit in the existing integer key-decoding path.

## Validation

- I built the provider with KEM encoders enabled and `-Werror=deprecated-declarations` against OpenSSL 3.5.6.
- I built the provider with the same options against OpenSSL 4.1.0-dev from the current OpenSSL `master` branch.
- I ran all 9 CTest tests successfully against both OpenSSL versions.
- I reran the focused `oqs_endecode` test successfully on the exact commit against both versions.
- I ran the changed-line clang-format check and `git diff --check`.

Fixes #804
