### PR TITLE
Add security submission guidance for AI agents and humans

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -1,0 +1,315 @@
+# Instructions For Security Researchers And Automated Agents
+
+This repository is `oqsprovider`, an
+[OpenSSL provider](https://docs.openssl.org/master/man7/provider/) written in C
+that bridges post-quantum and hybrid post-quantum/traditional algorithms from
+[liboqs](https://github.com/open-quantum-safe/liboqs) into OpenSSL. It requires
+**OpenSSL version 3.0 or later (including the 4.x series)** and does not implement
+cryptographic primitives itself.
+
+Low-quality reports waste scarce maintainer time. Do not submit a security
+finding until you have read the threat model, built the affected configuration,
+reproduced the issue through a real provider entry point, and confirmed it is a
+defect in `oqsprovider` itself rather than in one of its dependencies.
+
+Start here:
+
+- [`.github/THREAT_MODEL.md`](THREAT_MODEL.md)
+- [`SECURITY.md`](../SECURITY.md)
+- [`README.md`](../README.md) and [`USAGE.md`](../USAGE.md)
+- [`CONFIGURE.md`](../CONFIGURE.md)
+- [`ALGORITHMS.md`](../ALGORITHMS.md)
+- [`STANDARDS.md`](../STANDARDS.md)
+- [`CONTRIBUTING.md`](../CONTRIBUTING.md)
+- [`test/README.md`](../test/README.md)
+
+## Security Handling
+
+Do not publicly disclose a plausible vulnerability before following the process
+in [`SECURITY.md`](../SECURITY.md). If a finding could affect confidentiality,
+integrity, availability, secret-key material, signature/KEM acceptance, or safe
+handling of hybrid keys, treat it as security-sensitive until maintainers say
+otherwise. Note that [`SECURITY.md`](../SECURITY.md) asks reporters to first
+consider whether an issue is serious enough to warrant a CVE; many valid findings
+are best handled by a public issue and/or a fix PR.
+
+**Dependencies are out of scope here.** Per [`SECURITY.md`](../SECURITY.md), weak
+or broken cryptographic algorithm *implementations* provided by
+[liboqs](https://github.com/open-quantum-safe/liboqs) or by OpenSSL's `libcrypto`
+are not vulnerabilities in this project and must be reported to those projects
+instead. A finding is in scope only when the defect is in the provider's own
+logic — how it parses, composes, validates, allocates, frees, or dispatches —
+including calling a `liboqs` or `libcrypto` API incorrectly in a way the upstream
+cannot defend against.
+
+## AI Disclosure
+
+Reports and patches that use generative AI must say so, as required by
+[`CONTRIBUTING.md`](../CONTRIBUTING.md). You are responsible for verifying
+AI-generated code, tests, and prose before submitting them. Unverified,
+AI-generated "vulnerability" reports that do not build and run against a real
+provider entry point create disproportionate maintainer load and may lead to
+restricted access to the Security Advisory interface (see
+[`SECURITY.md`](../SECURITY.md)).
+
+## Research Priorities
+
+The project exists to serve **novel, experimental, and community** post-quantum
+algorithms. Standardized algorithms (ML-KEM, ML-DSA, SLH-DSA, and similar) are
+already well supported by OpenSSL itself and elsewhere and are candidates for
+removal to shrink the maintenance and vulnerability surface (see
+[issue #821](https://github.com/open-quantum-safe/oqs-provider/issues/821)).
+Prioritize accordingly:
+
+- **Experimental / community algorithms** and their provider-side handling: they
+  are less exercised elsewhere and are the reason this project exists. Findings
+  only in a standardized algorithm's handling are lower priority — that code may
+  be removed rather than patched, and the algorithm is better maintained upstream.
+- **Generic, algorithm-independent provider logic** (highest value, because one
+  defect affects many algorithms at once):
+  - **Decoders / parsers** —
+    [`oqsprov/oqs_decode_der2key.c`](../oqsprov/oqs_decode_der2key.c) and the
+    key-loading functions in
+    [`oqsprov/oqsprov_keys.c`](../oqsprov/oqsprov_keys.c) — which turn
+    attacker-supplied X.509 / PKCS#8 / PEM / DER bytes into key objects.
+  - **Hybrid composition** — the length-prefixed concatenation of a traditional
+    and a post-quantum component (defined in
+    [`oqsprov/oqs_prov.h`](../oqsprov/oqs_prov.h) and split/joined in
+    [`oqsprov/oqsprov_keys.c`](../oqsprov/oqsprov_keys.c)). The 4-byte
+    classical-length prefix and the overall buffer length are attacker-controlled
+    at the parse boundary.
+  - **Key-management lifecycle** in
+    [`oqsprov/oqsprov_keys.c`](../oqsprov/oqsprov_keys.c): allocation, reference
+    counting, duplication/loading, and free/cleanup paths.
+  - **Encoders** —
+    [`oqsprov/oqs_encode_key2any.c`](../oqsprov/oqs_encode_key2any.c) and
+    [`oqsprov/oqs_endecoder_common.c`](../oqsprov/oqs_endecoder_common.c).
+  - **Signature, KEM, and hybrid-KEM dispatch** —
+    [`oqsprov/oqs_sig.c`](../oqsprov/oqs_sig.c),
+    [`oqsprov/oqs_kem.c`](../oqsprov/oqs_kem.c),
+    [`oqsprov/oqs_hyb_kem.c`](../oqsprov/oqs_hyb_kem.c): buffer sizing when
+    calling `liboqs`, return-value handling, and correct accept/reject semantics.
+  - **Provider wiring** — [`oqsprov/oqsprov.c`](../oqsprov/oqsprov.c) and
+    [`oqsprov/oqsprov_capabilities.c`](../oqsprov/oqsprov_capabilities.c):
+    correct TLS group / signature-algorithm registration and `OSSL_PARAM`
+    validation, so a hybrid never silently degrades to a single component.
+- Tests and sanitizer coverage for any of the above.
+
+## Provider API Preconditions
+
+`oqsprovider` is invoked by OpenSSL's `libcrypto` (version 3.0 or later, including
+4.x) through the provider dispatch tables. The *caller* (`libcrypto`) is trusted
+to honour the provider ABI: correct argument types, honouring returned lengths,
+and correct object lifetimes. Treat a report that requires `libcrypto` or the
+application to violate that contract as out of scope.
+
+Within that contract, the *data* is untrusted: bytes inside a decoded key,
+certificate, signature, or ciphertext, and any embedded length, count, OID, or
+`OSSL_PARAM` value ultimately originate from an attacker. `oqsprovider` must not
+read past a supplied length, trust an embedded length prefix (especially the
+hybrid classical-length field), or accept malformed / cross-parameter encodings.
+Honour the OpenSSL convention that a `NULL` output buffer is a size query.
+
+For secret-lifetime claims, trace secret-derived bytes across the intended
+cleanup boundary (key free or an error path) and show an observation or reuse
+path. A missing cleanse call by itself is a hardening lead, not a confirmed
+vulnerability.
+
+## Required Finding Workflow
+
+1. Read [`.github/THREAT_MODEL.md`](THREAT_MODEL.md) and write down the boundary
+   crossed.
+2. Confirm the defect is in `oqsprovider`, not in `liboqs` or `libcrypto`.
+3. Check [`SECURITY.md`](../SECURITY.md), existing issues/PRs, and the
+   [`test/`](../test) directory for known behavior.
+4. Identify the affected provider entry point, algorithm, parameter set, source
+   location, OpenSSL version, and build options.
+5. State which bytes / lengths remain attacker-controlled and, for hybrids, how
+   the classical-length prefix relates to the actual buffer.
+6. Build the affected configuration from a clean worktree (see below).
+7. Create a minimal PoC or regression test that reaches the issue through a
+   provider entry point (via the OpenSSL API or an existing test binary) and
+   fails on the vulnerable build.
+8. Run it under AddressSanitizer (the primary detector for this project) or with
+   a wrong verify/decapsulation/KAT/interop result as evidence.
+9. Confirm the impact against the threat model. Do not report out-of-scope or
+   dependency behavior as an `oqsprovider` vulnerability.
+10. Minimize the reproducer; document exact commands and expected vulnerable vs.
+    fixed output. If proposing a patch, add a regression test that fails before
+    and passes after.
+
+A report without a build, a runnable reproducer through the provider, or a clear
+threat-model mapping should be treated as a draft note, not a confirmed
+vulnerability.
+
+## Build Prerequisites
+
+Verify the local toolchain instead of assuming it is suitable:
+
+```sh
+cmake --version
+ninja --version   # or: make --version
+cc --version
+openssl version   # must be OpenSSL 3.0 or later (including 4.x)
+```
+
+`oqsprovider` requires an **OpenSSL 3.0-or-later** installation (the 4.x series is
+supported) and a [liboqs](https://github.com/open-quantum-safe/liboqs)
+installation. The convenience script
+[`scripts/fullbuild.sh`](../scripts/fullbuild.sh) will build OpenSSL, `liboqs`,
+and the provider together; the environment variables it honours are documented in
+[`CONFIGURE.md`](../CONFIGURE.md) (for example `OPENSSL_BRANCH`, `LIBOQS_BRANCH`,
+`liboqs_DIR`, `OPENSSL_INSTALL`). For a focused, reproducible security build,
+prefer building the provider explicitly against known OpenSSL and `liboqs` trees.
+
+For long-running builds, write full output to a log and keep only the tail and
+final summary in the report:
+
+```sh
+log="$(mktemp "${TMPDIR:-/tmp}/oqsprov-build.XXXXXX.log")"
+cmake -S . -B build -GNinja -DCMAKE_BUILD_TYPE=Debug >"$log" 2>&1
+rc=$?; tail -200 "$log"; echo "full log: $log"; exit "$rc"
+```
+
+## Standard Builds
+
+Debug build (enables extra warnings and debug env vars such as `OQSPROV`,
+`OQSDEC`, `OQSKEM`, `OQSSIG` for tracing):
+
+```sh
+cmake -S . -B build -GNinja -DCMAKE_BUILD_TYPE=Debug \
+  -DOPENSSL_ROOT_DIR=/path/to/openssl/install \
+  -Dliboqs_DIR=/path/to/liboqs/install/lib/cmake/liboqs
+cmake --build build
+```
+
+If the finding involves the KEM encoder/decoder paths, add
+[`-DOQS_KEM_ENCODERS=ON`](../CONFIGURE.md#oqs_kem_encoders) and say so in the
+report (it is OFF by default and uses random OIDs). Note
+[`NOPUBKEY_IN_PRIVKEY`](../CONFIGURE.md#nopubkey_in_privkey) similarly changes
+private-key serialization.
+
+## AddressSanitizer Build
+
+This mirrors the CI "Security checks" job (see
+[`.github/workflows/linux.yml`](workflows/linux.yml)) and is the recommended way
+to demonstrate memory-safety findings. Build OpenSSL (`enable-asan --debug`),
+`liboqs`, and the provider all with ASan, then:
+
+```sh
+export ASAN_C_FLAGS="-fsanitize=address -fno-omit-frame-pointer"
+cmake -S . -B build -GNinja -DCMAKE_BUILD_TYPE=Debug \
+  -DCMAKE_C_COMPILER=clang \
+  -DOPENSSL_ROOT_DIR=/path/to/asan/openssl/install \
+  -Dliboqs_DIR=/path/to/asan/liboqs/install/lib/cmake/liboqs \
+  -DCMAKE_C_FLAGS="$ASAN_C_FLAGS" -DCMAKE_EXE_LINKER_FLAGS="$ASAN_C_FLAGS"
+cmake --build build
+ASAN_OPTIONS="detect_stack_use_after_return=1,detect_leaks=1" \
+  ctest --test-dir build --output-on-failure
+```
+
+For a standalone PoC, load the ASan-built `oqsprovider` into an ASan-built
+OpenSSL (`openssl -provider oqsprovider ...`, or via `OSSL_PROVIDER_load` in a
+small C program) and keep the PoC small, deterministic, and focused on one bug.
+
+## Running Tests
+
+Run the full suite after broad changes:
+
+```sh
+ctest --test-dir build --output-on-failure
+```
+
+Focused test binaries under `build/test/` map to areas of interest:
+
+```sh
+build/test/oqs_test_endecode        # encoders/decoders, key parsing
+build/test/oqs_test_signatures      # signature + hybrid signature
+build/test/oqs_test_kems            # KEM + hybrid KEM
+build/test/oqs_test_groups          # TLS group registration
+build/test/oqs_test_tlssig          # TLS signature negotiation
+build/test/oqs_test_evp_pkey_params # EVP_PKEY parameter handling
+build/test/oqs_test_alloc_failures  # allocation-failure / cleanup paths
+```
+
+Most take an algorithm name and paths to the test config and certs (see
+[`test/CMakeLists.txt`](../test/CMakeLists.txt) for exact invocation). Shell
+interop scripts under [`scripts/`](../scripts) (`oqsprovider-certgen.sh`,
+`-certverify.sh`, `-cmssign.sh`, `-cmsverify.sh`, `-ca.sh`, `-pkcs12gen.sh`) and
+[`scripts/test_tls_full.py`](../scripts/test_tls_full.py) exercise real
+X.509/CMS/TLS flows and are good for end-to-end reproducers.
+
+Do not submit a patch that changes key/signature encodings or algorithm
+identifiers without confirming the endecode and interop tests still pass.
+
+## Side Channels
+
+Constant-time behavior of the KEM and signature math is the responsibility of
+[liboqs](https://github.com/open-quantum-safe/liboqs) and `libcrypto`, not this
+provider — report primitive timing issues upstream. A provider-level
+side-channel report is in scope only if it traces secret data to a branch or
+memory access **in `oqsprovider`'s own code** (for example, secret-dependent
+handling while splitting or cleansing a hybrid private key). State which operands
+are secret, which are public, and which are transcript-visible.
+
+## Patch Expectations
+
+Keep changes narrow and reviewable.
+
+- Prefer validation at the parse/compose boundary that fixes every affected
+  algorithm consistently over algorithm-specific special cases.
+- Add a regression test that fails before the fix and passes after it.
+- Run [`./scripts/format_code.sh`](../scripts/format_code.sh) before submitting
+  (the project uses the LLVM / clang-format style; see
+  [`CONTRIBUTING.md`](../CONTRIBUTING.md)).
+- If your change touches generated code, regenerate via
+  [`oqs-template/generate.py`](../oqs-template/generate.py) and include all files
+  it changes (see [`CONFIGURE.md`](../CONFIGURE.md#pre-build-configuration));
+  update [`CODEOWNERS`](CODEOWNERS) if relevant.
+- Update documentation when behavior, build options, algorithm lists, or
+  supported standards change.
+- Documentation-only commits should carry `[skip ci]` (see
+  [`CONTRIBUTING.md`](../CONTRIBUTING.md#resource-efficiency)).
+
+## Report Template For Agents
+
+```md
+# Title
+
+## Summary
+One or two paragraphs: the bug and why it matters for oqsprovider.
+
+## Threat Model Fit
+- Boundary crossed (decode/parse, hybrid composition, dispatch, liboqs call,
+  libcrypto call):
+- Why the defect is in oqsprovider and not in liboqs/libcrypto/the caller:
+- Attacker capability and input (cert, key file, signature, ciphertext, TLS
+  message, OSSL_PARAM):
+- In-scope rationale / out-of-scope considerations:
+
+## Affected Target
+- Repository commit and branch:
+- OpenSSL version (>= 3.0, incl. 4.x), liboqs version/branch, compiler,
+  sanitizer, OS:
+- Build options (default? OQS_KEM_ENCODERS / NOPUBKEY_IN_PRIVKEY / static?):
+- Provider entry point and source location:
+- Algorithm and parameter set (experimental/community or standardized?):
+
+## Impact
+Concrete impact without exaggeration. For secret-lifetime findings: secret
+source, intended cleanup boundary, residual bytes, observation/reuse path.
+
+## Reproduction
+Build and run commands from a clean checkout.
+
+## Expected Output
+Vulnerable output and fixed output (e.g. ASan trace before, clean after).
+
+## PoC Or Regression Test
+Minimal source, OpenSSL command line, or path to a test file.
+
+## Recommended Fix
+Patch direction and regression coverage.
+```
+
+If you cannot fill in these fields, keep investigating before submitting.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -48,6 +48,16 @@ problems.
 **Additional context**
 Add any other context about the problem here.
 
+**Use of generative AI**
+If this report (text, reproduction steps, code, or suspected-vulnerability
+analysis) was produced with the help of generative AI, please say so and describe
+the nature of the use. You are expected to have verified and affirm such content
+yourself before submission. See
+[CONTRIBUTING.md](https://github.com/open-quantum-safe/oqs-provider/blob/main/CONTRIBUTING.md);
+for suspected security issues, please also follow
+[SECURITY.md](https://github.com/open-quantum-safe/oqs-provider/blob/main/SECURITY.md)
+and the [threat model](https://github.com/open-quantum-safe/oqs-provider/blob/main/.github/THREAT_MODEL.md).
+
 **Hints**
 To exclude a build/setup error, please consider running your test
 commands to reproduce the problem in our [pre-build docker image](https://hub.docker.com/repository/docker/openquantumsafe/oqs-ossl3/general),

--- a/.github/THREAT_MODEL.md
+++ b/.github/THREAT_MODEL.md
@@ -1,0 +1,274 @@
+# oqs-provider Security Threat Model
+
+This document describes the security boundaries that `oqsprovider` expects
+researchers, contributors, and automated agents to use when evaluating possible
+vulnerabilities. It complements [`SECURITY.md`](../SECURITY.md),
+[`README.md`](../README.md), [`CONFIGURE.md`](../CONFIGURE.md),
+[`ALGORITHMS.md`](../ALGORITHMS.md), and [`STANDARDS.md`](../STANDARDS.md).
+
+The purpose is practical triage: a good report explains which boundary is
+crossed, how the issue is reachable through the OpenSSL provider interface, what
+evidence reproduces it, and why it is a defect in `oqsprovider` itself rather
+than in one of its dependencies, a known limitation, or a caller error.
+
+## Project Security Role
+
+`oqsprovider` is an [OpenSSL provider](https://docs.openssl.org/master/man7/provider/):
+a module loaded by `libcrypto` that exposes post-quantum and hybrid
+post-quantum/traditional KEMs, signatures, and key management to any application
+using OpenSSL. It requires **OpenSSL version 3.0 or later (including the 4.x
+series)** and does **not** implement cryptographic primitives itself. The
+post-quantum primitives come from
+[liboqs](https://github.com/open-quantum-safe/liboqs) ("downwards"), and the
+traditional primitives, ASN.1/X.509/PKCS#8/CMS handling, and TLS plumbing come
+from OpenSSL's `libcrypto`/`libssl` ("upwards").
+
+`oqsprovider` is therefore glue and composition code. Its security value is in
+handling attacker-influenced data safely as it crosses between an application
+(often a TLS peer or a certificate/key file) and the two libraries it bridges.
+It is normally embedded in a larger application, so a "remote attacker" is
+usually remote to that application (for example, a TLS client or server, or the
+supplier of a certificate, key, or signature) rather than remote to the provider
+as a standalone service.
+
+The provider is invoked by the OpenSSL core through the provider dispatch
+mechanism. The core is assumed to honour the provider API contract: it calls
+provider functions with the documented argument types, obeys returned lengths,
+and manages object lifetimes as specified. `oqsprovider` cannot defend against a
+`libcrypto` that violates its own provider contract. Within that assumption,
+`oqsprovider` is responsible for safely handling the byte contents, explicit
+lengths, `OSSL_PARAM` values, serialized encodings, and algorithm identifiers
+that ultimately originate from untrusted sources.
+
+## What Is Explicitly Out Of Scope: Dependencies
+
+As stated in [`SECURITY.md`](../SECURITY.md), incorrect, weak, or vulnerable
+cryptographic algorithm *implementations* provided by
+[liboqs](https://github.com/open-quantum-safe/liboqs) or by OpenSSL's
+`libcrypto` are **not** vulnerabilities in this project. This includes:
+
+- Cryptanalytic weakness of a post-quantum algorithm.
+- A memory-safety or constant-time defect inside a `liboqs` primitive
+  (`OQS_KEM_*`, `OQS_SIG_*`) or inside an OpenSSL primitive.
+- A bug reachable only through a `liboqs` or `libcrypto` API that `oqsprovider`
+  calls correctly.
+
+Such issues must be reported to the respective upstream project. A report is
+in scope for `oqsprovider` only when the defect is in the provider's own logic —
+how it parses, composes, validates, allocates, frees, or dispatches — including
+calling an upstream API incorrectly (wrong length, ignored return value, wrong
+buffer) in a way that a correct upstream cannot defend against.
+
+## Protected Assets And Security Goals
+
+- Secret keys and secret-derived material (private keys, KEM shared secrets,
+  seeds, hybrid private components) passed to/from `liboqs` and `libcrypto`.
+- Memory safety of every provider entry point reachable from `libcrypto`:
+  key management, encoders, decoders, signature, KEM, and key-exchange
+  dispatch functions.
+- Correct rejection of malformed or malicious serialized inputs: X.509
+  `SubjectPublicKeyInfo`, PKCS#8 `PrivateKeyInfo`, raw public/private key
+  buffers, signatures, KEM ciphertexts, PEM/DER, and algorithm identifiers/OIDs.
+- Correct handling of the hybrid composition format (see below): the
+  length-prefixed concatenation of a traditional and a post-quantum component.
+- Correct signature verification and KEM decapsulation semantics as surfaced
+  through the provider (no acceptance of a signature under the wrong component,
+  parameter set, or composition; correct success/failure status).
+- Cleansing of secret-derived material when a key object is freed.
+- Correct registration of TLS groups and signature algorithms so that a
+  negotiated hybrid does not silently degrade to only its traditional or only
+  its post-quantum half.
+
+## Trust Boundaries
+
+### Decode / Parse Boundary (highest value)
+
+The decoders ([`oqsprov/oqs_decode_der2key.c`](../oqsprov/oqs_decode_der2key.c)
+and the key-loading functions in
+[`oqsprov/oqsprov_keys.c`](../oqsprov/oqsprov_keys.c)) turn attacker-supplied
+bytes — a certificate, a public key, a PKCS#8 private key, a PEM/DER blob — into
+internal key objects. Every byte here is untrusted, including any embedded
+length, count, or OID. `oqsprovider` must not read past supplied lengths, trust
+an embedded length field, or accept malformed or cross-parameter encodings.
+
+### Hybrid Composition Boundary
+
+Hybrid keys, signatures, and KEM shares are encoded as a **simple concatenation**
+of a traditional and a post-quantum component (see [`STANDARDS.md`](../STANDARDS.md)).
+For key material the traditional component is prefixed with a 4-byte big-endian
+length. That length prefix and the overall buffer length are attacker-controlled
+at the parse boundary: a report that shows a mismatch between the declared
+classical length and the actual buffer size leading to an out-of-bounds
+read/write, an under-read, or acceptance of a malformed hybrid is in scope.
+Splitting and reassembling the components is a core part of this boundary.
+
+### Provider Dispatch Boundary
+
+`libcrypto` drives the provider through `OSSL_DISPATCH` tables and passes data as
+`OSSL_PARAM` arrays and pointer/length pairs. Provider code must validate the
+presence, type, and size of parameters it consumes and must honour the OpenSSL
+convention for size queries (a `NULL` output buffer requesting a length). Treat
+the *contents* of these buffers as untrusted even though the *caller*
+(`libcrypto`) is trusted to follow the ABI.
+
+### liboqs Boundary ("downwards")
+
+`oqsprovider` calls `liboqs` with buffers it has sized from its own metadata.
+Passing a buffer shorter than the algorithm requires, ignoring an `OQS_STATUS`
+return, or reusing state incorrectly is an `oqsprovider` defect even though the
+crash surfaces inside `liboqs`. A weakness *within* the `liboqs` primitive is not.
+
+### libcrypto Boundary ("upwards")
+
+`oqsprovider` calls OpenSSL for traditional primitives and ASN.1. Mishandling an
+OpenSSL return value, object, or error (for example, using an `EVP_PKEY` that
+failed to construct, or leaking/double-freeing an OpenSSL object) is an
+`oqsprovider` defect. A bug inside `libcrypto` itself is not.
+
+## In-Scope Vulnerability Classes
+
+Reachable through a supported build and backed by a working reproducer:
+
+### Memory Safety
+- Out-of-bounds read/write in decoders, encoders, or hybrid split/join logic.
+- Use-after-free, double free, invalid free, or uninitialized-memory use in key
+  management and the key duplication/loading paths.
+- Integer overflow/truncation on a length, count, or size field that leads to
+  memory corruption, invalid acceptance, or wrong output length.
+- NULL-pointer dereference reachable through a provider entry point with
+  attacker-controlled input (a malformed key/cert that a well-behaved
+  application feeds to OpenSSL).
+
+### Cryptographic API Correctness
+- A verifier accepting a signature that is invalid, from the wrong component,
+  wrong parameter set, or a non-canonical/malformed hybrid encoding.
+- A KEM accepting a malformed public key or ciphertext in a way that breaks the
+  expected security or canonicalization contract.
+- Wrong success/failure status returned to a caller that relies on it before
+  using generated output.
+- Mismatched public/secret key metadata, OIDs, or algorithm identifiers leading
+  to unsafe behavior or a silent hybrid downgrade.
+
+### Secret Material Lifetime
+- Private keys, shared secrets, seeds, or secret-derived intermediates left in
+  reusable memory after a key is freed or after an error path, with a realistic
+  observation or reuse path. A missing cleanse call *alone* is a hardening lead,
+  not a confirmed vulnerability: identify the secret source, the intended
+  cleanup boundary, the residual bytes, and how they are observed or reused.
+
+### Denial Of Service
+- A crash, unbounded allocation, or excessive resource use triggered by an
+  ordinary application feeding attacker-controlled input (a certificate,
+  key, TLS handshake message, signature, or ciphertext) through OpenSSL into the
+  provider. Describe the attacker-controlled input and the deployment path
+  (loading a cert, verifying a signature, TLS handshake, decapsulation, key
+  decode).
+
+## Out-Of-Scope Or Usually Non-Vulnerabilities
+
+- Weakness, cryptanalysis, or implementation defects of a post-quantum algorithm
+  itself, or any bug inside [liboqs](https://github.com/open-quantum-safe/liboqs)
+  or `libcrypto` (report upstream — such reports opened here are closed
+  immediately, per [`SECURITY.md`](../SECURITY.md)).
+- Reports that only state that a post-quantum algorithm may someday be broken.
+- Physical, power/EM, fault-injection (including Rowhammer), and CPU/hardware
+  side channels.
+- Timing/side-channel claims about the underlying primitives: constant-time
+  behavior of the KEM/signature math is a `liboqs`/`libcrypto` responsibility.
+  A provider-level timing claim must trace secret data to a branch or memory
+  access *in `oqsprovider`'s own code*, not in a primitive it calls.
+- Claims based only on source pattern matching with no reachable PoC, test, or
+  sanitizer evidence through a provider entry point.
+- Crashes that require a caller (application or `libcrypto`) to violate the
+  documented provider/OpenSSL API contract (for example, passing a pointer that
+  does not reference a region of the claimed size).
+- Missing-zeroization claims with no secret-derived dataflow, no intended
+  cleanup boundary, or no realistic observation path.
+- Vulnerabilities solely in a downstream application that misuses OpenSSL or the
+  provider despite a clear contract.
+- Behavior only reproducible with a non-default or experimental build option
+  (for example [`OQS_KEM_ENCODERS`](../CONFIGURE.md#oqs_kem_encoders) or
+  [`NOPUBKEY_IN_PRIVKEY`](../CONFIGURE.md#nopubkey_in_privkey), whose OIDs are
+  chosen at random) without saying so and explaining the realistic deployment.
+
+Note that `oqsprovider` "is not meant for productive use"
+([`SECURITY.md`](../SECURITY.md)); severity should be assessed accordingly, and
+most valid findings are best handled by a public issue and/or a fix PR rather
+than an embargoed CVE.
+
+## Platform And Algorithm Priority
+
+The project's purpose is to serve **novel, experimental, and community**
+post-quantum algorithms. Standardized algorithms (ML-KEM, ML-DSA, SLH-DSA, and
+similar) are already well supported by OpenSSL itself and by other projects, so
+they receive comparatively little added value here and are candidates for removal
+to reduce the maintenance and vulnerability surface (see
+[issue #821](https://github.com/open-quantum-safe/oqs-provider/issues/821)).
+Prioritize accordingly:
+
+- **Experimental and community algorithms deserve the most scrutiny**: they are
+  less well exercised elsewhere and are the reason this project exists. A defect
+  in their provider-side handling is more likely to be novel and actionable here.
+- The **generic provider logic** — encoders, decoders, hybrid composition, key
+  management, and TLS group/signature registration — is algorithm-independent and
+  is the highest-value target regardless of the specific algorithm, because one
+  defect affects many algorithms at once.
+- Findings that exist *only* in a standardized algorithm's handling are lower
+  priority: the affected code may be removed rather than patched, and the same
+  algorithm is better maintained upstream.
+- Prioritize the platforms exercised in
+  [CI](workflows) (Linux x86_64 with the AddressSanitizer "Security
+  checks" job, plus macOS and Windows). A finding on another platform should
+  explain whether it also affects a CI-covered platform.
+- Identify the affected OpenSSL version. `oqsprovider` supports OpenSSL 3.0 and
+  later (including 4.x), and provider behavior can vary across those versions.
+
+## Report Quality Requirements
+
+A security report should include:
+
+- Repository commit/branch and the exact build options.
+- OpenSSL version (must be 3.0 or later, including 4.x),
+  [liboqs](https://github.com/open-quantum-safe/liboqs) version/branch, compiler,
+  sanitizer, OS, CMake, and (if relevant) the OpenSSL configuration.
+- A threat-model statement: attacker capability, boundary crossed, and why the
+  defect is in `oqsprovider` rather than in `liboqs`, `libcrypto`, or the caller.
+- The affected provider entry point (keymgmt/encoder/decoder/signature/KEM/
+  keyexch), algorithm family, parameter set, and a representative source
+  location.
+- A minimal PoC or failing regression test that exercises the issue through the
+  provider (ideally via the OpenSSL API or a test binary), and the exact build
+  and run commands from a clean checkout.
+- Sanitizer output (AddressSanitizer is the primary detector here), plus
+  expected vulnerable and fixed behavior.
+- Impact stated without exaggeration, distinguishing memory safety, DoS,
+  signature/KEM acceptance, hybrid mishandling, and secret-lifetime issues.
+- A suggested fix and regression test where possible.
+
+Do not submit a report that has not been built and run unless it is explicitly
+labeled an unverified hypothesis.
+
+## Triage Checklist For Researchers
+
+1. Which provider boundary is crossed — decode/parse, hybrid composition,
+   provider dispatch, the `liboqs` call boundary, or the `libcrypto` call
+   boundary?
+2. Is the defect in `oqsprovider`'s own logic, or does it actually live in
+   `liboqs` or `libcrypto` (and therefore belong upstream)?
+3. What attacker controls the input — certificate, key file, signature,
+   ciphertext, TLS message, `OSSL_PARAM`, or build configuration?
+4. Does the reproducer reach the code through a real provider entry point under
+   the documented OpenSSL/provider API contract, on OpenSSL 3.0 or later?
+5. Is the affected algorithm experimental/community (higher priority) or
+   standardized (lower priority, possibly slated for removal)? Is a non-default
+   build option required?
+6. Does a clean build reproduce it with the provided commands, and does a
+   detector (AddressSanitizer, a KAT/interop failure, a wrong verify/decaps
+   result) give concrete evidence?
+7. Is it already covered by an existing test, open issue, or a known upstream
+   advisory?
+8. Is this a vulnerability, a hardening opportunity, a test gap, or a
+   documentation issue?
+
+If any answer is unknown, state the uncertainty in the report rather than filling
+the gap with speculation.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,3 +3,5 @@
 <!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->
 
 <!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->
+
+<!-- If this contribution (code, documentation, descriptive text) was produced with the help of generative AI, please describe the nature of the use. Contributors are expected to have verified and affirm such contributions themselves before submission. See CONTRIBUTING.md. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,4 +4,4 @@
 
 <!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->
 
-<!-- If this contribution (code, documentation, descriptive text) was produced with the help of generative AI, please describe the nature of the use. Contributors are expected to have verified and affirm such contributions themselves before submission. See CONTRIBUTING.md. -->
+<!-- If this contribution (code, documentation, descriptive text) was produced with the help of generative AI, please describe the nature of the use. Contributors are expected to have verified and affirm such contributions themselves before submission. When AI use is extensive or definitive, also credit the tool with a "Co-Authored-By:" trailer on the commits (e.g. "Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"). See CONTRIBUTING.md. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,21 @@ All PRs should move to "Ready for Review" stage only if all CI tests pass (are g
 The OQS core team is happy to provide feedback also to Draft PRs in order to improve
 them before the final "Review" stage.
 
+### Use of generative AI
+
+Pull requests containing code, documentation, or text produced with the help of
+generative AI must declare that in the pull request description and describe the
+nature of the use. The same applies to issues and, in particular, security
+reports. Contributors are expected to have verified and affirm such contributions
+themselves before submission.
+
+Contributors using AI assistants are encouraged to read the OpenSSF's
+[Security-Focused Guide for AI Code Assistant Instructions](https://best.openssf.org/Security-Focused-Guide-for-AI-Code-Assistant-Instructions).
+Automated agents and researchers investigating potential vulnerabilities should
+also follow the repository-specific guidance in
+[`.github/AGENTS.md`](.github/AGENTS.md) and the
+[`.github/THREAT_MODEL.md`](.github/THREAT_MODEL.md).
+
 ### CODEOWNERS
 
 This file is used to track which contributors are most well suited for reviewing

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,14 @@ nature of the use. The same applies to issues and, in particular, security
 reports. Contributors are expected to have verified and affirm such contributions
 themselves before submission.
 
+When AI use is extensive or definitive (as opposed to merely assistive), the
+contribution's commits must additionally credit the tool with a
+`Co-Authored-By:` trailer naming the AI, for example:
+
+```
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+```
+
 Contributors using AI assistants are encouraged to read the OpenSSF's
 [Security-Focused Guide for AI Code Assistant Instructions](https://best.openssf.org/Security-Focused-Guide-for-AI-Code-Assistant-Instructions).
 Automated agents and researchers investigating potential vulnerabilities should

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -37,6 +37,14 @@ implementations actually provided by either of these libraries (`liboqs` or `lib
 `openssl`). Any such problem shall be reported to those projects, respectively. Any report of
 this sort opened in this repository will be closed immediately without further action.
 
+Before preparing a report, please read the [threat model](.github/THREAT_MODEL.md),
+which describes the trust boundaries of this provider and what is (and is not) an
+`oqsprovider` vulnerability as opposed to an issue in `liboqs` or `libcrypto`.
+Security researchers and automated agents should additionally follow the
+step-by-step guidance in [`.github/AGENTS.md`](.github/AGENTS.md). Reports (and
+patches) produced with the help of generative AI must say so, as required by
+[`CONTRIBUTING.md`](CONTRIBUTING.md).
+
 ## Criteria for a valid security report
 
 - **Categorization**: The reported issue must be identified as a logic error, safety check failure,

--- a/oqs-template/oqs-sig-info.md
+++ b/oqs-template/oqs-sig-info.md
@@ -111,27 +111,27 @@
 | snova60104 **hybrid with** p521           | Round 2                                   | 2            |                    5 | 0xff4f       | 1.3.9999.10.11.2             |
 | snova2965                                 | Round 2                                   | 2            |                    5 | 0xff51       | 1.3.9999.10.12.1             |
 | snova2965 **hybrid with** p521            | Round 2                                   | 2            |                    5 | 0xff52       | 1.3.9999.10.12.2             |
-| OV_Is                                     | NIST Round 2 (February 2025)              | 2            |                    1 | 0xff0a       | 1.3.9999.9.1.1               |
-| OV_Is **hybrid with** p256                | NIST Round 2 (February 2025)              | 2            |                    1 | 0xff16       | 1.3.9999.9.1.2               |
-| OV_Ip                                     | NIST Round 2 (February 2025)              | 2            |                    1 | 0xff0b       | 1.3.9999.9.2.1               |
-| OV_Ip **hybrid with** p256                | NIST Round 2 (February 2025)              | 2            |                    1 | 0xff17       | 1.3.9999.9.2.2               |
-| OV_III                                    | NIST Round 2 (February 2025)              | 2            |                    3 | 0xff0c       | 1.3.9999.9.3.1               |
-| OV_III **hybrid with** p384               | NIST Round 2 (February 2025)              | 2            |                    3 | 0xff18       | 1.3.9999.9.3.2               |
-| OV_V                                      | NIST Round 2 (February 2025)              | 2            |                    5 | 0xff0d       | 1.3.9999.9.4.1               |
-| OV_V **hybrid with** p521                 | NIST Round 2 (February 2025)              | 2            |                    5 | 0xff19       | 1.3.9999.9.4.2               |
-| OV_Is_pkc                                 | NIST Round 2 (February 2025)              | 2            |                    1 | 0xff0e       | 1.3.9999.9.5.1               |
-| OV_Is_pkc **hybrid with** p256            | NIST Round 2 (February 2025)              | 2            |                    1 | 0xff1a       | 1.3.9999.9.5.2               |
-| OV_Ip_pkc                                 | NIST Round 2 (February 2025)              | 2            |                    1 | 0xff0f       | 1.3.9999.9.6.1               |
-| OV_Ip_pkc **hybrid with** p256            | NIST Round 2 (February 2025)              | 2            |                    1 | 0xff1b       | 1.3.9999.9.6.2               |
-| OV_III_pkc                                | NIST Round 2 (February 2025)              | 2            |                    3 | 0xff10       | 1.3.9999.9.7.1               |
-| OV_III_pkc **hybrid with** p384           | NIST Round 2 (February 2025)              | 2            |                    3 | 0xff1c       | 1.3.9999.9.7.2               |
-| OV_V_pkc                                  | NIST Round 2 (February 2025)              | 2            |                    5 | 0xff11       | 1.3.9999.9.8.1               |
-| OV_V_pkc **hybrid with** p521             | NIST Round 2 (February 2025)              | 2            |                    5 | 0xff1d       | 1.3.9999.9.8.2               |
-| OV_Is_pkc_skc                             | NIST Round 2 (February 2025)              | 2            |                    1 | 0xff12       | 1.3.9999.9.9.1               |
-| OV_Is_pkc_skc **hybrid with** p256        | NIST Round 2 (February 2025)              | 2            |                    1 | 0xff1e       | 1.3.9999.9.9.2               |
-| OV_Ip_pkc_skc                             | NIST Round 2 (February 2025)              | 2            |                    1 | 0xff13       | 1.3.9999.9.10.1              |
-| OV_Ip_pkc_skc **hybrid with** p256        | NIST Round 2 (February 2025)              | 2            |                    1 | 0xff1f       | 1.3.9999.9.10.2              |
-| OV_III_pkc_skc                            | NIST Round 2 (February 2025)              | 2            |                    3 | 0xff14       | 1.3.9999.9.11.1              |
-| OV_III_pkc_skc **hybrid with** p384       | NIST Round 2 (February 2025)              | 2            |                    3 | 0xff20       | 1.3.9999.9.11.2              |
-| OV_V_pkc_skc                              | NIST Round 2 (February 2025)              | 2            |                    5 | 0xff15       | 1.3.9999.9.12.1              |
-| OV_V_pkc_skc **hybrid with** p521         | NIST Round 2 (February 2025)              | 2            |                    5 | 0xff21       | 1.3.9999.9.12.2              |
+| OV_Is                                     | NIST Round 3                              | 3            |                    1 | 0xff0a       | 1.3.9999.9.1.1               |
+| OV_Is **hybrid with** p256                | NIST Round 3                              | 3            |                    1 | 0xff16       | 1.3.9999.9.1.2               |
+| OV_Ip                                     | NIST Round 3                              | 3            |                    1 | 0xff0b       | 1.3.9999.9.2.1               |
+| OV_Ip **hybrid with** p256                | NIST Round 3                              | 3            |                    1 | 0xff17       | 1.3.9999.9.2.2               |
+| OV_III                                    | NIST Round 3                              | 3            |                    3 | 0xff0c       | 1.3.9999.9.3.1               |
+| OV_III **hybrid with** p384               | NIST Round 3                              | 3            |                    3 | 0xff18       | 1.3.9999.9.3.2               |
+| OV_V                                      | NIST Round 3                              | 3            |                    5 | 0xff0d       | 1.3.9999.9.4.1               |
+| OV_V **hybrid with** p521                 | NIST Round 3                              | 3            |                    5 | 0xff19       | 1.3.9999.9.4.2               |
+| OV_Is_pkc                                 | NIST Round 3                              | 3            |                    1 | 0xff0e       | 1.3.9999.9.5.1               |
+| OV_Is_pkc **hybrid with** p256            | NIST Round 3                              | 3            |                    1 | 0xff1a       | 1.3.9999.9.5.2               |
+| OV_Ip_pkc                                 | NIST Round 3                              | 3            |                    1 | 0xff0f       | 1.3.9999.9.6.1               |
+| OV_Ip_pkc **hybrid with** p256            | NIST Round 3                              | 3            |                    1 | 0xff1b       | 1.3.9999.9.6.2               |
+| OV_III_pkc                                | NIST Round 3                              | 3            |                    3 | 0xff10       | 1.3.9999.9.7.1               |
+| OV_III_pkc **hybrid with** p384           | NIST Round 3                              | 3            |                    3 | 0xff1c       | 1.3.9999.9.7.2               |
+| OV_V_pkc                                  | NIST Round 3                              | 3            |                    5 | 0xff11       | 1.3.9999.9.8.1               |
+| OV_V_pkc **hybrid with** p521             | NIST Round 3                              | 3            |                    5 | 0xff1d       | 1.3.9999.9.8.2               |
+| OV_Is_pkc_skc                             | NIST Round 3                              | 3            |                    1 | 0xff12       | 1.3.9999.9.9.1               |
+| OV_Is_pkc_skc **hybrid with** p256        | NIST Round 3                              | 3            |                    1 | 0xff1e       | 1.3.9999.9.9.2               |
+| OV_Ip_pkc_skc                             | NIST Round 3                              | 3            |                    1 | 0xff13       | 1.3.9999.9.10.1              |
+| OV_Ip_pkc_skc **hybrid with** p256        | NIST Round 3                              | 3            |                    1 | 0xff1f       | 1.3.9999.9.10.2              |
+| OV_III_pkc_skc                            | NIST Round 3                              | 3            |                    3 | 0xff14       | 1.3.9999.9.11.1              |
+| OV_III_pkc_skc **hybrid with** p384       | NIST Round 3                              | 3            |                    3 | 0xff20       | 1.3.9999.9.11.2              |
+| OV_V_pkc_skc                              | NIST Round 3                              | 3            |                    5 | 0xff15       | 1.3.9999.9.12.1              |
+| OV_V_pkc_skc **hybrid with** p521         | NIST Round 3                              | 3            |                    5 | 0xff21       | 1.3.9999.9.12.2              |


### PR DESCRIPTION
Adds provider-specific security submission guidance for both human and
automated (AI) reporters, adapting the equivalent liboqs documents to
oqs-provider's role as an OpenSSL provider.

## What's added
- **`.github/THREAT_MODEL.md`** — trust boundaries (decode/parse, hybrid
  composition, provider dispatch, and the liboqs/libcrypto call boundaries),
  in/out-of-scope vulnerability classes, and what belongs upstream vs. here.
- **`.github/AGENTS.md`** — step-by-step guidance for researchers and agents:
  build/AddressSanitizer/test recipes, a required finding workflow, and a
  report template.

## What's changed
- **AI disclosure** now required in `CONTRIBUTING.md`, the PR template, and the
  bug-report template.
- `SECURITY.md` cross-links the threat model and agent guidance.

## Use of generative AI
These documents and edits were drafted with the help of generative AI
(Claude Code), based on the liboqs threat-model/AGENTS guidance and on a review
of this repository's structure, source layout, and existing policy files. The
maintainer has reviewed, verified, and affirms the content prior to submission.

Resolves #823, resolves #822.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
