### PR TITLE
test: constant-time key comparison, no key-material dump on mismatch

### DIFF
--- a/test/oqs_test_evp_pkey_params.c
+++ b/test/oqs_test_evp_pkey_params.c
@@ -279,14 +279,11 @@ static int keypairs_verify_consistency(const struct KeyPair *classical,
                 comb->pubkey_len, n);
         goto free_reconstitute;
     }
-    if (memcmp(reconstitution, comb->pubkey, n) &&
-        memcmp(reconstitution_rev, comb->pubkey, n)) {
-        fputs(cRED "pubkey and comb->pubkey differ " cNORM "\n", stderr);
-        fputs(cRED "pubkey: ", stderr);
-        hexdump(reconstitution, n);
-        fputs("\ncomb->pubkey: ", stderr);
-        hexdump(comb->pubkey, n);
-        fputs(cNORM "\n", stderr);
+    if (CRYPTO_memcmp(reconstitution, comb->pubkey, n) &&
+        CRYPTO_memcmp(reconstitution_rev, comb->pubkey, n)) {
+        fprintf(stderr,
+                cRED "pubkey and comb->pubkey differ (%zu byte(s))" cNORM "\n",
+                n);
         goto free_reconstitute;
     }
     free(reconstitution);
@@ -309,14 +306,11 @@ static int keypairs_verify_consistency(const struct KeyPair *classical,
                 comb->privkey_len, n);
         goto free_reconstitute;
     }
-    if (memcmp(reconstitution, comb->privkey, n) &&
-        memcmp(reconstitution_rev, comb->privkey, n)) {
-        fputs(cRED "privkey and comb->privkey differ" cNORM "\n", stderr);
-        fputs(cRED "privkey: ", stderr);
-        hexdump(reconstitution, n);
-        fputs("\ncomb->privkey: ", stderr);
-        hexdump(comb->privkey, n);
-        fputs(cNORM "\n", stderr);
+    if (CRYPTO_memcmp(reconstitution, comb->privkey, n) &&
+        CRYPTO_memcmp(reconstitution_rev, comb->privkey, n)) {
+        fprintf(stderr,
+                cRED "privkey and comb->privkey differ (%zu byte(s))" cNORM "\n",
+                n);
         goto free_reconstitute;
     }
     ret = 0;


### PR DESCRIPTION
As discussed in GHSA-c4hr-5hp6-266m: test-harness hardening only, no CVE requested.

`memcmp()` is not constant-time, and the mismatch path in `keypairs_verify_consistency()` hexdumped private key material to stderr. This switches the hybrid-key consistency checks to `CRYPTO_memcmp()` and reports lengths only on mismatch, so CI/test logs never contain secret bytes.

Tests pass locally (10/10, including `oqs_evp_pkey_params`).

Related: GHSA-c4hr-5hp6-266m