### PR TITLE
oqsx_key_new() double free

### DIFF
--- a/oqsprov/oqsprov_keys.c
+++ b/oqsprov/oqsprov_keys.c
@@ -1232,6 +1232,10 @@ err:
     }
 
     if (evp_ctx) {
+        EVP_PKEY_CTX_free(evp_ctx->ctx);
+        evp_ctx->ctx = NULL;
+        EVP_PKEY_free(evp_ctx->keyParam);
+        evp_ctx->keyParam = NULL;
         OPENSSL_free(evp_ctx);
         evp_ctx = NULL;
     }

--- a/oqsprov/oqsprov_keys.c
+++ b/oqsprov/oqsprov_keys.c
@@ -1211,6 +1211,10 @@ OQSX_KEY *oqsx_key_new(OSSL_LIB_CTX *libctx, char *oqs_name, char *tls_name,
     return ret;
 err:
     ERR_raise(ERR_LIB_USER, ERR_R_MALLOC_FAILURE);
+
+    if (!ret)
+        return NULL;
+
 #ifdef OQS_PROVIDER_NOATOMIC
     if (ret->lock)
         CRYPTO_THREAD_lock_free(ret->lock);

--- a/oqsprov/oqsprov_keys.c
+++ b/oqsprov/oqsprov_keys.c
@@ -1155,6 +1155,7 @@ OQSX_KEY *oqsx_key_new(OSSL_LIB_CTX *libctx, char *oqs_name, char *tls_name,
         ret->oqsx_provider_ctx.oqsx_evp_ctx = evp_ctx;
         ret->keytype = primitive;
         ret->evp_info = evp_ctx->evp_info;
+        evp_ctx = NULL;
         break;
     case KEY_TYPE_HYB_SIG:
         ret->oqsx_provider_ctx.oqsx_qs_ctx.sig = OQS_SIG_new(oqs_name);
@@ -1187,6 +1188,7 @@ OQSX_KEY *oqsx_key_new(OSSL_LIB_CTX *libctx, char *oqs_name, char *tls_name,
         ret->oqsx_provider_ctx.oqsx_evp_ctx = evp_ctx;
         ret->keytype = primitive;
         ret->evp_info = evp_ctx->evp_info;
+        evp_ctx = NULL;
         break;
     default:
         OQS_KEY_PRINTF2("OQSX_KEY: Unknown key type encountered: %d\n",

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -225,6 +225,7 @@ set_tests_properties(oqs_alloc_failures
     PROPERTIES ENVIRONMENT "OPENSSL_MODULES=${OQS_PROV_BINARY_DIR}"
 )
 endif()
+set_tests_properties(oqs_alloc_failures PROPERTIES SKIP_RETURN_CODE 77)
 
 add_executable(oqs_test_alloc_failures oqs_test_alloc_failures.c test_common.c tlstest_helpers.c)
 target_link_libraries(oqs_test_alloc_failures PRIVATE ${OPENSSL_SSL_LIBRARY} ${OPENSSL_CRYPTO_LIBRARY} OQS::oqs ${OQS_ADDL_SOCKET_LIBS} ${REQ_LIBS_T})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -208,6 +208,27 @@ endif()
 add_executable(oqs_test_alg_overlap oqs_test_alg_overlap.c test_common.c)
 target_link_libraries(oqs_test_alg_overlap PRIVATE ${OPENSSL_CRYPTO_LIBRARY} OQS::oqs ${OQS_ADDL_SOCKET_LIBS} ${REQ_LIBS_T})
 
+add_test(
+    NAME oqs_alloc_failures
+    COMMAND oqs_test_alloc_failures
+            "oqsprovider"
+            "${CMAKE_CURRENT_SOURCE_DIR}/oqs.cnf"
+)
+# openssl under MSVC seems to have a bug registering NIDs:
+# It only works when setting OPENSSL_CONF, not when loading the same cnf file:
+if (MSVC)
+set_tests_properties(oqs_alloc_failures
+    PROPERTIES ENVIRONMENT "OPENSSL_MODULES=${OQS_PROV_BINARY_DIR};OPENSSL_CONF=${CMAKE_CURRENT_SOURCE_DIR}/openssl-ca.cnf"
+)
+else()
+set_tests_properties(oqs_alloc_failures
+    PROPERTIES ENVIRONMENT "OPENSSL_MODULES=${OQS_PROV_BINARY_DIR}"
+)
+endif()
+
+add_executable(oqs_test_alloc_failures oqs_test_alloc_failures.c test_common.c tlstest_helpers.c)
+target_link_libraries(oqs_test_alloc_failures PRIVATE ${OPENSSL_SSL_LIBRARY} ${OPENSSL_CRYPTO_LIBRARY} OQS::oqs ${OQS_ADDL_SOCKET_LIBS} ${REQ_LIBS_T})
+
 if (OQS_PROVIDER_BUILD_STATIC)
   targets_set_static_provider(oqs_test_signatures
     oqs_test_kems
@@ -218,5 +239,6 @@ if (OQS_PROVIDER_BUILD_STATIC)
     oqs_test_evp_pkey_params
     oqs_test_prop_str
     oqs_test_alg_overlap
+    oqs_test_alloc_failures
   )
 endif()

--- a/test/oqs_test_alloc_failures.c
+++ b/test/oqs_test_alloc_failures.c
@@ -77,8 +77,6 @@ int main(int argc, char *argv[]) {
 
     load_oqs_provider(libctx, modulename, configfile);
 
-    T(OSSL_PROVIDER_available(libctx, "default"));
-
     // Test the hybrid signature functions
     oqsprov = OSSL_PROVIDER_load(libctx, modulename);
     algs = OSSL_PROVIDER_query_operation(oqsprov, OSSL_OP_SIGNATURE,

--- a/test/oqs_test_alloc_failures.c
+++ b/test/oqs_test_alloc_failures.c
@@ -9,6 +9,10 @@
 #include "test_common.h"
 #include "tlstest_helpers.h"
 
+
+// If this is updated, update the reference in CMakeLists.txt
+#define EXIT_SKIP 77
+
 static OSSL_LIB_CTX *libctx = NULL;
 static char *modulename = NULL;
 static char *configfile = NULL;
@@ -67,6 +71,7 @@ int main(int argc, char *argv[]) {
     int query_nocache;
     OSSL_PROVIDER *oqsprov = NULL;
     const OSSL_ALGORITHM *algs;
+    int work_done = 0;
 
     T(CRYPTO_set_mem_functions(test_malloc, test_realloc, test_free) == 1);
 
@@ -90,19 +95,26 @@ int main(int argc, char *argv[]) {
         if (!is_signature_algorithm_hybrid(name))
             continue;
 
-        fprintf(stderr, cGREEN "  Testing signature algorithm %s\n", name);
+        fprintf(stderr, cGREEN "  Testing signature algorithm %s\n" cNORM,
+                name);
         // This counts the number of allocations in the target file
         hits = 0;
         fail_nth = -1;
         test_alloc_failures(name);
         long allocs = hits;
-        T(allocs > 0);
+        if (allocs == 0)
+            continue;
+
+        work_done = 1;
 
         for (fail_nth = 0; fail_nth < allocs; ++fail_nth) {
             hits = 0;
             test_alloc_failures(name);
         }
     }
+
+    // Make sure we don't fail any mallocs in OSSL_PROVIDER_query_operation
+    fail_nth = -1;
 
     // Now test the hybrid kem functions
     algs = OSSL_PROVIDER_query_operation(oqsprov, OSSL_OP_KEM, &query_nocache);
@@ -111,13 +123,16 @@ int main(int argc, char *argv[]) {
         if (!is_kem_algorithm_hybrid(name))
             continue;
 
-        fprintf(stderr, cGREEN "  Testing kem algorithm %s\n", name);
+        fprintf(stderr, cGREEN "  Testing kem algorithm %s\n" cNORM, name);
         // This counts the number of allocations in the target file
         hits = 0;
         fail_nth = -1;
         test_alloc_failures(name);
         long allocs = hits;
-        T(allocs > 0);
+        if (allocs == 0)
+            continue;
+
+        work_done = 1;
 
         for (fail_nth = 0; fail_nth < allocs; ++fail_nth) {
             hits = 0;
@@ -125,7 +140,13 @@ int main(int argc, char *argv[]) {
         }
     }
 
+    if (!work_done)
+        fprintf(stderr,
+                cYELLOW "  No allocations intercepted in %s.\n"
+                        "  Nothing can be tested, skipping.\n" cNORM,
+                target_file);
+
     OSSL_PROVIDER_unload(oqsprov);
     OSSL_LIB_CTX_free(libctx);
-    return EXIT_SUCCESS;
+    return work_done ? EXIT_SUCCESS : EXIT_SKIP;
 }

--- a/test/oqs_test_alloc_failures.c
+++ b/test/oqs_test_alloc_failures.c
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: Apache-2.0 AND MIT
+
+#include <openssl/core_names.h>
+#include <openssl/evp.h>
+#include <openssl/provider.h>
+#include <string.h>
+
+#include "oqs/oqs.h"
+#include "test_common.h"
+#include "tlstest_helpers.h"
+
+static OSSL_LIB_CTX *libctx = NULL;
+static char *modulename = NULL;
+static char *configfile = NULL;
+
+// The file containing the mallocs we want to fail
+static const char *target_file = "";
+
+// We want the nth malloc to fail (0-indexed)
+static long fail_nth = -1;
+// Used to count allocations
+static long hits = 0;
+
+void *test_malloc(size_t num, const char *file, int line) {
+    if (file && strcasestr(file, target_file) != NULL) {
+        if (hits++ == fail_nth) {
+            fprintf(stderr, cGREEN "   Injecting malloc failure at %s:%d\n",
+                    file, line);
+            return NULL;
+        }
+    }
+    return malloc(num);
+}
+
+void *test_realloc(void *addr, size_t num, const char *file, int line) {
+    return realloc(addr, num);
+}
+
+void test_free(void *addr, const char *file, int line) { free(addr); }
+
+int test_alloc_failures(const char *algname) {
+    EVP_PKEY_CTX *ctx = NULL;
+    EVP_PKEY *key = NULL;
+
+    int testresult = 1;
+
+    if (!alg_is_enabled(algname)) {
+        fprintf(stderr, "Not testing disabled algorithm %s.\n", algname);
+        return 1;
+    }
+
+    if (OSSL_PROVIDER_available(libctx, "default")) {
+        testresult &= (ctx = EVP_PKEY_CTX_new_from_name(
+                           libctx, algname, OQSPROV_PROPQ)) != NULL &&
+                      EVP_PKEY_keygen_init(ctx) && EVP_PKEY_generate(ctx, &key);
+    }
+
+    EVP_PKEY_free(key);
+    EVP_PKEY_CTX_free(ctx);
+
+    return testresult;
+}
+
+// This test is meant to crash with either a NULL pointer access or
+// some address sanitizer error if malloc failures aren't handled
+int main(int argc, char *argv[]) {
+    int query_nocache;
+    OSSL_PROVIDER *oqsprov = NULL;
+    const OSSL_ALGORITHM *algs;
+
+    T(CRYPTO_set_mem_functions(test_malloc, test_realloc, test_free) == 1);
+
+    T((libctx = OSSL_LIB_CTX_new()) != NULL);
+    T(argc == 3);
+    modulename = argv[1];
+    configfile = argv[2];
+
+    load_oqs_provider(libctx, modulename, configfile);
+
+    T(OSSL_PROVIDER_available(libctx, "default"));
+
+    // Test the hybrid signature functions
+    oqsprov = OSSL_PROVIDER_load(libctx, modulename);
+    algs = OSSL_PROVIDER_query_operation(oqsprov, OSSL_OP_SIGNATURE,
+                                         &query_nocache);
+
+    // We only want to insert malloc failures in oqsprov_keys.c
+    target_file = "oqsprov_keys.c";
+
+    for (; algs && algs->algorithm_names != NULL; ++algs) {
+        const char *name = algs->algorithm_names;
+        if (!is_signature_algorithm_hybrid(name))
+            continue;
+
+        fprintf(stderr, cGREEN "  Testing signature algorithm %s\n", name);
+        // This counts the number of allocations in the target file
+        hits = 0;
+        fail_nth = -1;
+        test_alloc_failures(name);
+        long allocs = hits;
+        T(allocs > 0);
+
+        for (fail_nth = 0; fail_nth < allocs; ++fail_nth) {
+            hits = 0;
+            test_alloc_failures(name);
+        }
+    }
+
+    // Now test the hybrid kem functions
+    algs = OSSL_PROVIDER_query_operation(oqsprov, OSSL_OP_KEM, &query_nocache);
+    for (; algs && algs->algorithm_names != NULL; ++algs) {
+        const char *name = algs->algorithm_names;
+        if (!is_kem_algorithm_hybrid(name))
+            continue;
+
+        fprintf(stderr, cGREEN "  Testing kem algorithm %s\n", name);
+        // This counts the number of allocations in the target file
+        hits = 0;
+        fail_nth = -1;
+        test_alloc_failures(name);
+        long allocs = hits;
+        T(allocs > 0);
+
+        for (fail_nth = 0; fail_nth < allocs; ++fail_nth) {
+            hits = 0;
+            test_alloc_failures(name);
+        }
+    }
+
+    OSSL_PROVIDER_unload(oqsprov);
+    OSSL_LIB_CTX_free(libctx);
+    return EXIT_SUCCESS;
+}

--- a/test/oqs_test_alloc_failures.c
+++ b/test/oqs_test_alloc_failures.c
@@ -9,7 +9,6 @@
 #include "test_common.h"
 #include "tlstest_helpers.h"
 
-
 // If this is updated, update the reference in CMakeLists.txt
 #define EXIT_SKIP 77
 

--- a/test/oqs_test_alloc_failures.c
+++ b/test/oqs_test_alloc_failures.c
@@ -22,7 +22,7 @@ static long fail_nth = -1;
 static long hits = 0;
 
 void *test_malloc(size_t num, const char *file, int line) {
-    if (file && strcasestr(file, target_file) != NULL) {
+    if (file && strstr(file, target_file) != NULL) {
         if (hits++ == fail_nth) {
             fprintf(stderr, cGREEN "   Injecting malloc failure at %s:%d\n",
                     file, line);


### PR DESCRIPTION
This PR is meant to fix the double free in `oqsx_key_new()` (#793).
I reproduced this with a test first, which injects malloc failures only into `oqsprov_keys.c` when generating keys. This surfaced two other related problems in `oqsx_key_new()` caused by malloc failure, which this PR also fixes.

The changes are:
- #793 
- NULL dereference in `err:` if `ret`'s allocation fails
- Leak of `evp_ctx->ctx` and `evp_ctx->keyParam` on paths that fail after `evp_ctx` was allocated but before it was aliased.

No security advisory for these was opened, because they're malloc failures (OOM only), and they're much less severe. They are in the same function, and they are the same class of bug. Anyone reading #793 would also see these problems.

Test is included and will run in CI. Its goal is to just run without any crashes or ASan errors.

Fixes #793.