### PR TITLE
Support out-of-source builds and tests in the convenience scripts

### DIFF
--- a/.github/workflows/standalone.yml
+++ b/.github/workflows/standalone.yml
@@ -67,3 +67,52 @@ jobs:
         run: LIBOQS_BRANCH=main ./scripts/fullbuild.sh
       - name: Test
         run: ./scripts/runtests.sh -V
+
+  # Ascertain that the convenience build and test scripts also work when the
+  # build and test target is not co-located with the source code, see
+  # https://github.com/open-quantum-safe/oqs-provider/issues/545
+  standalone_linux_intel_out_of_source:
+    needs: [coding_style_tests]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: ubuntu-latest
+            container: ubuntu@sha256:53958ec7b67c2c9355df922dd08dbf0360611f8c3cdb656875e81873db9ffdba
+    container:
+      image: ${{ matrix.container }}
+    env:
+      MAKE_PARAMS: "-j 18"
+    steps:
+      - name: Update container
+        run: |
+          apt update
+          DEBIAN_FRONTEND=noninteractive apt install -y --no-install-recommends \
+            build-essential \
+            cmake \
+            ninja-build \
+            libssl-dev \
+            git \
+            pkg-config \
+            ca-certificates
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          path: src
+          persist-credentials: false
+      - name: Full build outside the source tree
+        run: |
+          mkdir -p "$GITHUB_WORKSPACE/oos"
+          cd "$GITHUB_WORKSPACE/oos"
+          LIBOQS_BRANCH=main "$GITHUB_WORKSPACE/src/scripts/fullbuild.sh"
+      - name: Test outside the source tree
+        run: |
+          cd "$GITHUB_WORKSPACE/oos"
+          "$GITHUB_WORKSPACE/src/scripts/runtests.sh" -V
+      - name: Ensure the source tree was not written to
+        run: |
+          cd "$GITHUB_WORKSPACE/src"
+          git config --global --add safe.directory "$GITHUB_WORKSPACE/src"
+          git status --porcelain
+          test -z "$(git status --porcelain)"

