### PR TITLE
Fix component selection in hybrid KEM TEXT encoding

### DIFF
--- a/oqsprov/oqs_encode_key2any.c
+++ b/oqsprov/oqs_encode_key2any.c
@@ -1439,6 +1439,10 @@ static int oqsx_to_text(BIO *out, const void *key, int selection) {
                     okey->oqsx_provider_ctx.oqsx_qs_ctx.kem->length_secret_key;
                 size_t space_for_classical_privkey =
                     okey->privkeylen - SIZE_OF_UINT32 - fixed_pq_privkey_len;
+                int idx_classic = okey->reverse_share ? okey->numkeys - 1 : 0;
+                int idx_pq = okey->reverse_share ? 0 : okey->numkeys - 1;
+                size_t pq_privkey_len;
+
                 sprintf(classic_label,
                         "%s key material:", OBJ_nid2sn(okey->evp_info->nid));
                 DECODE_UINT32(classic_key_len, okey->privkey);
@@ -1446,14 +1450,18 @@ static int oqsx_to_text(BIO *out, const void *key, int selection) {
                     ERR_raise(ERR_LIB_USER, OQSPROV_R_INVALID_ENCODING);
                     return 0;
                 }
+                pq_privkey_len =
+                    okey->reverse_share
+                        ? fixed_pq_privkey_len
+                        : okey->privkeylen - classic_key_len - SIZE_OF_UINT32;
                 if (!print_labeled_buf(out, classic_label,
-                                       okey->comp_privkey[0], classic_key_len))
+                                       okey->comp_privkey[idx_classic],
+                                       classic_key_len))
                     return 0;
                 /* finally print pure PQ key */
