### PR TITLE
fix: resolve OpenSSL 4.1 ASN.1 APIs at runtime

### DIFF
--- a/oqsprov/CMakeLists.txt
+++ b/oqsprov/CMakeLists.txt
@@ -9,7 +9,7 @@ add_definitions(-DOQSPROVIDER_VERSION_TEXT="${OQSPROVIDER_VERSION_TEXT}")
 message(STATUS "Building commit ${GIT_COMMIT_HASH} in ${CMAKE_SOURCE_DIR}")
 add_definitions(-DOQS_PROVIDER_COMMIT=" \(${GIT_COMMIT_HASH}\)")
 set(PROVIDER_SOURCE_FILES
-  oqsprov.c oqsprov_capabilities.c oqsprov_keys.c
+  oqsprov.c oqsprov_capabilities.c oqsprov_keys.c oqsprov_compat.c
   oqs_kmgmt.c oqs_sig.c oqs_kem.c
   oqs_encode_key2any.c oqs_endecoder_common.c oqs_decode_der2key.c oqsprov_bio.c
   oqsprov.def
@@ -76,7 +76,7 @@ if (NOT OQS_LIBRARY_TYPE STREQUAL "STATIC")
   endif()
 endif()
 
-target_link_libraries(oqsprovider PUBLIC OQS::oqs ${OPENSSL_CRYPTO_LIBRARY} ${OQS_ADDL_SOCKET_LIBS})
+target_link_libraries(oqsprovider PUBLIC OQS::oqs ${OPENSSL_CRYPTO_LIBRARY} ${OQS_ADDL_SOCKET_LIBS} ${CMAKE_DL_LIBS})
 
 # Hide liboqs symbols to applications loading oqsprovider.
 # CheckLinkerFlag requires CMake 3.18, target_link_options requires CMake 3.13.

--- a/oqsprov/oqs_encode_key2any.c
+++ b/oqsprov/oqs_encode_key2any.c
@@ -8,6 +8,7 @@
  * ToDo: Adding hybrid alg support
  */
 
+#include "oqsprov_compat.h"
 #include <openssl/asn1.h>
 #include <openssl/core.h>
 #include <openssl/core_dispatch.h>
@@ -574,7 +575,7 @@ static int oqsx_pki_priv_to_der(const void *vxkey, unsigned char **pder) {
         goto done;
     }
 
-    if (!ASN1_STRING_set(oct, buf, buflen)) {
+    if (!oqsx_ASN1_STRING_set(oct, buf, buflen)) {
         ERR_raise(ERR_LIB_USER, ERR_R_MALLOC_FAILURE);
         goto done;
     }

--- a/oqsprov/oqsprov_compat.c
+++ b/oqsprov/oqsprov_compat.c
@@ -1,0 +1,74 @@
+/*
+ * Runtime compatibility layer for OpenSSL 4.1 deprecated ASN.1 APIs.
+ *
+ * All OpenSSL ASN.1 functions are resolved via dlsym/GetProcAddress at
+ * first call. This avoids deprecation warnings at compile time (because
+ * we never directly call deprecated declarations) and guarantees cross-
+ * runtime compatibility (a provider built against 4.1 runs on 3.x).
+ */
+
+#include "oqsprov_compat.h"
+
+#ifdef _WIN32
+#include <windows.h>
+
+static void *oqsx_dlsym(const char *name) {
+    /* oqs-provider runs inside the OpenSSL process, so all libcrypto
+     * symbols are already mapped in the current process address space. */
+    return (void *)GetProcAddress(GetModuleHandle(NULL), name);
+}
+
+#else
+#include <dlfcn.h>
+
+static void *oqsx_dlsym(const char *name) { return dlsym(RTLD_DEFAULT, name); }
+
+#endif
+
+/* ---------------------------------------------------------------------- */
+/* ASN1_STRING_length                                                     */
+/* ---------------------------------------------------------------------- */
+
+size_t oqsx_ASN1_STRING_length(const ASN1_STRING *x) {
+    static int resolved = 0;
+    static size_t (*fn)(const ASN1_STRING *) = NULL;
+
+    if (!resolved) {
+        /* Prefer new OpenSSL 4.1 APIs, fall back to legacy */
+        fn = (size_t (*)(const ASN1_STRING *))oqsx_dlsym(
+            "ASN1_STRING_get_length");
+        if (!fn)
+            fn = (size_t (*)(const ASN1_STRING *))oqsx_dlsym(
+                "ASN1_STRING_length_ex");
+        if (!fn)
+            fn = (size_t (*)(const ASN1_STRING *))oqsx_dlsym(
+                "ASN1_STRING_length");
+        resolved = 1;
+    }
+
+    return fn(x);
+}
+
+/* ---------------------------------------------------------------------- */
+/* ASN1_STRING_set                                                        */
+/* ---------------------------------------------------------------------- */
+
+int oqsx_ASN1_STRING_set(ASN1_STRING *str, const void *data, int len) {
+    static int resolved = 0;
+    static int (*fn)(ASN1_STRING *, const void *, int) = NULL;
+
+    if (!resolved) {
+        /* Prefer new OpenSSL 4.1 APIs, fall back to legacy */
+        fn = (int (*)(ASN1_STRING *, const void *, int))oqsx_dlsym(
+            "ASN1_STRING_set1_data");
+        if (!fn)
+            fn = (int (*)(ASN1_STRING *, const void *, int))oqsx_dlsym(
+                "ASN1_STRING_set_data");
+        if (!fn)
+            fn = (int (*)(ASN1_STRING *, const void *, int))oqsx_dlsym(
+                "ASN1_STRING_set");
+        resolved = 1;
+    }
+
+    return fn(str, data, len);
+}

--- a/oqsprov/oqsprov_compat.h
+++ b/oqsprov/oqsprov_compat.h
@@ -1,0 +1,33 @@
+#ifndef OQSPROV_COMPAT_H
+#define OQSPROV_COMPAT_H
+
+#include <openssl/asn1.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Runtime-resolved wrappers for OpenSSL 4.1 deprecated ASN.1 APIs.
+ *
+ * These functions use dlsym/GetProcAddress to resolve the new OpenSSL 4.1
+ * APIs at first call, falling back to legacy APIs if unavailable. This
+ * preserves cross-runtime compatibility: a provider built against OpenSSL
+ * 4.1 can still load and run against OpenSSL 3.x (and vice versa).
+ */
+
+/* Returns the length of an ASN1_STRING, using ASN1_STRING_get_length()
+ * or ASN1_STRING_length_ex() if available at runtime, else ASN1_STRING_length()
+ */
+size_t oqsx_ASN1_STRING_length(const ASN1_STRING *x);
+
+/* Sets data in an ASN1_STRING, using ASN1_STRING_set1_data() or
+ * ASN1_STRING_set_data() if available at runtime, else ASN1_STRING_set() */
+int oqsx_ASN1_STRING_set(ASN1_STRING *str, const void *data, int len);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* OQSPROV_COMPAT_H */

--- a/oqsprov/oqsprov_keys.c
+++ b/oqsprov/oqsprov_keys.c
@@ -8,6 +8,7 @@
  *
  */
 
+#include "oqsprov_compat.h"
 #include <assert.h>
 #include <openssl/core_names.h>
 #include <openssl/err.h>
@@ -1040,7 +1041,7 @@ OQSX_KEY *oqsx_key_from_pkcs8(const PKCS8_PRIV_KEY_INFO *p8inf,
         plen = 0;
     } else {
         p = ASN1_STRING_get0_data(oct);
-        plen = ASN1_STRING_length(oct);
+        plen = oqsx_ASN1_STRING_length(oct);
     }
 
     oqsx = oqsx_key_op(palg, p, plen + key_diff, KEY_OP_PRIVATE, libctx, propq);


### PR DESCRIPTION
## Summary
Replaces the compile-time-only approach in #808 with runtime symbol resolution via `dlsym`/`GetProcAddress`, solving the cross-runtime compatibility concern raised by @RodriM11.

## Problem
PR #808 used `check_symbol_exists` at CMake configure time to detect OpenSSL 4.1's new `ASN1_STRING_get_length` and `ASN1_STRING_set1_data` APIs. This hardcodes API availability based on the OpenSSL version present at **build time**. A provider compiled against OpenSSL 4.1 would fail to load (undefined symbol crash) when run against OpenSSL 3.x at runtime.

## Solution
- `oqsx_ASN1_STRING_length()` and `oqsx_ASN1_STRING_set()` are thin wrappers that resolve the new OpenSSL 4.1 APIs at **first call** using `dlsym()` (POSIX) or `GetProcAddress()` (Windows), falling back to legacy APIs if unavailable.
- No `#ifdef` maze, no pragma warning suppression, no CMake `check_symbol_exists` logic.
- The provider can be compiled against OpenSSL 4.1 and run against 3.5.7 (and vice versa).

## Files Changed
| File | Change |
|------|--------|
| `oqsprov/oqsprov_compat.h` | New: wrapper declarations |
| `oqsprov/oqsprov_compat.c` | New: runtime resolution implementation |
| `oqsprov/oqsprov_keys.c` | Use `oqsx_ASN1_STRING_length()` |
| `oqsprov/oqs_encode_key2any.c` | Use `oqsx_ASN1_STRING_set()` |
| `oqsprov/CMakeLists.txt` | Add new source, link `${CMAKE_DL_LIBS}` |

## Validation Matrix
| Build \ Runtime | OpenSSL 3.5.7 | OpenSSL 4.1-dev |
|-----------------|---------------|-----------------|
| Against 3.5.7   |  10/10      |  10/10        |
| Against 4.1-dev |  10/10      | 10/10        |

- `-Werror=deprecated-declarations` build against 4.1-dev: **clean** (no warnings)
- Cross-runtime test (build 4.1, force load 3.5.7): **passes** — the exact scenario that would crash with #808

## Related
- Fixes #804
- Closes #808 (supersedes with architecturally cleaner approach)