### PR TITLE
cygnet: add provider init skeleton with fail-closed policy gate

### DIFF
--- a/docs/CYGNET-DROPIN-PLAN.md
+++ b/docs/CYGNET-DROPIN-PLAN.md
@@ -1,0 +1,125 @@
+# CygnetLib Drop-In Remediation Plan
+
+Target repo: `sanctumsecopsmssp/oqs-provider` (fork of `open-quantum-safe/oqs-provider`, created 2026-08-19)
+Rename to: `sanctumsecopsmssp/cygnet-provider`
+Owning repo for policy/evidence: `sanctumsecopsmssp/CygnetLib`
+Tracking issue: `sanctumsecopsmssp/CygnetLib#4`
+
+## Goal
+
+Convert CygnetLib from a typed interface specification with stub PQC implementations into a
+drop-in provider consumable by any application linking libcrypto, without reimplementing
+lattice or hash-based primitives in Python.
+
+Architecture after remediation:
+
+```
+application (unmodified)
+    -> libcrypto EVP high-level API
+        -> cygnet-provider.so   [policy gate + composite OIDs + evidence self-test]
+            -> liboqs / OpenSSL FIPS provider   [actual primitives]
+
+CygnetLib (Python)  -> ctypes binding to cygnet-provider.so  [tooling, audit, evidence]
+```
+
+## Remediation Items
+
+### R1 — Rename fork and wire upstream remote
+- Rename repo to `cygnet-provider` in Settings (no API tool available for rename; manual).
+- Enable Issues on the fork; they are disabled by default and blocked ticket creation here.
+- `git remote add upstream https://github.com/open-quantum-safe/oqs-provider.git`
+- Add a quarterly scheduled workflow that opens a PR merging `upstream/main`.
+- Keep `LICENSE.txt` (upstream MIT) alongside a new `NOTICE` attributing Sanctum additions.
+- Status: pending
+
+### R2 — Strip non-CNSA-2.0 algorithm families
+- Edit `oqs-template/generate.yml` to emit only ML-KEM, ML-DSA, SLH-DSA, X25519MLKEM768.
+- Regenerate `oqsprov_capabilities.c`, `oqsencoders.inc`, `oqsdecoders.inc`.
+- Record every removed family in `docs/removed-algorithms.md`; a smaller surface is a
+  cheaper CMVP and audit conversation.
+- Do not remove the encoder/decoder machinery itself — see R6.
+- Status: pending
+
+### R3 — Composite keymgmt and signature for the Sanctum PEN arc
+- Arc: `1.3.6.1.4.1.65953`
+- `CYGNET-L5-Triple` = ML-KEM-1024 (confidentiality) + SLH-DSA-SHA2-256s + ML-DSA-87
+  (two independent signature families for defense in depth).
+- `ALBIREO` = second composite profile.
+- Implement as `OSSL_OP_KEYMGMT` + `OSSL_OP_SIGNATURE` following the component-OID-list
+  structure in `draft-ietf-lamps-pq-composite-sigs`, which the CygnetLib evidence file
+  `ietf-pqc-interop.json` already claims alignment with.
+- This is the only genuinely novel code in the fork. Everything else is integration.
+- Status: pending
+
+### R4 — Fail-closed policy gate in provider init
+- Port the rules in `cygnet/policy.py` into `oqsprov/cygnet_prov_init.c`.
+- Deny by default: an algorithm absent from the allowlist is not exposed, not warned about.
+- Refuse to load if CNSA 2.0 required-set coverage regresses below 6/6.
+- `CYGNET_POLICY_RELAX=1` escape hatch for lab work only; assert it is unset in CI.
+- Emit `actv-results.json` and `cnsa2-compliance-matrix.json` at load time rather than
+  build time, so posture is proven per host.
+- Status: skeleton committed on `cygnet/policy-gate`; not yet wired into CMakeLists.txt.
+
+### R5 — Repoint CygnetLib FFI and delete the stubs
+- `cygnet/ffi/bindings.py`: make `LibOQSProvider` / `OpenSSLProvider` bind the built
+  `cygnet-provider.so` instead of returning interface stubs.
+- Delete the stub round-trip shims in `cygnet/kem/kem.py` and the parallel files under
+  `cygnet/sig/`, `cygnet/composite/`.
+- Update `evidence/actv-results.json` generation so the note about
+  "interface-specification stubs" can be removed truthfully.
+- Uncomment `pyoqs` / `cryptography` in `requirements.txt` and lock them.
+- Status: pending
+
+### R6 — SSH and PKCS#8 key formats (separate track)
+The fork already ships `oqs_encode_key2any.c` and `oqs_decode_der2key.c`, giving
+SubjectPublicKeyInfo / PKCS#8 / PEM round-tripping for the PQC key types. This closes
+most of the CygnetLib `pki` gap for free.
+
+It does **not** close the OpenSSH gap. OpenSSH does not consume OpenSSL providers for its
+key types, so the original SSH key problem still needs either:
+- an OpenSSH wire-format writer (length-prefixed blobs) in CygnetLib's `pki` module, or
+- routing through `ssh-agent` / a PKCS#11 or `sk-` middleware path.
+
+Do not conflate this with the provider work. Provider gets ecosystem reach; encoders get a
+key that can be pasted into `authorized_keys`.
+
+## Verification Gates
+
+Every item ships with evidence, not narrative:
+
+1. `openssl list -providers` shows `Cygnet Provider 0.1.0-dev`, status active.
+2. `openssl list -kem-algorithms -provider cygnet` shows exactly the allowlist.
+3. Negative test: an algorithm removed in R2 fails, and fails closed rather than silently
+   falling through to the default provider.
+4. `openssl req -provider cygnet -newkey mldsa87` produces a parseable cert.
+5. Composite round-trip vectors from the Sanctum internal harness pass against R3.
+6. `pytest` in CygnetLib passes with FFI bound to the real `.so`, no stub branches taken.
+
+## openssl.cnf Activation
+
+Keep the default provider active alongside Cygnet, or every algorithm the fork does not
+implement disappears.
+
+```ini
+[provider_sect]
+default = default_sect
+cygnet  = cygnet_sect
+
+[default_sect]
+activate = 1
+
+[cygnet_sect]
+module   = /usr/lib/ossl-modules/cygnet-provider.so
+activate = 1
+```
+
+## Known Constraint
+
+For the NIST-standardized set alone, OpenSSL 3.5+ already ships ML-KEM, ML-DSA and SLH-DSA
+natively. The fork's value is therefore *not* PQC availability. It is policy enforcement,
+composite OIDs under the Sanctum arc, and machine-readable compliance evidence. Position it
+that way internally and externally; claiming otherwise invites a comparison you lose.
+
+FIPS status: OpenSSL cert #4985 covers 3.1.2; 3.5.4 is submitted and still in CMVP review.
+Nobody has a validated PQC module in hand yet. Cygnet inherits whatever the loaded module
+carries and should say so explicitly in client-facing documentation.

