### PR TITLE
Fix heap buffer overflow in RSA-hybrid classical public key reconstruction (GHSA-2g5g-3c4v-v8pw)

### DIFF
--- a/oqsprov/oqsprov_keys.c
+++ b/oqsprov/oqsprov_keys.c
@@ -967,8 +967,22 @@ static int oqsx_key_recreate_classickey(OQSX_KEY *key, oqsx_key_op_t op) {
 #ifndef NOPUBKEY_IN_PRIVKEY
                 // re-create classic public key part from
                 // private key:
-                int pubkeylen = i2d_PublicKey(key->classical_pkey, &enc_pubkey);
+                // Query the encoded length before writing (mirroring the
+                // raw_key_support branch above), instead of writing first
+                // and checking the length afterwards: i2d_PublicKey() with
+                // a NULL output pointer only computes the size, it does not
+                // write. classical_privkey_len is bounded above, but its
+                // *content* is attacker-controlled and unconstrained, so an
+                // oversized reconstructed public key must be rejected
+                // before any write into the fixed-size destination buffer,
+                // not after.
+                int pubkeylen = i2d_PublicKey(key->classical_pkey, NULL);
                 if (pubkeylen != key->evp_info->length_public_key) {
+                    ERR_raise(ERR_LIB_USER, OQSPROV_R_INVALID_ENCODING);
+                    goto rec_err;
+                }
+                if (i2d_PublicKey(key->classical_pkey, &enc_pubkey) !=
+                    pubkeylen) {
                     ERR_raise(ERR_LIB_USER, OQSPROV_R_INVALID_ENCODING);
                     goto rec_err;
                 }


### PR DESCRIPTION
Fixes the heap buffer overflow reported in GHSA-2g5g-3c4v-v8pw (thank you for asking for a PR, @RodriM11!).

## Summary

For the RSA-hybrid signature algorithms (`rsa3072_falcon512`, `rsa3072_falconpadded512`, `rsa3072_mldsa44`), `oqsx_key_recreate_classickey()`'s RSA (non-`raw_key_support`) branch wrote the reconstructed classical public key via `i2d_PublicKey(key->classical_pkey, &enc_pubkey)` into the fixed-size `key->pubkey` buffer and checked the returned length only *after* the write. The classical private-key DER content decoded from an attacker-supplied PKCS#8 `PrivateKeyInfo` is length-gated only to `<= evp_info->length_private_key`; its *content* is unconstrained, so a private key carrying an oversized modulus makes `i2d_PublicKey()` serialize more bytes than the buffer holds -- a heap buffer overflow (CWE-787) whose overflow content is attacker-chosen.

## Fix

Mirrors the pattern already used a few lines above in the `raw_key_support` branch (`EVP_PKEY_get_raw_public_key` with a `NULL` output, size-checked before writing): query the length via `i2d_PublicKey(key->classical_pkey, NULL)` first (a `NULL` output pointer only computes the size, it does not write), reject if it doesn't match `evp_info->length_public_key`, and only then perform the write -- with a defensive re-check that the write's own return value still matches, since the buffer is only known-safe if both agree.

```diff
-                int pubkeylen = i2d_PublicKey(key->classical_pkey, &enc_pubkey);
+                int pubkeylen = i2d_PublicKey(key->classical_pkey, NULL);
                 if (pubkeylen != key->evp_info->length_public_key) {
                     ERR_raise(ERR_LIB_USER, OQSPROV_R_INVALID_ENCODING);
                     goto rec_err;
                 }
+                if (i2d_PublicKey(key->classical_pkey, &enc_pubkey) !=
+                    pubkeylen) {
+                    ERR_raise(ERR_LIB_USER, OQSPROV_R_INVALID_ENCODING);
+                    goto rec_err;
+                }
```

## Testing

- `./scripts/format_code.sh` (via local `clang-format --style="{BasedOnStyle: llvm, IndentWidth: 4}"`, same invocation as `do_code_format.sh`): clean, no violations.
- Verified against a standalone harness reproducing the exact call sequence with OpenSSL's public API directly (mirrors the two PoC inputs from the advisory):
  - `evil_rsa.der` (the 7-byte-overflow case from the advisory): before the fix, `i2d_PublicKey` wrote 1302 bytes into a 1295-byte region. After the fix, `i2d_PublicKey(pkey, NULL)` returns 1302, which doesn't match the expected 398, and the key is rejected *before* any write.
  - `evil_rsa_maxbudget.der` (the 454-byte-overflow / reproducible-crash case): same outcome, rejected before any write.
  - A freshly generated, legitimate RSA-3072 key: `i2d_PublicKey(pkey, NULL)` returns exactly 398 (== `evp_info->length_public_key` for `rsa3072_*`), matches, and the key is accepted and written safely -- confirming no false-positive rejection of legitimate keys.
- I ran `./scripts/fullbuild.sh` locally and it failed, but I misdiagnosed why in the first version of this description. A stale system-installed liboqs on my machine was shadowing the one the build script had just built; the freshly built liboqs does define the symbols I claimed were missing. My earlier claim that this might also affect liboqs or this repo's CI was wrong. The patched file compiles clean against the script's own liboqs (`clang -fsyntax-only`, no warnings). For end-to-end verification through the built provider, I'm relying on CI here.

This is a small, minimal-diff fix and I've kept it scoped to only the vulnerable branch; I did not touch the `raw_key_support` branch (already correct) or the encoding-direction `i2d_PublicKey`/`i2d_PrivateKey` calls elsewhere in this file (those operate on keys generated by this provider itself, not on attacker-controlled decoded DER, so they're a different code path from the one GHSA-2g5g-3c4v-v8pw concerns).