-                if (!print_labeled_buf(out, "PQ key material:",
-                                       okey->comp_privkey[okey->numkeys - 1],
-                                       okey->privkeylen - classic_key_len -
-                                           SIZE_OF_UINT32))
+                if (!print_labeled_buf(
+                        out, "PQ key material:", okey->comp_privkey[idx_pq],
+                        pq_privkey_len))
                     return 0;
             } else { // plain PQ key
                 if (!print_labeled_buf(out, "PQ key material:",
@@ -1472,21 +1480,29 @@ static int oqsx_to_text(BIO *out, const void *key, int selection) {
                     okey->oqsx_provider_ctx.oqsx_qs_ctx.kem->length_public_key;
                 size_t space_for_classical_pubkey =
                     okey->pubkeylen - SIZE_OF_UINT32 - fixed_pq_pubkey_len;
+                int idx_classic = okey->reverse_share ? okey->numkeys - 1 : 0;
+                int idx_pq = okey->reverse_share ? 0 : okey->numkeys - 1;
+                size_t pq_pubkey_len;
+
                 DECODE_UINT32(classic_key_len, okey->pubkey);
                 if (classic_key_len > space_for_classical_pubkey) {
                     ERR_raise(ERR_LIB_USER, OQSPROV_R_INVALID_ENCODING);
                     return 0;
                 }
+                pq_pubkey_len =
+                    okey->reverse_share
+                        ? fixed_pq_pubkey_len
+                        : okey->pubkeylen - classic_key_len - SIZE_OF_UINT32;
                 sprintf(classic_label,
                         "%s key material:", OBJ_nid2sn(okey->evp_info->nid));
-                if (!print_labeled_buf(out, classic_label, okey->comp_pubkey[0],
+                if (!print_labeled_buf(out, classic_label,
+                                       okey->comp_pubkey[idx_classic],
                                        classic_key_len))
                     return 0;
                 /* finally print pure PQ key */
-                if (!print_labeled_buf(out, "PQ key material:",
-                                       okey->comp_pubkey[okey->numkeys - 1],
-                                       okey->pubkeylen - classic_key_len -
-                                           SIZE_OF_UINT32))
+                if (!print_labeled_buf(
+                        out, "PQ key material:", okey->comp_pubkey[idx_pq],
+                        pq_pubkey_len))
                     return 0;
             } else { // PQ key only
                 if (!print_labeled_buf(out, "PQ key material:",

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -125,6 +125,7 @@ add_executable(oqs_test_tlssig oqs_test_tlssig.c test_common.c tlstest_helpers.c
 target_link_libraries(oqs_test_tlssig PRIVATE OQS::oqs ${OPENSSL_SSL_LIBRARY} ${OPENSSL_CRYPTO_LIBRARY} ${OQS_ADDL_SOCKET_LIBS} ${REQ_LIBS_T})
 
 add_executable(oqs_test_endecode oqs_test_endecode.c test_common.c)
+target_include_directories(oqs_test_endecode PRIVATE "../oqsprov")
 target_link_libraries(oqs_test_endecode PRIVATE OQS::oqs ${OPENSSL_CRYPTO_LIBRARY} ${OQS_ADDL_SOCKET_LIBS} ${REQ_LIBS_T})
 add_test(
   NAME oqs_endecode

--- a/test/oqs_test_endecode.c
+++ b/test/oqs_test_endecode.c
@@ -409,17 +409,23 @@ int main(int argc, char *argv[]) {
     algs = OSSL_PROVIDER_query_operation(oqsprov, OSSL_OP_KEM, &query_nocache);
 
     if (algs) {
+        const OSSL_ALGORITHM *kemalgs;
+
         errcnt += test_algs(algs);
+        for (kemalgs = algs; kemalgs->algorithm_names != NULL; kemalgs++) {
+            if (!is_kem_algorithm_hybrid(kemalgs->algorithm_names))
+                continue;
+            if (!test_hybrid_kem_text_components(kemalgs->algorithm_names)) {
+                fprintf(stderr,
+                        cRED "  Hybrid KEM TEXT encoding test failed: %s" cNORM
+                             "\n",
+                        kemalgs->algorithm_names);
+                ERR_print_errors_fp(stderr);
+                errcnt++;
+            }
+        }
     } else {
         fprintf(stderr, cRED "  No KEM algorithms found" cNORM "\n");
-        ERR_print_errors_fp(stderr);
-        errcnt++;
-    }
-
-    if (!test_hybrid_kem_text_components("p256_mlkem512") ||
-        !test_hybrid_kem_text_components("x25519_mlkem512")) {
-        fprintf(stderr,
-                cRED "  Hybrid KEM TEXT encoding test failed" cNORM "\n");
         ERR_print_errors_fp(stderr);
         errcnt++;
     }

--- a/test/oqs_test_endecode.c
+++ b/test/oqs_test_endecode.c
@@ -11,6 +11,7 @@
 #include <string.h>
 
 #include "oqs/oqs.h"
+#include "oqs_prov.h"
 #include "test_common.h"
 
 static OSSL_LIB_CTX *libctx = NULL;
@@ -122,6 +123,137 @@ end:
     OSSL_ENCODER_CTX_free(ectx);
     return ok;
 }
+
+#ifdef OQS_KEM_ENCODERS
+static char *format_component(const char *label, const unsigned char *buf,
+                              size_t buflen) {
+    BIO *out = NULL;
+    BUF_MEM *mem = NULL;
+    char *formatted = NULL;
+    size_t i;
+
+    out = BIO_new(BIO_s_mem());
+    if (out == NULL || (label != NULL && BIO_printf(out, "%s\n", label) <= 0))
+        goto end;
+
+    for (i = 0; i < buflen; i++) {
+        if ((i % 15) == 0) {
+            if (i > 0 && BIO_printf(out, "\n") <= 0)
+                goto end;
+            if (BIO_printf(out, "    ") <= 0)
+                goto end;
+        }
+        if (BIO_printf(out, "%02x%s", buf[i], (i == buflen - 1) ? "" : ":") <=
+            0)
+            goto end;
+    }
+    if (BIO_printf(out, "\n") <= 0)
+        goto end;
+
+    BIO_get_mem_ptr(out, &mem);
+    if (mem == NULL)
+        goto end;
+    formatted = OPENSSL_malloc(mem->length + 1);
+    if (formatted == NULL)
+        goto end;
+    memcpy(formatted, mem->data, mem->length);
+    formatted[mem->length] = '\0';
+
+end:
+    BIO_free(out);
+    return formatted;
+}
+
+static int text_contains_component(const BUF_MEM *encoded, const char *label,
+                                   const unsigned char *component,
+                                   size_t component_len) {
+    char *formatted = NULL;
+    char *text = NULL;
+    int ok = 0;
+
+    formatted = format_component(label, component, component_len);
+    text = OPENSSL_malloc(encoded->length + 1);
+    if (formatted == NULL || text == NULL)
+        goto end;
+    memcpy(text, encoded->data, encoded->length);
+    text[encoded->length] = '\0';
+    ok = strstr(text, formatted) != NULL;
+
+end:
+    OPENSSL_free(formatted);
+    OPENSSL_free(text);
+    return ok;
+}
+
+static int test_hybrid_kem_text_components(const char *alg_name) {
+    EVP_PKEY_CTX *ctx = NULL;
+    EVP_PKEY *key = NULL, *pubonly = NULL;
+    OSSL_PARAM *public_params = NULL;
+    BUF_MEM *keypair_text = NULL, *public_text = NULL;
+    unsigned char *classic_pub = NULL, *classic_priv = NULL;
+    unsigned char *pq_pub = NULL, *pq_priv = NULL;
+    size_t classic_pub_len = 0, classic_priv_len = 0;
+    size_t pq_pub_len = 0, pq_priv_len = 0;
+    int ok = 0;
+
+    if (!alg_is_enabled(alg_name))
+        return 1;
+
+    key = oqstest_make_key(alg_name, NULL, NULL);
+    if (key == NULL ||
+        get_param_octet_string(key, OQS_HYBRID_PKEY_PARAM_CLASSICAL_PUB_KEY,
+                               &classic_pub, &classic_pub_len) != 0 ||
+        get_param_octet_string(key, OQS_HYBRID_PKEY_PARAM_CLASSICAL_PRIV_KEY,
+                               &classic_priv, &classic_priv_len) != 0 ||
+        get_param_octet_string(key, OQS_HYBRID_PKEY_PARAM_PQ_PUB_KEY, &pq_pub,
+                               &pq_pub_len) != 0 ||
+        get_param_octet_string(key, OQS_HYBRID_PKEY_PARAM_PQ_PRIV_KEY, &pq_priv,
+                               &pq_priv_len) != 0)
+        goto end;
+
+    if (!encode_EVP_PKEY_prov(key, "TEXT", NULL, NULL,
+                              OSSL_KEYMGMT_SELECT_KEYPAIR, &keypair_text) ||
+        !text_contains_component(keypair_text, NULL, classic_priv,
+                                 classic_priv_len) ||
+        !text_contains_component(keypair_text, "PQ key material:", pq_priv,
+                                 pq_priv_len) ||
+        !text_contains_component(keypair_text, NULL, classic_pub,
+                                 classic_pub_len) ||
+        !text_contains_component(keypair_text, "PQ key material:", pq_pub,
+                                 pq_pub_len))
+        goto end;
+
+    if (EVP_PKEY_todata(key, EVP_PKEY_PUBLIC_KEY, &public_params) != 1)
+        goto end;
+    ctx = EVP_PKEY_CTX_new_from_name(keyctx, alg_name, OQSPROV_PROPQ);
+    if (ctx == NULL || EVP_PKEY_fromdata_init(ctx) != 1 ||
+        EVP_PKEY_fromdata(ctx, &pubonly, EVP_PKEY_PUBLIC_KEY, public_params) !=
+            1)
+        goto end;
+    if (!encode_EVP_PKEY_prov(pubonly, "TEXT", NULL, NULL,
+                              OSSL_KEYMGMT_SELECT_PUBLIC_KEY, &public_text) ||
+        !text_contains_component(public_text, NULL, classic_pub,
+                                 classic_pub_len) ||
+        !text_contains_component(public_text, "PQ key material:", pq_pub,
+                                 pq_pub_len))
+        goto end;
+
+    ok = 1;
+
+end:
+    EVP_PKEY_CTX_free(ctx);
+    EVP_PKEY_free(key);
+    EVP_PKEY_free(pubonly);
+    OSSL_PARAM_free(public_params);
+    BUF_MEM_free(keypair_text);
+    BUF_MEM_free(public_text);
+    free(classic_pub);
+    free(classic_priv);
+    free(pq_pub);
+    free(pq_priv);
+    return ok;
+}
+#endif
 
 static int decode_EVP_PKEY_prov(const char *input_type, const char *structure,
                                 const char *pass, const char *keytype,
@@ -280,6 +412,14 @@ int main(int argc, char *argv[]) {
         errcnt += test_algs(algs);
     } else {
         fprintf(stderr, cRED "  No KEM algorithms found" cNORM "\n");
+        ERR_print_errors_fp(stderr);
+        errcnt++;
+    }
+
+    if (!test_hybrid_kem_text_components("p256_mlkem512") ||
+        !test_hybrid_kem_text_components("x25519_mlkem512")) {
+        fprintf(stderr,
+                cRED "  Hybrid KEM TEXT encoding test failed" cNORM "\n");
         ERR_print_errors_fp(stderr);
         errcnt++;
     }


### PR DESCRIPTION
## Summary

- Select the classical and PQ components according to `reverse_share` when encoding hybrid KEM keys as TEXT.
- Use the fixed liboqs PQ key lengths for reverse-share layouts.
- Add regression coverage for normal-order and reverse-share keys, for both keypair and public-only TEXT output.

## Rationale

Reverse-share hybrid KEM keys use the layout `length | PQ | classical`, while the TEXT encoder treated every hybrid key as `length | classical | PQ`. This made the encoder read the wrong component with the wrong length. The change aligns TEXT encoding with the component ordering already used elsewhere in the provider.

The regression test compares the encoded classical and PQ byte sequences with the corresponding exported key components. It covers `p256_mlkem512` as the normal-order control and `x25519_mlkem512` as the reverse-share case.

## Testing

- `OQS_KEM_ENCODERS=ON`: 9/9 CTest tests passed.
- Default configuration (`OQS_KEM_ENCODERS=OFF`): 9/9 CTest tests passed.
- `./scripts/do_code_format.sh`
- `git diff --check`