--- a/oqsprov/cygnet_prov_init.c
+++ b/oqsprov/cygnet_prov_init.c
@@ -1,0 +1,278 @@
+/*
+ * cygnet_prov_init.c — Cygnet provider entry point and fail-closed policy gate.
+ *
+ * Drop into oqsprov/ in sanctumsecopsmssp/cygnet-provider (forked from
+ * open-quantum-safe/oqs-provider). Replaces the OSSL_provider_init in
+ * oqsprov.c; the algorithm tables from oqsprov_capabilities.c are reused
+ * unchanged and then filtered through cygnet_policy_permits().
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2026 Sanctum IP Co. All rights reserved.
+ */
+
+#include <openssl/core.h>
+#include <openssl/core_dispatch.h>
+#include <openssl/core_names.h>
+#include <openssl/params.h>
+#include <openssl/err.h>
+#include <string.h>
+
+#include "oqs_prov.h"
+
+#define CYGNET_PROV_NAME    "Cygnet Provider"
+#define CYGNET_PROV_VERSION "0.1.0-dev"
+
+/* IANA Private Enterprise Number arc administered by Sanctum. */
+#define CYGNET_PEN_ARC "1.3.6.1.4.1.65953"
+#define OID_CYGNET_L5  CYGNET_PEN_ARC ".1.1"
+#define OID_ALBIREO    CYGNET_PEN_ARC ".1.2"
+
+/* ---------------------------------------------------------------------------
+ * Policy table. Mirrors cygnet/policy.py. Anything absent is denied.
+ * Sourced from evidence/cnsa2-compliance-matrix.json (6/6 requirements).
+ * ------------------------------------------------------------------------- */
+
+typedef enum {
+    CYGNET_MECH_KEM = 0,
+    CYGNET_MECH_SIG,
+    CYGNET_MECH_HASH,
+    CYGNET_MECH_CIPHER,
+    CYGNET_MECH_KDF,
+    CYGNET_MECH_COMPOSITE
+} CYGNET_MECH;
+
+typedef struct {
+    const char *name;
+    const char *oid;
+    CYGNET_MECH mech;
+    const char *standard;
+    int         cnsa2_required;
+} CYGNET_POLICY_ENTRY;
+
+static const CYGNET_POLICY_ENTRY cygnet_allowlist[] = {
+    /* Key establishment — FIPS 203 */
+    { "ML-KEM-512",        NULL, CYGNET_MECH_KEM,       "FIPS 203",   0 },
+    { "ML-KEM-768",        NULL, CYGNET_MECH_KEM,       "FIPS 203",   0 },
+    { "ML-KEM-1024",       NULL, CYGNET_MECH_KEM,       "FIPS 203",   1 },
+
+    /* Signatures — FIPS 204 / 205 */
+    { "ML-DSA-44",         NULL, CYGNET_MECH_SIG,       "FIPS 204",   0 },
+    { "ML-DSA-65",         NULL, CYGNET_MECH_SIG,       "FIPS 204",   0 },
+    { "ML-DSA-87",         NULL, CYGNET_MECH_SIG,       "FIPS 204",   1 },
+    { "SLH-DSA-SHA2-128s", NULL, CYGNET_MECH_SIG,       "FIPS 205",   0 },
+    { "SLH-DSA-SHA2-192s", NULL, CYGNET_MECH_SIG,       "FIPS 205",   0 },
+    { "SLH-DSA-SHA2-256s", NULL, CYGNET_MECH_SIG,       "FIPS 205",   1 },
+
+    /* Classical transition set */
+    { "ECDSA-P256",        NULL, CYGNET_MECH_SIG,       "FIPS 186-5", 0 },
+    { "ECDSA-P384",        NULL, CYGNET_MECH_SIG,       "FIPS 186-5", 1 },
+    { "RSA-3072-PSS",      NULL, CYGNET_MECH_SIG,       "FIPS 186-5", 0 },
+
+    /* Hybrid TLS group — matches OpenSSL 3.5 default */
+    { "X25519MLKEM768",    NULL, CYGNET_MECH_KEM,       "IETF hybrid", 0 },
+
+    /* Cygnet composites — the differentiated surface */
+    { "CYGNET-L5-Triple",  OID_CYGNET_L5, CYGNET_MECH_COMPOSITE,
+      "Sanctum composite (ML-KEM-1024 + SLH-DSA-SHA2-256s + ML-DSA-87)", 0 },
+    { "ALBIREO",           OID_ALBIREO,   CYGNET_MECH_COMPOSITE,
+      "Sanctum composite", 0 },
+
+    { NULL, NULL, 0, NULL, 0 }
+};
+
+static int cygnet_strict_mode = 1;   /* fail closed by default */
+
+/*
+ * Return 1 if the algorithm may be exposed, 0 otherwise.
+ * In strict mode an unknown algorithm is denied, never warned about.
+ */
+static int cygnet_policy_permits(const char *name)
+{
+    const CYGNET_POLICY_ENTRY *e;
+
+    if (name == NULL)
+        return 0;
+
+    for (e = cygnet_allowlist; e->name != NULL; e++) {
+        if (strcmp(e->name, name) == 0)
+            return 1;
+    }
+    return cygnet_strict_mode ? 0 : 1;
+}
+
+/* ---------------------------------------------------------------------------
+ * Capability filtering. Walks the inherited OQS algorithm tables and drops
+ * every entry the policy does not permit before OpenSSL ever sees them.
+ * ------------------------------------------------------------------------- */
+
+static OSSL_ALGORITHM *cygnet_filter_algorithms(const OSSL_ALGORITHM *in,
+                                                size_t *out_count)
+{
+    size_t          n = 0, keep = 0, i;
+    OSSL_ALGORITHM *out;
+
+    if (in == NULL)
+        return NULL;
+
+    while (in[n].algorithm_names != NULL)
+        n++;
+
+    out = OPENSSL_zalloc(sizeof(*out) * (n + 1));
+    if (out == NULL)
+        return NULL;
+
+    for (i = 0; i < n; i++) {
+        /* algorithm_names may be a colon-delimited alias list; check the
+         * primary name only, aliases inherit the decision. */
+        char        primary[128];
+        const char *colon = strchr(in[i].algorithm_names, ':');
+        size_t      len = colon ? (size_t)(colon - in[i].algorithm_names)
+                                : strlen(in[i].algorithm_names);
+
+        if (len >= sizeof(primary))
+            len = sizeof(primary) - 1;
+        memcpy(primary, in[i].algorithm_names, len);
+        primary[len] = '\0';
+
+        if (cygnet_policy_permits(primary))
+            out[keep++] = in[i];
+    }
+
+    if (out_count != NULL)
+        *out_count = keep;
+    return out;
+}
+
+/* ---------------------------------------------------------------------------
+ * Self-test. Emits the evidence JSON that CygnetLib currently generates at
+ * build time, so posture is proven at load time instead.
+ * ------------------------------------------------------------------------- */
+
+static int cygnet_self_test(const OSSL_CORE_HANDLE *handle)
+{
+    const CYGNET_POLICY_ENTRY *e;
+    int required = 0, present = 0;
+
+    for (e = cygnet_allowlist; e->name != NULL; e++) {
+        if (!e->cnsa2_required)
+            continue;
+        required++;
+        /* TODO: replace with an actual keygen/sign/verify round trip through
+         * the inherited liboqs dispatch, then write results to
+         * $CYGNET_EVIDENCE_DIR/actv-results.json */
+        if (cygnet_policy_permits(e->name))
+            present++;
+    }
+
+    /* Fail closed: refuse to load if CNSA 2.0 coverage regressed. */
+    return (required > 0 && present == required);
+}
+
+/* ---------------------------------------------------------------------------
+ * Provider dispatch
+ * ------------------------------------------------------------------------- */
+
+static const OSSL_ITEM cygnet_param_types[] = {
+    { OSSL_PARAM_UTF8_PTR, (char *)OSSL_PROV_PARAM_NAME },
+    { OSSL_PARAM_UTF8_PTR, (char *)OSSL_PROV_PARAM_VERSION },
+    { OSSL_PARAM_UTF8_PTR, (char *)OSSL_PROV_PARAM_BUILDINFO },
+    { OSSL_PARAM_INTEGER,  (char *)OSSL_PROV_PARAM_STATUS },
+    { 0, NULL }
+};
+
+static int cygnet_get_params(void *provctx, OSSL_PARAM params[])
+{
+    OSSL_PARAM *p;
+
+    if ((p = OSSL_PARAM_locate(params, OSSL_PROV_PARAM_NAME)) != NULL
+        && !OSSL_PARAM_set_utf8_ptr(p, CYGNET_PROV_NAME))
+        return 0;
+    if ((p = OSSL_PARAM_locate(params, OSSL_PROV_PARAM_VERSION)) != NULL
+        && !OSSL_PARAM_set_utf8_ptr(p, CYGNET_PROV_VERSION))
+        return 0;
+    if ((p = OSSL_PARAM_locate(params, OSSL_PROV_PARAM_BUILDINFO)) != NULL
+        && !OSSL_PARAM_set_utf8_ptr(p, "cygnet-provider (fork of oqs-provider)"))
+        return 0;
+    if ((p = OSSL_PARAM_locate(params, OSSL_PROV_PARAM_STATUS)) != NULL
+        && !OSSL_PARAM_set_int(p, 1))
+        return 0;
+    return 1;
+}
+
+static const OSSL_ITEM *cygnet_gettable_params(void *provctx)
+{
+    return cygnet_param_types;
+}
+
+/* Filtered views of the inherited tables, built once at init. */
+static OSSL_ALGORITHM *cygnet_kems, *cygnet_sigs, *cygnet_kmgmt,
+                      *cygnet_encoders, *cygnet_decoders;
+
+static const OSSL_ALGORITHM *cygnet_query(void *provctx, int operation_id,
+                                          int *no_cache)
+{
+    *no_cache = 0;
+
+    switch (operation_id) {
+    case OSSL_OP_KEM:
+        return cygnet_kems;
+    case OSSL_OP_SIGNATURE:
+        return cygnet_sigs;
+    case OSSL_OP_KEYMGMT:
+        return cygnet_kmgmt;
+    case OSSL_OP_ENCODER:
+        return cygnet_encoders;
+    case OSSL_OP_DECODER:
+        return cygnet_decoders;
+    default:
+        return NULL;
+    }
+}
+
+static void cygnet_teardown(void *provctx)
+{
+    OPENSSL_free(cygnet_kems);
+    OPENSSL_free(cygnet_sigs);
+    OPENSSL_free(cygnet_kmgmt);
+    OPENSSL_free(cygnet_encoders);
+    OPENSSL_free(cygnet_decoders);
+    oqsprovider_teardown(provctx);   /* inherited cleanup */
+}
+
+static const OSSL_DISPATCH cygnet_dispatch_table[] = {
+    { OSSL_FUNC_PROVIDER_TEARDOWN,        (void (*)(void))cygnet_teardown },
+    { OSSL_FUNC_PROVIDER_GETTABLE_PARAMS, (void (*)(void))cygnet_gettable_params },
+    { OSSL_FUNC_PROVIDER_GET_PARAMS,      (void (*)(void))cygnet_get_params },
+    { OSSL_FUNC_PROVIDER_QUERY_OPERATION, (void (*)(void))cygnet_query },
+    { 0, NULL }
+};
+
+int OSSL_provider_init(const OSSL_CORE_HANDLE *handle,
+                       const OSSL_DISPATCH *in,
+                       const OSSL_DISPATCH **out,
+                       void **provctx)
+{
+    const char *relax = getenv("CYGNET_POLICY_RELAX");
+
+    if (relax != NULL && strcmp(relax, "1") == 0)
+        cygnet_strict_mode = 0;   /* lab use only; never in production */
+
+    /* Reuse the upstream OQS init for liboqs binding and provctx setup. */
+    if (oqs_provider_init_base(handle, in, out, provctx) != 1)
+        return 0;
+
+    if (!cygnet_self_test(handle)) {
+        ERR_raise_data(ERR_LIB_PROV, PROV_R_SELF_TEST_POST_FAILURE,
+                       "Cygnet CNSA 2.0 coverage self-test failed");
+        return 0;
+    }
+
+    cygnet_kems     = cygnet_filter_algorithms(oqsprovider_kem, NULL);
+    cygnet_sigs     = cygnet_filter_algorithms(oqsprovider_signature, NULL);
+    cygnet_kmgmt    = cygnet_filter_algorithms(oqsprovider_keymgmt, NULL);
+    cygnet_encoders = cygnet_filter_algorithms(oqsprovider_encoder, NULL);
+    cygnet_decoders = cygnet_filter_algorithms(oqsprovider_decoder, NULL);
+
+    *out = cygnet_dispatch_table;
+    return 1;
+}


### PR DESCRIPTION
Adds oqsprov/cygnet_prov_init.c implementing R4 from the drop-in remediation plan: a CNSA 2.0 allowlist ported from cygnet/policy.py, a capability filter that drops non-permitted algorithms before OpenSSL queries them, a load-time coverage self-test that fails closed, and the provider dispatch table.

Also adds docs/CYGNET-DROPIN-PLAN.md covering R1-R6 and the openssl.cnf activation block.

Not yet wired into CMakeLists.txt. oqs_provider_init_base() is a placeholder for the upstream init body currently inline in oqsprov.c.

Refs sanctumsecopsmssp/CygnetLib#4

<!-- Please give a brief explanation of the purpose of this pull request. -->

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->