--- a/CONFIGURE.md
+++ b/CONFIGURE.md
@@ -187,6 +187,31 @@ By default this variable is unset.
 
 This environment variable can be used to pass arguments to the `./config` command that precedes the `make` of the OpenSSL, e.g. to build in [debug](https://wiki.openssl.org/index.php/Compilation_and_Installation#Debug_Configuration).
 
+### OQS_PROVIDER_SRC_DIR
+
+Directory holding the `oqs-provider` sources to be built by `fullbuild.sh`.
+If this variable is not set, the parent directory of the `fullbuild.sh`
+script itself is used, so the sources are always found regardless of the
+directory the script is invoked from.
+
+### OQS_PROVIDER_BUILD_DIR
+
+Directory into which `fullbuild.sh` builds `oqs-provider` and in which
+`runtests.sh` expects the provider module and the `ctest` setup to be found.
+If this variable is not set, `_build` below the current directory is used.
+
+Together with [`OQS_PROVIDER_SRC_DIR`](#oqs_provider_src_dir) this permits
+building and testing "out of source", i.e., with the build and test target
+not co-located with the source code:
+
+    mkdir /tmp/oqsprovider-build && cd /tmp/oqsprovider-build
+    /path/to/oqs-provider/scripts/fullbuild.sh
+    /path/to/oqs-provider/scripts/runtests.sh
+
+*Note*: `fullbuild.sh` continues to place its `openssl`, `liboqs` and
+`.local` working directories below the current directory, so an out-of-source
+build leaves the source tree untouched.
+
 ## LIBOQS configuration options
 
 These are [documented in full here](https://github.com/open-quantum-safe/liboqs/wiki/Customizing-liboqs).

--- a/scripts/fullbuild.sh
+++ b/scripts/fullbuild.sh
@@ -13,6 +13,19 @@
 #        Setting this to feature/dtls-1.3 enables build&test of all PQ algs using DTLS1.3 feature branch
 # EnvVar OSSL_CONFIG: If set, passes arguments to the "./config" command that precedes the "make" of the OpenSSL
 # EnvVar liboqs_DIR: If set, needs to point to a directory where liboqs has been installed to
+# EnvVar OQS_PROVIDER_SRC_DIR: oqs-provider source directory; defaults to the directory containing this script's parent
+# EnvVar OQS_PROVIDER_BUILD_DIR: oqs-provider build directory; defaults to "_build" below the current directory
+
+# Both defaults below reproduce the historic behaviour when this script is run
+# as "./scripts/fullbuild.sh" from the source root; setting them (or just
+# running from elsewhere) permits building out of source:
+if [ -z "$OQS_PROVIDER_SRC_DIR" ]; then
+   export OQS_PROVIDER_SRC_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+fi
+
+if [ -z "$OQS_PROVIDER_BUILD_DIR" ]; then
+   export OQS_PROVIDER_BUILD_DIR=$(pwd)/_build
+fi
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
    SHLIBEXT="dylib"
@@ -24,10 +37,10 @@ fi
 
 if [ $# -gt 0 ]; then
    if [ "$1" == "-f" ]; then
-      rm -rf _build
+      rm -rf "$OQS_PROVIDER_BUILD_DIR"
    fi
    if [ "$1" == "-F" ]; then
-      rm -rf _build openssl liboqs .local
+      rm -rf "$OQS_PROVIDER_BUILD_DIR" openssl liboqs .local
    fi
 fi
 
@@ -128,16 +141,16 @@ if [ -z $liboqs_DIR ]; then
 fi
 
 # Check whether provider is built:
-if [ ! -f "_build/lib/oqsprovider.$SHLIBEXT" ]; then
-   echo "oqsprovider (_build/lib/oqsprovider.$SHLIBEXT) not built: Building..."
+if [ ! -f "$OQS_PROVIDER_BUILD_DIR/lib/oqsprovider.$SHLIBEXT" ]; then
+   echo "oqsprovider ($OQS_PROVIDER_BUILD_DIR/lib/oqsprovider.$SHLIBEXT) not built: Building..."
    # for full debug build add: -DCMAKE_BUILD_TYPE=Debug
    #BUILD_TYPE="-DCMAKE_BUILD_TYPE=Debug"
    BUILD_TYPE=""
    # for omitting public key in private keys add -DNOPUBKEY_IN_PRIVKEY=ON
    if [ -z "$OPENSSL_INSTALL" ]; then
-       cmake $CMAKE_PARAMS $CMAKE_OPENSSL_LOCATION $BUILD_TYPE $OQSPROV_CMAKE_PARAMS -S . -B _build && cmake --build _build
+       cmake $CMAKE_PARAMS $CMAKE_OPENSSL_LOCATION $BUILD_TYPE $OQSPROV_CMAKE_PARAMS -S "$OQS_PROVIDER_SRC_DIR" -B "$OQS_PROVIDER_BUILD_DIR" && cmake --build "$OQS_PROVIDER_BUILD_DIR"
    else
-       cmake $CMAKE_PARAMS -DOPENSSL_ROOT_DIR=$OPENSSL_INSTALL $BUILD_TYPE $OQSPROV_CMAKE_PARAMS -S . -B _build && cmake --build _build
+       cmake $CMAKE_PARAMS -DOPENSSL_ROOT_DIR=$OPENSSL_INSTALL $BUILD_TYPE $OQSPROV_CMAKE_PARAMS -S "$OQS_PROVIDER_SRC_DIR" -B "$OQS_PROVIDER_BUILD_DIR" && cmake --build "$OQS_PROVIDER_BUILD_DIR"
    fi
    if [ $? -ne 0 ]; then
      echo "provider build failed. Exiting."

--- a/scripts/runtests.sh
+++ b/scripts/runtests.sh
@@ -56,8 +56,19 @@ interop() {
     fi
 }
 
+# Locate this script such that the helper scripts and the OpenSSL config
+# shipped alongside it are found also when testing out of source, i.e., when
+# the current directory is not the source root:
+OQS_PROVIDER_SCRIPTDIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+
+# Build directory holding the provider module and the ctest setup; defaults to
+# "_build" below the current directory as created by "fullbuild.sh":
+if [ -z "${OQS_PROVIDER_BUILD_DIR}" ]; then
+    export OQS_PROVIDER_BUILD_DIR="$(pwd)/_build"
+fi
+
 if [ -z "${OQS_PROVIDER_TESTSCRIPTS}" ]; then
-    export OQS_PROVIDER_TESTSCRIPTS="$(pwd)/scripts"
+    export OQS_PROVIDER_TESTSCRIPTS="${OQS_PROVIDER_SCRIPTDIR}"
 fi
 
 if [ -n "${OPENSSL_INSTALL}" ]; then
@@ -78,7 +89,7 @@ if [ -n "${OPENSSL_INSTALL}" ]; then
 fi
 
 if [ -z "${OPENSSL_CONF}" ]; then
-    export OPENSSL_CONF="$(pwd)/scripts/openssl-ca.cnf"
+    export OPENSSL_CONF="${OQS_PROVIDER_SCRIPTDIR}/openssl-ca.cnf"
 fi
 
 if [ -z "${OPENSSL_APP}" ]; then
@@ -90,7 +101,7 @@ if [ -z "${OPENSSL_APP}" ]; then
 fi
 
 if [ -z "${OPENSSL_MODULES}" ]; then
-    export OPENSSL_MODULES="$(pwd)/_build/lib"
+    export OPENSSL_MODULES="${OQS_PROVIDER_BUILD_DIR}/lib"
 fi
 
 if [ -z "${LD_LIBRARY_PATH}" ]; then
@@ -192,7 +203,7 @@ ${OQS_PROVIDER_TESTSCRIPTS}/oqsprovider-externalinterop.sh
 # Without removing OPENSSL_CONF ctest hangs... ???
 unset OPENSSL_CONF
 rv=0
-if ! ( cd _build && ctest $@ ); then
+if ! ( cd "${OQS_PROVIDER_BUILD_DIR}" && ctest $@ ); then
    rv=1
 fi
 


### PR DESCRIPTION
Fixes #545.

Follow-up to my [design proposal on the issue](https://github.com/open-quantum-safe/oqs-provider/issues/545#issuecomment-5269204105). The two questions I raised there (variable naming, and on-push vs. weekly for the new job) are still open — I have picked one answer for each to have something concrete to review, and both are trivial to change if you prefer otherwise.

## Problem

`cmake` and `ctest` are already fine out of source. The two convenience shell drivers are not: both assume the current working directory *is* the source root, so neither can be used when the build and test target is not co-located with the source code.

## Root cause

**`scripts/fullbuild.sh:138` and `:140`** — `-S .` resolves to the *caller's* working directory, not the source tree:

```
cmake $CMAKE_PARAMS $CMAKE_OPENSSL_LOCATION $BUILD_TYPE $OQSPROV_CMAKE_PARAMS -S . -B _build && cmake --build _build
```

(also the `-f "_build/lib/oqsprovider.$SHLIBEXT"` guard at `:131` and the `rm -rf _build` at `:27`/`:30`.) Note `fullbuild.sh:121` also uses `-S .` for liboqs, but that one is correct — it is preceded by `cd liboqs`, so it is left alone.

**`scripts/runtests.sh`** derives four things from `$(pwd)`:

| line | expression |
|---|---|
| `:60` | `export OQS_PROVIDER_TESTSCRIPTS="$(pwd)/scripts"` |
| `:81` | `export OPENSSL_CONF="$(pwd)/scripts/openssl-ca.cnf"` |
| `:93` | `export OPENSSL_MODULES="$(pwd)/_build/lib"` |
| `:195` | `if ! ( cd _build && ctest $@ ); then` |

For the first three the correct source is the script's own location; for the build directory it needs to be an explicit, overridable variable.

## Reproduction (before)

All against `main` @ `7e70df2`, using a pristine `git archive HEAD` export as the source so the baseline provably contains none of my changes:

```
$ grep -rn "OQS_PROVIDER_BUILD_DIR\|OQS_PROVIDER_SRC_DIR\|OQS_PROVIDER_SCRIPTDIR" <src-baseline>/scripts | wc -l
       0
```

**1. `fullbuild.sh` cannot build out of source**

```
$ mkdir <scratch>/oos-a && cd <scratch>/oos-a
$ liboqs_DIR=/opt/homebrew <src-baseline>/scripts/fullbuild.sh
oqsprovider (_build/lib/oqsprovider.dylib) not built: Building...
CMake Error: The source directory "<scratch>/oos-a" does not appear to contain CMakeLists.txt.
Specify --help for usage, or press the help button on the CMake GUI.
provider build failed. Exiting.
$ echo $?
255
$ ls -a <scratch>/oos-a
.  ..                     <-- nothing produced
```

**2a. `runtests.sh` synthesises `OPENSSL_CONF` from the wrong tree**

(build directory `<scratch>/oos-b` configured and built successfully with plain `cmake -S <src-baseline> -B <scratch>/oos-b`; `ctest` there is already 9/9 green)

```
$ cd <scratch>/oos-b
$ OPENSSL_MODULES=$PWD/lib <src-baseline>/scripts/runtests.sh
Test setup:
OPENSSL_CONF=<scratch>/oos-b/scripts/openssl-ca.cnf      <-- does not exist
OPENSSL_MODULES=<scratch>/oos-b/lib
Providers:
  default
    name: OpenSSL Default Provider
oqsprovider not registered. Exit test.
$ echo $?
1
```

**2b. with `OPENSSL_CONF` corrected by hand, the helper scripts are still resolved from `$(pwd)`**

```
$ OPENSSL_CONF=<src-baseline>/scripts/openssl-ca.cnf <src-baseline>/scripts/runtests.sh
Cert gen/verify, CMS sign/verify, CA tests for all enabled OQS signature algorithms commencing:
.localalgtest p256_mldsa44 failed. Exiting..
<src-baseline>/scripts/runtests.sh: line 20: <scratch>/oos-b/scripts/oqsprovider-certgen.sh: No such file or directory
$ echo $?
1
```

## Fix

- `runtests.sh` learns `OQS_PROVIDER_SCRIPTDIR` (from `$0`) and uses it for the `OQS_PROVIDER_TESTSCRIPTS` and `OPENSSL_CONF` defaults.
- New `OQS_PROVIDER_BUILD_DIR` (default `$(pwd)/_build`) drives the `OPENSSL_MODULES` default and the final `cd … && ctest`, in both scripts.
- `fullbuild.sh` learns `OQS_PROVIDER_SRC_DIR` (default: the script's parent directory) for `-S`.
- Both documented in `CONFIGURE.md` under "Convenience build script options".
- One new `standalone.yml` job that builds and tests entirely from a directory outside the checkout — the actual ask of #545 — plus a final step asserting the source tree was not written to.

**Every default collapses to today's literal value when the scripts are invoked as `./scripts/…` from the source root**, which is how all existing call sites (`linux.yml` ×4, `standalone.yml`, `release-test-ci.sh`) invoke them.

## After — same commands, same machine

```
$ mkdir <scratch>/oos-fixed && cd <scratch>/oos-fixed
$ liboqs_DIR=/opt/homebrew <src-fixed>/scripts/fullbuild.sh ; echo $?
[100%] Built target oqs_test_alg_overlap
0
$ ls <scratch>/oos-fixed/_build/lib
oqsprovider.dylib

$ <src-fixed>/scripts/runtests.sh ; echo $?
Test setup:
OPENSSL_CONF=<src-fixed>/scripts/openssl-ca.cnf            <-- now the source tree
OPENSSL_MODULES=<scratch>/oos-fixed/_build/lib             <-- now the build tree
...
100% tests passed out of 9
All oqsprovider tests passed.
0
```

And the source tree is untouched by that run — `_build`, `tmp`, `interop.log`, `.local`, `liboqs`, `openssl` are all absent from `<src-fixed>` and all present under `<scratch>/oos-fixed`.

## Backwards compatibility

This is the load-bearing check, since all existing call sites are in-source. The `Test setup:` block printed by `runtests.sh` is **byte-identical** before and after the change when run in source (only the export directory name normalised):

```
$ diff <(sed -n '1,6p' base_insource_tests.log | sed 's/src-baseline/SRCTREE/g') \
       <(sed -n '1,6p' fixed_insource_tests.log | sed 's/src-fixed/SRCTREE/g') \
  && echo IDENTICAL
IDENTICAL
```

| run | result |
|---|---|
| baseline in-source `./scripts/fullbuild.sh` + `./scripts/runtests.sh` | exit 0, 9/9, 47 algorithms |
| patched in-source, same commands | exit 0, 9/9, 47 algorithms |
| patched in-source `./scripts/fullbuild.sh -f` (soft clean, as `linux.yml:94`) | exit 0, rebuilt |

Algorithm coverage is identical between the baseline in-source run and the patched out-of-source run — the sorted list of `Testing <alg>` lines diffs clean at 47 entries each.

## Everything I ran

Environment: macOS 26.6 / arm64, Apple clang 17.0.0, CMake 4.4.2, Ninja, OpenSSL 3.6.3 (`brew openssl@3`), liboqs 0.16.0 (brew) and liboqs `main` built from source.

| check | result |
|---|---|
| baseline out-of-source `fullbuild.sh` | **exit 255**, nothing built |
| baseline out-of-source `runtests.sh` | **exit 1**, "oqsprovider not registered" |
| baseline out-of-source `runtests.sh`, `OPENSSL_CONF` fixed by hand | **exit 1**, certgen not found |
| baseline in-source `runtests.sh` | exit 0, 9/9 — **no pre-existing failures on this machine** |
| patched out-of-source `fullbuild.sh` + `runtests.sh` | exit 0, 9/9 |
| patched out-of-source `runtests.sh -V` (as the new CI job runs it) | exit 0, 9/9, 47 algs |
| patched out-of-source with liboqs cloned+built from source (`LIBOQS_BRANCH=main`, i.e. the CI path) | exit 0, 9/9 |
| patched, source + build dir + cwd all three in different places via `OQS_PROVIDER_BUILD_DIR` | exit 0, 9/9 |
| patched `runtests.sh` under `dash` (strict POSIX, no bashisms) | exit 0, 9/9 |
| patched in-source `runtests.sh` | exit 0, 9/9 |
| `actionlint -shellcheck ""` (v1.7.12, exactly as `check_workflows.yml` runs it) | exit 0, no findings |
| `zizmor` v1.0.0 `--persona=regular` | "No findings to report." |

## What I could NOT verify

- **The new CI job has not been observed running.** I cannot execute a GitHub-hosted Ubuntu container job locally, and I did not get `act` working. It is a near-copy of the existing `standalone_linux_intel` job (same image digest, same package list) with the working directory moved, and I did reproduce its exact sequence locally on macOS including the from-source liboqs build — but I am not claiming a green CI run I did not see. The run on this PR is the first real execution.
- **All local evidence is macOS/arm64.** I did not reproduce on Linux locally. The defect is pure shell path logic, but I would rather state the environment than imply broader coverage.
- **Windows is untested.** `NOTES-Windows.md` drives cmake directly and the MSVC CI does not use these scripts, so I believe there is no exposure, but I have not run it.

## Observations, deliberately left out of this diff

1. `fullbuild.sh` still places its `openssl/`, `liboqs/` and `.local/` working directories below `$(pwd)`, and `runtests.sh` still writes `tmp/` and `interop.log` there. That is *correct* for out-of-source use (it is what keeps the source tree clean) so I left it as is.
2. `fullbuild.sh:93-97` tests `-f oqs-template/generate.yml-$LIBOQS_BRANCH` relative to `$(pwd)`, but `oqs-template/` lives in the source tree. Out of source with a non-`main` `LIBOQS_BRANCH` this silently skips the backwards-compatibility code generation rather than failing. It needs `$OQS_PROVIDER_SRC_DIR` too, but the fix also raises the question of where the generator should write its output, and I could not test that path — so I am flagging it rather than guessing. Happy to do it here or in a follow-up.
3. `runtests.sh:195` passes `$@` unquoted to `ctest`. Pre-existing, unrelated, untouched.

## On CI cost

@baentsch, mindful of the [CI usage guidelines](https://github.com/open-quantum-safe/tsc/blob/main/guidelines/ci_usage.md) you pointed at in #807 ("While coverage is good, it shouldn't get in the way of quick dev turnarounds"): this adds roughly one `standalone_linux_intel`-sized job per push. I am glad to move it to a weekly `schedule:` trigger, or to add the liboqs caching you suggested there, instead. Say which and I will change it.
