### PR TITLE
Reject inconsistent classical lengths in hybrid KEM public keys

### DIFF
--- a/oqsprov/oqsprov_keys.c
+++ b/oqsprov/oqsprov_keys.c
@@ -777,9 +777,21 @@ static OQSX_KEY *oqsx_key_op(const X509_ALGOR *palg, const unsigned char *p,
     OQS_KEY_PRINTF2("OQSX KEY: Recreated OQSX key %s\n", key->tls_name);
 
     if (op == KEY_OP_PUBLIC) {
+        uint32_t classical_pubkey_len = 0;
+        int classic_lengths_fixed = key->keytype == KEY_TYPE_ECP_HYB_KEM ||
+                                    key->keytype == KEY_TYPE_ECBP_HYB_KEM ||
+                                    key->keytype == KEY_TYPE_ECX_HYB_KEM;
+
         if (key->pubkeylen != plen) {
             ERR_raise(ERR_LIB_USER, OQSPROV_R_INVALID_ENCODING);
             goto err_key_op;
+        }
+        if (classic_lengths_fixed) {
+            DECODE_UINT32(classical_pubkey_len, p);
+            if (classical_pubkey_len != key->evp_info->length_public_key) {
+                ERR_raise(ERR_LIB_USER, OQSPROV_R_INVALID_ENCODING);
+                goto err_key_op;
+            }
         }
         if (oqsx_key_allocate_keymaterial(key, 0)) {
             ERR_raise(ERR_LIB_USER, ERR_R_MALLOC_FAILURE);
@@ -1362,6 +1374,8 @@ int oqsx_key_fromdata(OQSX_KEY *key, const OSSL_PARAM params[],
         memcpy(key->privkey, pp1->data, pp1->data_size);
     }
     if (pp2 != NULL) {
+        uint32_t classical_pubkey_len = 0;
+
         if (pp2->data_type != OSSL_PARAM_OCTET_STRING) {
             OQS_KEY_PRINTF("invalid data type\n");
             return 0;
@@ -1369,6 +1383,13 @@ int oqsx_key_fromdata(OQSX_KEY *key, const OSSL_PARAM params[],
         if (key->pubkeylen != pp2->data_size) {
             ERR_raise(ERR_LIB_USER, OQSPROV_R_INVALID_SIZE);
             return 0;
+        }
+        if (classic_lengths_fixed) {
+            DECODE_UINT32(classical_pubkey_len, pp2->data);
+            if (classical_pubkey_len != key->evp_info->length_public_key) {
+                ERR_raise(ERR_LIB_USER, OQSPROV_R_INVALID_ENCODING);
+                return 0;
+            }
         }
         OPENSSL_secure_clear_free(key->pubkey, pp2->data_size);
         key->pubkey = OPENSSL_secure_malloc(pp2->data_size);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -125,6 +125,7 @@ add_executable(oqs_test_tlssig oqs_test_tlssig.c test_common.c tlstest_helpers.c
 target_link_libraries(oqs_test_tlssig PRIVATE OQS::oqs ${OPENSSL_SSL_LIBRARY} ${OPENSSL_CRYPTO_LIBRARY} ${OQS_ADDL_SOCKET_LIBS} ${REQ_LIBS_T})
 
 add_executable(oqs_test_endecode oqs_test_endecode.c test_common.c)
+target_include_directories(oqs_test_endecode PRIVATE "../oqsprov")
 target_link_libraries(oqs_test_endecode PRIVATE OQS::oqs ${OPENSSL_CRYPTO_LIBRARY} ${OQS_ADDL_SOCKET_LIBS} ${REQ_LIBS_T})
 add_test(
   NAME oqs_endecode

--- a/test/oqs_test_endecode.c
+++ b/test/oqs_test_endecode.c
@@ -201,7 +201,6 @@ enum hybrid_length_test_result {
     HYBRID_LENGTH_TEST_PASSED = 1,
     HYBRID_LENGTH_TEST_SKIP_DISABLED = -1,
     HYBRID_LENGTH_TEST_SKIP_NO_CLASSICAL = -2,
-    HYBRID_LENGTH_TEST_SKIP_NON_SEC1 = -3,
 };
 
 static int get_optional_octet_string_param(const EVP_PKEY *key,
@@ -227,26 +226,6 @@ static int get_optional_octet_string_param(const EVP_PKEY *key,
         return -1;
     }
     return 1;
-}
-
-static int is_uncompressed_sec1_public_key(const unsigned char *public_key,
-                                           size_t public_key_len) {
-    /* SEC1 encodes an uncompressed point as 0x04 || X || Y. */
-    return public_key_len >= 3 && public_key[0] == 0x04 &&
-           (public_key_len - 1) % 2 == 0;
-}
-
-static int test_uncompressed_sec1_public_key_selector(void) {
-    unsigned char sec1_public_key[65] = {0x04};
-    unsigned char ecx_public_key[32] = {0x04};
-    unsigned char compressed_sec1_public_key[33] = {0x02};
-
-    return is_uncompressed_sec1_public_key(sec1_public_key,
-                                           sizeof(sec1_public_key)) &&
-           !is_uncompressed_sec1_public_key(ecx_public_key,
-                                            sizeof(ecx_public_key)) &&
-           !is_uncompressed_sec1_public_key(compressed_sec1_public_key,
-                                            sizeof(compressed_sec1_public_key));
 }
 
 static unsigned char *locate_classical_public_key(
@@ -358,11 +337,6 @@ test_hybrid_kem_rejects_invalid_classical_length(const char *alg_name) {
     }
     if (param_status < 0)
         goto end;
-    if (!is_uncompressed_sec1_public_key(classical_public_key,
-                                         classical_public_key_len)) {
-        result = HYBRID_LENGTH_TEST_SKIP_NON_SEC1;
-        goto end;
-    }
     if (get_optional_octet_string_param(key, OQS_HYBRID_PKEY_PARAM_PQ_PUB_KEY,
                                         &pq_public_key,
                                         &pq_public_key_len) != 1)
@@ -437,14 +411,8 @@ end:
 
 static int
 test_hybrid_kems_reject_invalid_classical_lengths(const OSSL_ALGORITHM *algs) {
-    int discovered = 0, disabled = 0, no_classical = 0, non_sec1 = 0;
+    int discovered = 0, disabled = 0, no_classical = 0;
     int errcnt = 0, tested = 0, spki_tested = 0;
-
-    if (!test_uncompressed_sec1_public_key_selector()) {
-        fprintf(stderr,
-                cRED "  Invalid SEC1 public-key selector controls" cNORM "\n");
-        errcnt++;
-    }
 
     for (; algs->algorithm_names != NULL; algs++) {
         int has_spki = OBJ_sn2nid(algs->algorithm_names) != NID_undef;
@@ -465,9 +433,6 @@ test_hybrid_kems_reject_invalid_classical_lengths(const OSSL_ALGORITHM *algs) {
         case HYBRID_LENGTH_TEST_SKIP_NO_CLASSICAL:
             no_classical++;
             break;
-        case HYBRID_LENGTH_TEST_SKIP_NON_SEC1:
-            non_sec1++;
-            break;
         default:
             fprintf(stderr,
                     cRED "  Invalid classical length test failed: %s" cNORM
@@ -479,13 +444,10 @@ test_hybrid_kems_reject_invalid_classical_lengths(const OSSL_ALGORITHM *algs) {
         }
     }
     fprintf(stderr,
-            cBLUE
-            "  Invalid classical length coverage: discovered=%d, "
-            "tested=%d, spki=%d, skipped_disabled=%d, "
-            "skipped_no_classical=%d, skipped_non_sec1=%d, failed=%d" cNORM
-            "\n",
-            discovered, tested, spki_tested, disabled, no_classical, non_sec1,
-            errcnt);
+            cBLUE "  Invalid classical length coverage: discovered=%d, "
+                  "tested=%d, spki=%d, skipped_disabled=%d, "
+                  "skipped_no_classical=%d, failed=%d" cNORM "\n",
+            discovered, tested, spki_tested, disabled, no_classical, errcnt);
     if (tested == 0) {
         fprintf(stderr, cRED
                 "  No hybrid KEM with a supported EC key found" cNORM "\n");

--- a/test/oqs_test_endecode.c
+++ b/test/oqs_test_endecode.c
@@ -8,9 +8,11 @@
 #include <openssl/pem.h>
 #include <openssl/provider.h>
 #include <openssl/trace.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include "oqs/oqs.h"
+#include "oqs_prov.h"
 #include "test_common.h"
 
 static OSSL_LIB_CTX *libctx = NULL;
@@ -205,56 +207,116 @@ static int import_hybrid_key(const char *alg_name, int selection,
     return ok;
 }
 
-static int test_hybrid_kem_rejects_invalid_classical_length(void) {
-    const char *alg_name = "p256_mlkem512";
+static int get_classical_public_key(const EVP_PKEY *key,
+                                    unsigned char **classical_public_key,
+                                    size_t *classical_public_key_len) {
+    *classical_public_key = NULL;
+    *classical_public_key_len = 0;
+
+    if (EVP_PKEY_get_octet_string_param(
+            key, OQS_HYBRID_PKEY_PARAM_CLASSICAL_PUB_KEY, NULL, 0,
+            classical_public_key_len) != 1 ||
+        *classical_public_key_len == 0) {
+        ERR_clear_error();
+        return 0;
+    }
+    *classical_public_key = malloc(*classical_public_key_len);
+    if (*classical_public_key == NULL)
+        return -1;
+    if (EVP_PKEY_get_octet_string_param(
+            key, OQS_HYBRID_PKEY_PARAM_CLASSICAL_PUB_KEY, *classical_public_key,
+            *classical_public_key_len, classical_public_key_len) != 1) {
+        free(*classical_public_key);
+        *classical_public_key = NULL;
+        return -1;
+    }
+    return 1;
+}
+
+static int
+test_hybrid_kem_rejects_invalid_classical_length(const char *alg_name) {
     EVP_PKEY *key = NULL, *decoded = NULL;
     BUF_MEM *spki = NULL;
-    unsigned char *public_key = NULL, *private_key = NULL, *embedded = NULL;
+    unsigned char *public_key = NULL, *private_key = NULL;
+    unsigned char *classical_public_key = NULL, *classical_in_public = NULL;
+    unsigned char *embedded = NULL, *classical_in_spki = NULL;
     size_t public_key_len = 0, private_key_len = 0;
+    size_t classical_public_key_len = 0;
+    int classical_key_status;
     int ok = 0;
 
     if (!alg_is_enabled(alg_name))
-        return 1;
+        return -1;
     key = oqstest_make_key(alg_name, NULL, NULL);
-    if (key == NULL ||
-        get_param_octet_string(key, OSSL_PKEY_PARAM_PUB_KEY, &public_key,
+    if (key == NULL)
+        goto end;
+
+    classical_key_status = get_classical_public_key(key, &classical_public_key,
+                                                    &classical_public_key_len);
+    if (classical_key_status == 0) {
+        ok = -1;
+        goto end;
+    }
+    if (classical_key_status < 0)
+        goto end;
+    if (classical_public_key_len < 2 || classical_public_key[0] != 0x04) {
+        ok = -1;
+        goto end;
+    }
+    if (get_param_octet_string(key, OSSL_PKEY_PARAM_PUB_KEY, &public_key,
                                &public_key_len) != 0 ||
         get_param_octet_string(key, OSSL_PKEY_PARAM_PRIV_KEY, &private_key,
                                &private_key_len) != 0)
         goto end;
 
+    classical_in_public =
+        public_key_len > 4
+            ? find_bytes(public_key + 4, public_key_len - 4,
+                         classical_public_key, classical_public_key_len)
+            : NULL;
+    if (classical_in_public == NULL)
+        goto end;
+
     if (!import_hybrid_key(alg_name, EVP_PKEY_PUBLIC_KEY, public_key,
                            public_key_len, NULL, 0) ||
         !import_hybrid_key(alg_name, EVP_PKEY_KEYPAIR, public_key,
-                           public_key_len, private_key, private_key_len) ||
-        !encode_EVP_PKEY_prov(key, "DER", "SubjectPublicKeyInfo", NULL,
-                              EVP_PKEY_PUBLIC_KEY, &spki) ||
-        !decode_EVP_PKEY_prov("DER", "SubjectPublicKeyInfo", NULL, alg_name,
-                              EVP_PKEY_PUBLIC_KEY, &decoded, spki->data,
-                              spki->length))
+                           public_key_len, private_key, private_key_len))
         goto end;
-    EVP_PKEY_free(decoded);
-    decoded = NULL;
 
-    embedded = find_bytes((unsigned char *)spki->data, spki->length, public_key,
-                          public_key_len);
-    if (embedded == NULL || public_key_len < 5)
-        goto end;
+    if (OBJ_sn2nid(alg_name) != NID_undef) {
+        if (!encode_EVP_PKEY_prov(key, "DER", "SubjectPublicKeyInfo", NULL,
+                                  EVP_PKEY_PUBLIC_KEY, &spki) ||
+            !decode_EVP_PKEY_prov("DER", "SubjectPublicKeyInfo", NULL, alg_name,
+                                  EVP_PKEY_PUBLIC_KEY, &decoded, spki->data,
+                                  spki->length))
+            goto end;
+        EVP_PKEY_free(decoded);
+        decoded = NULL;
+
+        embedded = find_bytes((unsigned char *)spki->data, spki->length,
+                              public_key, public_key_len);
+        if (embedded == NULL)
+            goto end;
+        classical_in_spki = embedded + (classical_in_public - public_key);
+    }
 
     public_key[0] = public_key[1] = public_key[2] = 0;
     public_key[3] = 1;
-    public_key[4] = 0;
-    embedded[0] = embedded[1] = embedded[2] = 0;
-    embedded[3] = 1;
-    embedded[4] = 0;
+    classical_in_public[0] = 0;
+    if (embedded != NULL) {
+        embedded[0] = embedded[1] = embedded[2] = 0;
+        embedded[3] = 1;
+        classical_in_spki[0] = 0;
+    }
 
     if (import_hybrid_key(alg_name, EVP_PKEY_PUBLIC_KEY, public_key,
                           public_key_len, NULL, 0) ||
         import_hybrid_key(alg_name, EVP_PKEY_KEYPAIR, public_key,
                           public_key_len, private_key, private_key_len) ||
-        decode_EVP_PKEY_prov("DER", "SubjectPublicKeyInfo", NULL, alg_name,
-                             EVP_PKEY_PUBLIC_KEY, &decoded, spki->data,
-                             spki->length))
+        (spki != NULL &&
+         decode_EVP_PKEY_prov("DER", "SubjectPublicKeyInfo", NULL, alg_name,
+                              EVP_PKEY_PUBLIC_KEY, &decoded, spki->data,
+                              spki->length)))
         goto end;
 
     ERR_clear_error();
@@ -266,7 +328,41 @@ end:
     BUF_MEM_free(spki);
     free(public_key);
     free(private_key);
+    free(classical_public_key);
     return ok;
+}
+
+static int
+test_hybrid_kems_reject_invalid_classical_lengths(const OSSL_ALGORITHM *algs) {
+    int errcnt = 0, tested = 0;
+
+    for (; algs->algorithm_names != NULL; algs++) {
+        switch (test_hybrid_kem_rejects_invalid_classical_length(
+            algs->algorithm_names)) {
+        case 1:
+            fprintf(stderr,
+                    cGREEN "  Invalid classical length rejected: %s" cNORM "\n",
+                    algs->algorithm_names);
+            tested++;
+            break;
+        case -1:
+            break;
+        default:
+            fprintf(stderr,
+                    cRED "  Invalid classical length test failed: %s" cNORM
+                         "\n",
+                    algs->algorithm_names);
+            ERR_print_errors_fp(stderr);
+            errcnt++;
+            break;
+        }
+    }
+    if (tested == 0) {
+        fprintf(stderr, cRED
+                "  No hybrid KEM with a supported EC key found" cNORM "\n");
+        errcnt++;
+    }
+    return errcnt;
 }
 #endif
 
@@ -391,13 +487,7 @@ int main(int argc, char *argv[]) {
         errcnt++;
     }
 
-    if (!test_hybrid_kem_rejects_invalid_classical_length()) {
-        fprintf(stderr,
-                cRED "  Invalid hybrid KEM classical length was accepted" cNORM
-                     "\n");
-        ERR_print_errors_fp(stderr);
-        errcnt++;
-    }
+    errcnt += test_hybrid_kems_reject_invalid_classical_lengths(algs);
 #endif /* OQS_KEM_ENCODERS */
 
     OSSL_PROVIDER_unload(dfltprov);

--- a/test/oqs_test_endecode.c
+++ b/test/oqs_test_endecode.c
@@ -163,6 +163,113 @@ end:
     return ok;
 }
 
+#ifdef OQS_KEM_ENCODERS
+static unsigned char *find_bytes(unsigned char *haystack, size_t haystack_len,
+                                 const unsigned char *needle,
+                                 size_t needle_len) {
+    size_t i;
+
+    if (needle_len == 0 || haystack_len < needle_len)
+        return NULL;
+    for (i = 0; i <= haystack_len - needle_len; i++) {
+        if (memcmp(haystack + i, needle, needle_len) == 0)
+            return haystack + i;
+    }
+    return NULL;
+}
+
+static int import_hybrid_key(const char *alg_name, int selection,
+                             unsigned char *public_key, size_t public_key_len,
+                             unsigned char *private_key,
+                             size_t private_key_len) {
+    EVP_PKEY_CTX *ctx = NULL;
+    EVP_PKEY *key = NULL;
+    OSSL_PARAM params[3];
+    int ok = 0;
+
+    params[0] = OSSL_PARAM_construct_octet_string(OSSL_PKEY_PARAM_PUB_KEY,
+                                                  public_key, public_key_len);
+    if (selection == EVP_PKEY_KEYPAIR) {
+        params[1] = OSSL_PARAM_construct_octet_string(
+            OSSL_PKEY_PARAM_PRIV_KEY, private_key, private_key_len);
+        params[2] = OSSL_PARAM_construct_end();
+    } else {
+        params[1] = OSSL_PARAM_construct_end();
+    }
+
+    ctx = EVP_PKEY_CTX_new_from_name(keyctx, alg_name, OQSPROV_PROPQ);
+    ok = ctx != NULL && EVP_PKEY_fromdata_init(ctx) == 1 &&
+         EVP_PKEY_fromdata(ctx, &key, selection, params) == 1;
+    EVP_PKEY_free(key);
+    EVP_PKEY_CTX_free(ctx);
+    return ok;
+}
+
+static int test_hybrid_kem_rejects_invalid_classical_length(void) {
+    const char *alg_name = "p256_mlkem512";
+    EVP_PKEY *key = NULL, *decoded = NULL;
+    BUF_MEM *spki = NULL;
+    unsigned char *public_key = NULL, *private_key = NULL, *embedded = NULL;
+    size_t public_key_len = 0, private_key_len = 0;
+    int ok = 0;
+
+    if (!alg_is_enabled(alg_name))
+        return 1;
+    key = oqstest_make_key(alg_name, NULL, NULL);
+    if (key == NULL ||
+        get_param_octet_string(key, OSSL_PKEY_PARAM_PUB_KEY, &public_key,
+                               &public_key_len) != 0 ||
+        get_param_octet_string(key, OSSL_PKEY_PARAM_PRIV_KEY, &private_key,
+                               &private_key_len) != 0)
+        goto end;
+
+    if (!import_hybrid_key(alg_name, EVP_PKEY_PUBLIC_KEY, public_key,
+                           public_key_len, NULL, 0) ||
+        !import_hybrid_key(alg_name, EVP_PKEY_KEYPAIR, public_key,
+                           public_key_len, private_key, private_key_len) ||
+        !encode_EVP_PKEY_prov(key, "DER", "SubjectPublicKeyInfo", NULL,
+                              EVP_PKEY_PUBLIC_KEY, &spki) ||
+        !decode_EVP_PKEY_prov("DER", "SubjectPublicKeyInfo", NULL, alg_name,
+                              EVP_PKEY_PUBLIC_KEY, &decoded, spki->data,
+                              spki->length))
+        goto end;
+    EVP_PKEY_free(decoded);
+    decoded = NULL;
+
+    embedded = find_bytes((unsigned char *)spki->data, spki->length, public_key,
+                          public_key_len);
+    if (embedded == NULL || public_key_len < 5)
+        goto end;
+
+    public_key[0] = public_key[1] = public_key[2] = 0;
+    public_key[3] = 1;
+    public_key[4] = 0;
+    embedded[0] = embedded[1] = embedded[2] = 0;
+    embedded[3] = 1;
+    embedded[4] = 0;
+
+    if (import_hybrid_key(alg_name, EVP_PKEY_PUBLIC_KEY, public_key,
+                          public_key_len, NULL, 0) ||
+        import_hybrid_key(alg_name, EVP_PKEY_KEYPAIR, public_key,
+                          public_key_len, private_key, private_key_len) ||
+        decode_EVP_PKEY_prov("DER", "SubjectPublicKeyInfo", NULL, alg_name,
+                             EVP_PKEY_PUBLIC_KEY, &decoded, spki->data,
+                             spki->length))
+        goto end;
+
+    ERR_clear_error();
+    ok = 1;
+
+end:
+    EVP_PKEY_free(key);
+    EVP_PKEY_free(decoded);
+    BUF_MEM_free(spki);
+    free(public_key);
+    free(private_key);
+    return ok;
+}
+#endif
+
 static int test_oqs_encdec(const char *alg_name) {
     EVP_PKEY *pkey = NULL;
     EVP_PKEY *decoded_pkey = NULL;
@@ -280,6 +387,14 @@ int main(int argc, char *argv[]) {
         errcnt += test_algs(algs);
     } else {
         fprintf(stderr, cRED "  No KEM algorithms found" cNORM "\n");
+        ERR_print_errors_fp(stderr);
+        errcnt++;
+    }
+
+    if (!test_hybrid_kem_rejects_invalid_classical_length()) {
+        fprintf(stderr,
+                cRED "  Invalid hybrid KEM classical length was accepted" cNORM
+                     "\n");
         ERR_print_errors_fp(stderr);
         errcnt++;
     }

--- a/test/oqs_test_endecode.c
+++ b/test/oqs_test_endecode.c
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0 AND MIT
 
+#include <limits.h>
+#include <openssl/asn1.h>
 #include <openssl/buffer.h>
 #include <openssl/core_names.h>
 #include <openssl/decoder.h>
@@ -8,6 +10,7 @@
 #include <openssl/pem.h>
 #include <openssl/provider.h>
 #include <openssl/trace.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -166,20 +169,6 @@ end:
 }
 
 #ifdef OQS_KEM_ENCODERS
-static unsigned char *find_bytes(unsigned char *haystack, size_t haystack_len,
-                                 const unsigned char *needle,
-                                 size_t needle_len) {
-    size_t i;
-
-    if (needle_len == 0 || haystack_len < needle_len)
-        return NULL;
-    for (i = 0; i <= haystack_len - needle_len; i++) {
-        if (memcmp(haystack + i, needle, needle_len) == 0)
-            return haystack + i;
-    }
-    return NULL;
-}
-
 static int import_hybrid_key(const char *alg_name, int selection,
                              unsigned char *public_key, size_t public_key_len,
                              unsigned char *private_key,
@@ -207,73 +196,186 @@ static int import_hybrid_key(const char *alg_name, int selection,
     return ok;
 }
 
-static int get_classical_public_key(const EVP_PKEY *key,
-                                    unsigned char **classical_public_key,
-                                    size_t *classical_public_key_len) {
-    *classical_public_key = NULL;
-    *classical_public_key_len = 0;
+enum hybrid_length_test_result {
+    HYBRID_LENGTH_TEST_FAILED = 0,
+    HYBRID_LENGTH_TEST_PASSED = 1,
+    HYBRID_LENGTH_TEST_SKIP_DISABLED = -1,
+    HYBRID_LENGTH_TEST_SKIP_NO_CLASSICAL = -2,
+    HYBRID_LENGTH_TEST_SKIP_NON_SEC1 = -3,
+};
 
-    if (EVP_PKEY_get_octet_string_param(
-            key, OQS_HYBRID_PKEY_PARAM_CLASSICAL_PUB_KEY, NULL, 0,
-            classical_public_key_len) != 1 ||
-        *classical_public_key_len == 0) {
+static int get_optional_octet_string_param(const EVP_PKEY *key,
+                                           const char *param_name,
+                                           unsigned char **value,
+                                           size_t *value_len) {
+    *value = NULL;
+    *value_len = 0;
+
+    if (EVP_PKEY_get_octet_string_param(key, param_name, NULL, 0, value_len) !=
+            1 ||
+        *value_len == 0) {
         ERR_clear_error();
         return 0;
     }
-    *classical_public_key = malloc(*classical_public_key_len);
-    if (*classical_public_key == NULL)
+    *value = malloc(*value_len);
+    if (*value == NULL)
         return -1;
-    if (EVP_PKEY_get_octet_string_param(
-            key, OQS_HYBRID_PKEY_PARAM_CLASSICAL_PUB_KEY, *classical_public_key,
-            *classical_public_key_len, classical_public_key_len) != 1) {
-        free(*classical_public_key);
-        *classical_public_key = NULL;
+    if (EVP_PKEY_get_octet_string_param(key, param_name, *value, *value_len,
+                                        value_len) != 1) {
+        free(*value);
+        *value = NULL;
         return -1;
     }
     return 1;
 }
 
-static int
+static int is_uncompressed_sec1_public_key(const unsigned char *public_key,
+                                           size_t public_key_len) {
+    /* SEC1 encodes an uncompressed point as 0x04 || X || Y. */
+    return public_key_len >= 3 && public_key[0] == 0x04 &&
+           (public_key_len - 1) % 2 == 0;
+}
+
+static int test_uncompressed_sec1_public_key_selector(void) {
+    unsigned char sec1_public_key[65] = {0x04};
+    unsigned char ecx_public_key[32] = {0x04};
+    unsigned char compressed_sec1_public_key[33] = {0x02};
+
+    return is_uncompressed_sec1_public_key(sec1_public_key,
+                                           sizeof(sec1_public_key)) &&
+           !is_uncompressed_sec1_public_key(ecx_public_key,
+                                            sizeof(ecx_public_key)) &&
+           !is_uncompressed_sec1_public_key(compressed_sec1_public_key,
+                                            sizeof(compressed_sec1_public_key));
+}
+
+static unsigned char *locate_classical_public_key(
+    unsigned char *public_key, size_t public_key_len,
+    const unsigned char *classical_public_key, size_t classical_public_key_len,
+    const unsigned char *pq_public_key, size_t pq_public_key_len) {
+    unsigned char *components;
+    uint32_t encoded_classical_len;
+
+    if (classical_public_key_len > SIZE_MAX - SIZE_OF_UINT32 ||
+        pq_public_key_len >
+            SIZE_MAX - SIZE_OF_UINT32 - classical_public_key_len ||
+        public_key_len !=
+            SIZE_OF_UINT32 + classical_public_key_len + pq_public_key_len ||
+        classical_public_key_len > UINT32_MAX)
+        return NULL;
+
+    DECODE_UINT32(encoded_classical_len, public_key);
+    if (encoded_classical_len != classical_public_key_len)
+        return NULL;
+
+    /* Hybrid public keys contain either CLASSICAL || PQ or PQ || CLASSICAL. */
+    components = public_key + SIZE_OF_UINT32;
+    if (memcmp(components, classical_public_key, classical_public_key_len) ==
+            0 &&
+        memcmp(components + classical_public_key_len, pq_public_key,
+               pq_public_key_len) == 0)
+        return components;
+
+    if (memcmp(components, pq_public_key, pq_public_key_len) == 0 &&
+        memcmp(components + pq_public_key_len, classical_public_key,
+               classical_public_key_len) == 0)
+        return components + pq_public_key_len;
+
+    return NULL;
+}
+
+static unsigned char *get_spki_public_key(BUF_MEM *spki,
+                                          const unsigned char *expected,
+                                          size_t expected_len) {
+    const unsigned char *cursor, *outer_end;
+    long object_len;
+    int object_class, object_tag, ret;
+
+    if (spki == NULL || spki->data == NULL || spki->length > LONG_MAX)
+        return NULL;
+
+    cursor = (const unsigned char *)spki->data;
+    /* Walk SubjectPublicKeyInfo structurally to its subjectPublicKey BIT
+     * STRING. */
+    ret = ASN1_get_object(&cursor, &object_len, &object_tag, &object_class,
+                          (long)spki->length);
+    if ((ret & 0x80) != 0 || (ret & V_ASN1_CONSTRUCTED) == 0 ||
+        object_class != V_ASN1_UNIVERSAL || object_tag != V_ASN1_SEQUENCE ||
+        object_len < 0 ||
+        (size_t)object_len >
+            spki->length -
+                (size_t)(cursor - (const unsigned char *)spki->data) ||
+        cursor + object_len != (const unsigned char *)spki->data + spki->length)
+        return NULL;
+    outer_end = cursor + object_len;
+
+    ret = ASN1_get_object(&cursor, &object_len, &object_tag, &object_class,
+                          (long)(outer_end - cursor));
+    if ((ret & 0x80) != 0 || (ret & V_ASN1_CONSTRUCTED) == 0 ||
+        object_class != V_ASN1_UNIVERSAL || object_tag != V_ASN1_SEQUENCE ||
+        object_len < 0 || object_len > outer_end - cursor)
+        return NULL;
+    cursor += object_len;
+
+    ret = ASN1_get_object(&cursor, &object_len, &object_tag, &object_class,
+                          (long)(outer_end - cursor));
+    if ((ret & 0x80) != 0 || (ret & V_ASN1_CONSTRUCTED) != 0 ||
+        object_class != V_ASN1_UNIVERSAL || object_tag != V_ASN1_BIT_STRING ||
+        object_len < 1 || object_len - 1 != expected_len ||
+        object_len > outer_end - cursor || cursor[0] != 0 ||
+        cursor + object_len != outer_end ||
+        memcmp(cursor + 1, expected, expected_len) != 0)
+        return NULL;
+
+    return (unsigned char *)cursor + 1;
+}
+
+static enum hybrid_length_test_result
 test_hybrid_kem_rejects_invalid_classical_length(const char *alg_name) {
     EVP_PKEY *key = NULL, *decoded = NULL;
     BUF_MEM *spki = NULL;
     unsigned char *public_key = NULL, *private_key = NULL;
     unsigned char *classical_public_key = NULL, *classical_in_public = NULL;
-    unsigned char *embedded = NULL, *classical_in_spki = NULL;
+    unsigned char *pq_public_key = NULL, *spki_public_key = NULL;
+    unsigned char *classical_in_spki = NULL;
     size_t public_key_len = 0, private_key_len = 0;
-    size_t classical_public_key_len = 0;
-    int classical_key_status;
-    int ok = 0;
+    size_t classical_public_key_len = 0, pq_public_key_len = 0;
+    int param_status;
+    enum hybrid_length_test_result result = HYBRID_LENGTH_TEST_FAILED;
 
     if (!alg_is_enabled(alg_name))
-        return -1;
+        return HYBRID_LENGTH_TEST_SKIP_DISABLED;
     key = oqstest_make_key(alg_name, NULL, NULL);
     if (key == NULL)
         goto end;
 
-    classical_key_status = get_classical_public_key(key, &classical_public_key,
-                                                    &classical_public_key_len);
-    if (classical_key_status == 0) {
-        ok = -1;
+    param_status = get_optional_octet_string_param(
+        key, OQS_HYBRID_PKEY_PARAM_CLASSICAL_PUB_KEY, &classical_public_key,
+        &classical_public_key_len);
+    if (param_status == 0) {
+        result = HYBRID_LENGTH_TEST_SKIP_NO_CLASSICAL;
         goto end;
     }
-    if (classical_key_status < 0)
+    if (param_status < 0)
         goto end;
-    if (classical_public_key_len < 2 || classical_public_key[0] != 0x04) {
-        ok = -1;
+    if (!is_uncompressed_sec1_public_key(classical_public_key,
+                                         classical_public_key_len)) {
+        result = HYBRID_LENGTH_TEST_SKIP_NON_SEC1;
         goto end;
     }
+    if (get_optional_octet_string_param(key, OQS_HYBRID_PKEY_PARAM_PQ_PUB_KEY,
+                                        &pq_public_key,
+                                        &pq_public_key_len) != 1)
+        goto end;
     if (get_param_octet_string(key, OSSL_PKEY_PARAM_PUB_KEY, &public_key,
                                &public_key_len) != 0 ||
         get_param_octet_string(key, OSSL_PKEY_PARAM_PRIV_KEY, &private_key,
                                &private_key_len) != 0)
         goto end;
 
-    classical_in_public =
-        public_key_len > 4
-            ? find_bytes(public_key + 4, public_key_len - 4,
-                         classical_public_key, classical_public_key_len)
-            : NULL;
+    classical_in_public = locate_classical_public_key(
+        public_key, public_key_len, classical_public_key,
+        classical_public_key_len, pq_public_key, pq_public_key_len);
     if (classical_in_public == NULL)
         goto end;
 
@@ -293,19 +395,19 @@ test_hybrid_kem_rejects_invalid_classical_length(const char *alg_name) {
         EVP_PKEY_free(decoded);
         decoded = NULL;
 
-        embedded = find_bytes((unsigned char *)spki->data, spki->length,
-                              public_key, public_key_len);
-        if (embedded == NULL)
+        spki_public_key = get_spki_public_key(spki, public_key, public_key_len);
+        if (spki_public_key == NULL)
             goto end;
-        classical_in_spki = embedded + (classical_in_public - public_key);
+        classical_in_spki =
+            spki_public_key + (classical_in_public - public_key);
     }
 
     public_key[0] = public_key[1] = public_key[2] = 0;
     public_key[3] = 1;
     classical_in_public[0] = 0;
-    if (embedded != NULL) {
-        embedded[0] = embedded[1] = embedded[2] = 0;
-        embedded[3] = 1;
+    if (spki_public_key != NULL) {
+        spki_public_key[0] = spki_public_key[1] = spki_public_key[2] = 0;
+        spki_public_key[3] = 1;
         classical_in_spki[0] = 0;
     }
 
@@ -320,7 +422,7 @@ test_hybrid_kem_rejects_invalid_classical_length(const char *alg_name) {
         goto end;
 
     ERR_clear_error();
-    ok = 1;
+    result = HYBRID_LENGTH_TEST_PASSED;
 
 end:
     EVP_PKEY_free(key);
@@ -329,23 +431,42 @@ end:
     free(public_key);
     free(private_key);
     free(classical_public_key);
-    return ok;
+    free(pq_public_key);
+    return result;
 }
 
 static int
 test_hybrid_kems_reject_invalid_classical_lengths(const OSSL_ALGORITHM *algs) {
-    int errcnt = 0, tested = 0;
+    int discovered = 0, disabled = 0, no_classical = 0, non_sec1 = 0;
+    int errcnt = 0, tested = 0, spki_tested = 0;
+
+    if (!test_uncompressed_sec1_public_key_selector()) {
+        fprintf(stderr,
+                cRED "  Invalid SEC1 public-key selector controls" cNORM "\n");
+        errcnt++;
+    }
 
     for (; algs->algorithm_names != NULL; algs++) {
+        int has_spki = OBJ_sn2nid(algs->algorithm_names) != NID_undef;
+
+        discovered++;
         switch (test_hybrid_kem_rejects_invalid_classical_length(
             algs->algorithm_names)) {
-        case 1:
+        case HYBRID_LENGTH_TEST_PASSED:
             fprintf(stderr,
                     cGREEN "  Invalid classical length rejected: %s" cNORM "\n",
                     algs->algorithm_names);
             tested++;
+            spki_tested += has_spki;
             break;
-        case -1:
+        case HYBRID_LENGTH_TEST_SKIP_DISABLED:
+            disabled++;
+            break;
+        case HYBRID_LENGTH_TEST_SKIP_NO_CLASSICAL:
+            no_classical++;
+            break;
+        case HYBRID_LENGTH_TEST_SKIP_NON_SEC1:
+            non_sec1++;
             break;
         default:
             fprintf(stderr,
@@ -357,6 +478,14 @@ test_hybrid_kems_reject_invalid_classical_lengths(const OSSL_ALGORITHM *algs) {
             break;
         }
     }
+    fprintf(stderr,
+            cBLUE
+            "  Invalid classical length coverage: discovered=%d, "
+            "tested=%d, spki=%d, skipped_disabled=%d, "
+            "skipped_no_classical=%d, skipped_non_sec1=%d, failed=%d" cNORM
+            "\n",
+            discovered, tested, spki_tested, disabled, no_classical, non_sec1,
+            errcnt);
     if (tested == 0) {
         fprintf(stderr, cRED
                 "  No hybrid KEM with a supported EC key found" cNORM "\n");


### PR DESCRIPTION
## Summary

- Require the encoded classical public-key length to match the algorithm's fixed classical length for EC hybrid KEMs.
- Apply the validation to both `EVP_PKEY_fromdata()` imports and SubjectPublicKeyInfo decoding.
- Exercise every provider-exposed hybrid KEM that carries a classical public-key component, without depending on an algorithm name or on the classical key's encoding.

## Rationale

EC hybrid KEM component pointers are calculated using the algorithm's fixed classical-key length. Accepting a different embedded length lets later consumers combine a fixed component pointer with a length derived from the untrusted prefix. Requiring equality at both public-key import entry points keeps the layout and declared length consistent.

For each provider-exposed KEM, the regression test exports the classical, PQ, and composite public-key representations. An algorithm enters the tested population when it exposes a classical component. The fixed-length invariant holds for `KEY_TYPE_ECP_HYB_KEM`, `KEY_TYPE_ECBP_HYB_KEM` and `KEY_TYPE_ECX_HYB_KEM` alike, so the test does not restrict itself to one classical encoding.

The test verifies that the composite key is exactly either `length || classical || PQ` or `length || PQ || classical`; it does not locate components by substring search. SubjectPublicKeyInfo is traversed structurally to its `subjectPublicKey` BIT STRING. Valid public-only, keypair, and available SPKI controls must succeed before the classical-length prefix is changed to 1 and the first classical byte is zeroed. All applicable malformed imports must then be rejected.

SPKI coverage runs only where the algorithm has a registered OID and encoder. Lack of an OID does not remove the algorithm from the lower-level public-only and keypair checks.

## Testing

- `OQS_KEM_ENCODERS=ON`: 9/9 CTest tests passed.
- Encoder-ON coverage: `discovered=56, tested=38, spki=2, skipped_disabled=0, skipped_no_classical=18, failed=0`.
- The encoder-ON coverage result was stable across fifteen fresh-key runs.
- Negative controls: excluding only `KEY_TYPE_ECX_HYB_KEM` from the check fails exactly the
  fourteen x25519 and x448 hybrids and nothing else; reverting the whole
  `oqsprov/oqsprov_keys.c` change fails all 38.
- `OQS_ALGS_ENABLED=STD` and a second OpenSSL 3.6 point release: 9/9 CTest tests passed.
- AddressSanitizer and UndefinedBehaviorSanitizer (LLVM 22): no AddressSanitizer findings.
  The three pre-existing `-fsanitize=function` reports in `oqsprov/oqs_decode_der2key.c`
  are identical before and after this branch.
- Measured on macOS 26.6 arm64 with liboqs `main` and OpenSSL 3.6.1 and 3.6.3. Linux and
  the older OpenSSL branches are left to the remote matrix.
- Default configuration (`OQS_KEM_ENCODERS=OFF`): clean build and 9/9 CTest tests passed. The hybrid-length regression does not execute in this configuration; the counts above are encoder-ON results.
- `./scripts/do_code_format.sh`
- `git diff --check`

## AI assistance

OpenAI Codex assisted with the implementation, adversarial review, regression coverage, testing, and preparation of the pull request text. Claude assisted with the follow-up commit that removed the SEC1 restriction and with the measurements reported above. I reviewed the resulting code and evidence and take responsibility for the contribution under the DCO.
