### PR TITLE
ci: install build-essential in standalone_linux_intel job

### DIFF
--- a/.github/workflows/standalone.yml
+++ b/.github/workflows/standalone.yml
@@ -49,7 +49,16 @@ jobs:
       MAKE_PARAMS: "-j 18"
     steps:
       - name: Update container
-        run: apt update && apt install -y cmake ninja-build gcc libssl-dev git
+        run: |
+          apt update
+          DEBIAN_FRONTEND=noninteractive apt install -y --no-install-recommends \
+            build-essential \
+            cmake \
+            ninja-build \
+            libssl-dev \
+            git \
+            pkg-config \
+            ca-certificates
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:


### PR DESCRIPTION
Add build-essential, pkg-config and ca-certificates to the apt install step so the C runtime startup objects (Scrt1.o, crti.o) are present and linking succeeds when building liboqs inside the ubuntu container (authored by Copilot)
