### PR TITLE
Fix use-after-free of comp_privkey in KEM decapsulation (GHSA-g63q-c378-wphj)

### DIFF
--- a/oqsprov/oqs_hyb_kem.c
+++ b/oqsprov/oqs_hyb_kem.c
@@ -99,6 +99,16 @@ static int oqs_evp_kem_decaps_keyslot(void *vpkemctx, unsigned char *secret,
     const OQSX_EVP_CTX *evp_ctx = pkemctx->kem->oqsx_provider_ctx.oqsx_evp_ctx;
     OSSL_LIB_CTX *libctx = pkemctx->libctx;
 
+    // privkey must be checked in addition to comp_privkey[]: the latter aliases
+    // into privkey, so after privkey is freed (e.g. via set_params with
+    // OSSL_PKEY_PARAM_ENCODED_PUBLIC_KEY) comp_privkey[keyslot] may still be a
+    // non-NULL dangling pointer (GHSA-g63q-c378-wphj).
+    if (pkemctx->kem->privkey == NULL || pkemctx->kem->comp_privkey == NULL ||
+        pkemctx->kem->comp_privkey[keyslot] == NULL) {
+        OQS_KEM_PRINTF("OQS Warning: private key is NULL\n");
+        return -1;
+    }
+
     size_t pubkey_kexlen = evp_ctx->evp_info->length_public_key;
     size_t kexDeriveLen = evp_ctx->evp_info->kex_length_secret;
     unsigned char *privkey_kex = pkemctx->kem->comp_privkey[keyslot];

--- a/oqsprov/oqs_hyb_kem.c
+++ b/oqsprov/oqs_hyb_kem.c
@@ -99,10 +99,8 @@ static int oqs_evp_kem_decaps_keyslot(void *vpkemctx, unsigned char *secret,
     const OQSX_EVP_CTX *evp_ctx = pkemctx->kem->oqsx_provider_ctx.oqsx_evp_ctx;
     OSSL_LIB_CTX *libctx = pkemctx->libctx;
 
-    // privkey must be checked in addition to comp_privkey[]: the latter aliases
-    // into privkey, so after privkey is freed (e.g. via set_params with
-    // OSSL_PKEY_PARAM_ENCODED_PUBLIC_KEY) comp_privkey[keyslot] may still be a
-    // non-NULL dangling pointer (GHSA-g63q-c378-wphj).
+    // comp_privkey[keyslot] aliases into privkey and can dangle once privkey is
+    // freed, so guard on privkey too. GHSA-g63q-c378-wphj
     if (pkemctx->kem->privkey == NULL || pkemctx->kem->comp_privkey == NULL ||
         pkemctx->kem->comp_privkey[keyslot] == NULL) {
         OQS_KEM_PRINTF("OQS Warning: private key is NULL\n");

--- a/oqsprov/oqs_hyb_kem.c
+++ b/oqsprov/oqs_hyb_kem.c
@@ -100,7 +100,7 @@ static int oqs_evp_kem_decaps_keyslot(void *vpkemctx, unsigned char *secret,
     OSSL_LIB_CTX *libctx = pkemctx->libctx;
 
     // comp_privkey[keyslot] aliases into privkey and can dangle once privkey is
-    // freed, so guard on privkey too. GHSA-g63q-c378-wphj
+    // freed, so guard on privkey too.
     if (pkemctx->kem->privkey == NULL || pkemctx->kem->comp_privkey == NULL ||
         pkemctx->kem->comp_privkey[keyslot] == NULL) {
         OQS_KEM_PRINTF("OQS Warning: private key is NULL\n");

--- a/oqsprov/oqs_kem.c
+++ b/oqsprov/oqs_kem.c
@@ -161,7 +161,11 @@ static int oqs_qs_kem_decaps_keyslot(void *vpkemctx, unsigned char *out,
         return -1;
     }
     kem_ctx = pkemctx->kem->oqsx_provider_ctx.oqsx_qs_ctx.kem;
-    if (pkemctx->kem->comp_privkey == NULL ||
+    // privkey must be checked in addition to comp_privkey[]: the latter aliases
+    // into privkey, so after privkey is freed (e.g. via set_params with
+    // OSSL_PKEY_PARAM_ENCODED_PUBLIC_KEY) comp_privkey[keyslot] may still be a
+    // non-NULL dangling pointer (GHSA-g63q-c378-wphj).
+    if (pkemctx->kem->privkey == NULL || pkemctx->kem->comp_privkey == NULL ||
         pkemctx->kem->comp_privkey[keyslot] == NULL) {
         OQS_KEM_PRINTF("OQS Warning: private key is NULL\n");
         return -1;

--- a/oqsprov/oqs_kem.c
+++ b/oqsprov/oqs_kem.c
@@ -162,7 +162,7 @@ static int oqs_qs_kem_decaps_keyslot(void *vpkemctx, unsigned char *out,
     }
     kem_ctx = pkemctx->kem->oqsx_provider_ctx.oqsx_qs_ctx.kem;
     // comp_privkey[keyslot] aliases into privkey and can dangle once privkey is
-    // freed, so guard on privkey too. GHSA-g63q-c378-wphj
+    // freed, so guard on privkey too.
     if (pkemctx->kem->privkey == NULL || pkemctx->kem->comp_privkey == NULL ||
         pkemctx->kem->comp_privkey[keyslot] == NULL) {
         OQS_KEM_PRINTF("OQS Warning: private key is NULL\n");

--- a/oqsprov/oqs_kem.c
+++ b/oqsprov/oqs_kem.c
@@ -161,10 +161,8 @@ static int oqs_qs_kem_decaps_keyslot(void *vpkemctx, unsigned char *out,
         return -1;
     }
     kem_ctx = pkemctx->kem->oqsx_provider_ctx.oqsx_qs_ctx.kem;
-    // privkey must be checked in addition to comp_privkey[]: the latter aliases
-    // into privkey, so after privkey is freed (e.g. via set_params with
-    // OSSL_PKEY_PARAM_ENCODED_PUBLIC_KEY) comp_privkey[keyslot] may still be a
-    // non-NULL dangling pointer (GHSA-g63q-c378-wphj).
+    // comp_privkey[keyslot] aliases into privkey and can dangle once privkey is
+    // freed, so guard on privkey too. GHSA-g63q-c378-wphj
     if (pkemctx->kem->privkey == NULL || pkemctx->kem->comp_privkey == NULL ||
         pkemctx->kem->comp_privkey[keyslot] == NULL) {
         OQS_KEM_PRINTF("OQS Warning: private key is NULL\n");

--- a/oqsprov/oqs_kmgmt.c
+++ b/oqsprov/oqs_kmgmt.c
@@ -570,7 +570,7 @@ static int oqsx_set_params(void *key, const OSSL_PARAM params[]) {
         }
         // comp_privkey[] are interior pointers into privkey, not owned
         // allocations: NULL them (never free) once privkey is gone. Free
-        // privkey from the secure heap it lives on. GHSA-g63q-c378-wphj
+        // privkey from the secure heap it lives on.
         OPENSSL_secure_clear_free(oqsxkey->privkey, oqsxkey->privkeylen);
         oqsxkey->privkey = NULL;
         if (oqsxkey->comp_privkey != NULL) {

--- a/oqsprov/oqs_kmgmt.c
+++ b/oqsprov/oqs_kmgmt.c
@@ -568,13 +568,9 @@ static int oqsx_set_params(void *key, const OSSL_PARAM params[]) {
                 return 0;
             }
         }
-        // privkey is allocated from the secure heap (see oqsx_key_allocate_*),
-        // so it must be released with the matching secure free. Setting only
-        // privkey to NULL would leave the comp_privkey[] slots dangling into
-        // the freed buffer (they alias into privkey, see
-        // oqsx_key_set_composites()); clear them too so the KEM decaps and
-        // hybrid-params paths cannot read freed memory (GHSA-g63q-c378-wphj,
-        // variant of GHSA-mqwg-cg22-g8r8).
+        // comp_privkey[] are interior pointers into privkey, not owned
+        // allocations: NULL them (never free) once privkey is gone. Free
+        // privkey from the secure heap it lives on. GHSA-g63q-c378-wphj
         OPENSSL_secure_clear_free(oqsxkey->privkey, oqsxkey->privkeylen);
         oqsxkey->privkey = NULL;
         if (oqsxkey->comp_privkey != NULL) {

--- a/oqsprov/oqs_kmgmt.c
+++ b/oqsprov/oqs_kmgmt.c
@@ -568,8 +568,20 @@ static int oqsx_set_params(void *key, const OSSL_PARAM params[]) {
                 return 0;
             }
         }
-        OPENSSL_clear_free(oqsxkey->privkey, oqsxkey->privkeylen);
+        // privkey is allocated from the secure heap (see oqsx_key_allocate_*),
+        // so it must be released with the matching secure free. Setting only
+        // privkey to NULL would leave the comp_privkey[] slots dangling into
+        // the freed buffer (they alias into privkey, see
+        // oqsx_key_set_composites()); clear them too so the KEM decaps and
+        // hybrid-params paths cannot read freed memory (GHSA-g63q-c378-wphj,
+        // variant of GHSA-mqwg-cg22-g8r8).
+        OPENSSL_secure_clear_free(oqsxkey->privkey, oqsxkey->privkeylen);
         oqsxkey->privkey = NULL;
+        if (oqsxkey->comp_privkey != NULL) {
+            for (size_t i = 0; i < oqsxkey->numkeys; i++) {
+                oqsxkey->comp_privkey[i] = NULL;
+            }
+        }
     }
     p = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_PROPERTIES);
     if (p != NULL) {

--- a/test/oqs_test_evp_pkey_params.c
+++ b/test/oqs_test_evp_pkey_params.c
@@ -486,6 +486,124 @@ err:
     return ret;
 }
 
+/** \brief Tests that KEM decapsulation fails cleanly after the private key has
+ * been dropped via OSSL_PKEY_PARAM_ENCODED_PUBLIC_KEY.
+ *
+ * Regression test for GHSA-g63q-c378-wphj (a variant of GHSA-mqwg-cg22-g8r8):
+ * oqsx_set_params() frees oqsxkey->privkey when the caller sets the encoded
+ * public key, but used to leave the comp_privkey[] slots pointing into the
+ * freed buffer. The KEM decapsulation path only checked comp_privkey[keyslot]
+ * (still non-NULL) and fed the dangling pointer to the cryptographic core,
+ * causing a use-after-free. After the fix, decapsulation must fail because the
+ * private key is gone rather than read freed memory.
+ *
+ * The trigger uses only public OpenSSL API. The function self-selects KEM
+ * algorithms (signatures do not support encapsulation) so it can be called for
+ * every keymgmt algorithm. Run under AddressSanitizer to surface the UAF on a
+ * vulnerable build.
+ *
+ * \param libctx Top-level OpenSSL context.
+ * \param algname Algorithm name.
+ *
+ * \returns 0 on success (including for non-KEM algorithms, which are skipped).
+ */
+static int test_decaps_after_set_encoded_public_key(OSSL_LIB_CTX *libctx,
+                                                    const char *algname) {
+    EVP_PKEY_CTX *ctx = NULL, *encctx = NULL, *decctx = NULL;
+    EVP_PKEY *key = NULL;
+    unsigned char *encpub = NULL, *ct = NULL, *secret = NULL;
+    size_t encpub_len = 0, ctlen = 0, secretlen = 0;
+    int ret = -1;
+
+    /* Generate a full keypair. */
+    ctx = EVP_PKEY_CTX_new_from_name(libctx, algname, OQSPROV_PROPQ);
+    if (!ctx || EVP_PKEY_keygen_init(ctx) != 1 ||
+        EVP_PKEY_generate(ctx, &key) != 1) {
+        fprintf(stderr,
+                cRED "  decaps-after-set-encoded-pubkey: keygen failed "
+                     "for %s" cNORM "\n",
+                algname);
+        goto err;
+    }
+    EVP_PKEY_CTX_free(ctx);
+    ctx = NULL;
+
+    /* Only KEM algorithms support encapsulation; signatures are skipped. */
+    encctx = EVP_PKEY_CTX_new_from_pkey(libctx, key, OQSPROV_PROPQ);
+    if (!encctx) {
+        goto err;
+    }
+    if (EVP_PKEY_encapsulate_init(encctx, NULL) <= 0) {
+        ERR_clear_error();
+        ret = 0; /* not a KEM: nothing to exercise here */
+        goto err;
+    }
+
+    /* Produce a valid ciphertext from the public key (needs no private key). */
+    if (EVP_PKEY_encapsulate(encctx, NULL, &ctlen, NULL, &secretlen) != 1) {
+        goto err;
+    }
+    ct = malloc(ctlen);
+    secret = malloc(secretlen);
+    if (!ct || !secret) {
+        fprintf(stderr, cRED "  decaps-after-set-encoded-pubkey: malloc "
+                             "failed" cNORM "\n");
+        goto err;
+    }
+    if (EVP_PKEY_encapsulate(encctx, ct, &ctlen, secret, &secretlen) != 1) {
+        goto err;
+    }
+
+    /* Read back the encoded public key so it can be fed straight back in at the
+     * exact size the provider expects. */
+    encpub_len = EVP_PKEY_get1_encoded_public_key(key, &encpub);
+    if (encpub_len == 0 || encpub == NULL) {
+        fprintf(stderr,
+                cRED "  decaps-after-set-encoded-pubkey: get encoded pubkey "
+                     "failed for %s" cNORM "\n",
+                algname);
+        goto err;
+    }
+
+    /* Trigger: setting the encoded public key frees the private key. */
+    if (EVP_PKEY_set1_encoded_public_key(key, encpub, encpub_len) != 1) {
+        fprintf(stderr,
+                cRED "  decaps-after-set-encoded-pubkey: set encoded pubkey "
+                     "failed for %s" cNORM "\n",
+                algname);
+        goto err;
+    }
+
+    /* Decapsulation must now fail cleanly rather than read freed memory. On a
+     * vulnerable build this reads comp_privkey[] pointing into the freed
+     * private key (heap-use-after-free under ASan). */
+    decctx = EVP_PKEY_CTX_new_from_pkey(libctx, key, OQSPROV_PROPQ);
+    if (!decctx || EVP_PKEY_decapsulate_init(decctx, NULL) != 1) {
+        goto err;
+    }
+    memset(secret, 0, secretlen);
+    if (EVP_PKEY_decapsulate(decctx, secret, &secretlen, ct, ctlen) > 0) {
+        fprintf(stderr,
+                cRED "  decaps-after-set-encoded-pubkey: decapsulation "
+                     "unexpectedly succeeded without a private key "
+                     "for %s" cNORM "\n",
+                algname);
+        goto err;
+    }
+    ERR_clear_error(); /* the expected decapsulation failure raised errors */
+    ret = 0;
+
+err:
+    free(encpub);
+    free(ct);
+    free(secret);
+    EVP_PKEY_free(key);
+    EVP_PKEY_CTX_free(ctx);
+    EVP_PKEY_CTX_free(encctx);
+    EVP_PKEY_CTX_free(decctx);
+    return ret;
+}
+
 /** \brief Tests the export/import capacity of an algorithm.
  *
  * \param libctx Top-level OpenSSL context.
@@ -572,6 +690,10 @@ int main(int argc, char **argv) {
             test = test || test_pubkey_only_hybrid_get_params(
                                libctx, algs->algorithm_names);
         }
+        /* KEMs only (function skips signatures): regression for
+         * GHSA-g63q-c378-wphj. */
+        test = test || test_decaps_after_set_encoded_public_key(
+                           libctx, algs->algorithm_names);
         if (test) {
             ERR_print_errors_fp(stderr);
             fprintf(stderr,

--- a/test/oqs_test_evp_pkey_params.c
+++ b/test/oqs_test_evp_pkey_params.c
@@ -489,10 +489,11 @@ err:
 /** \brief Tests that KEM decapsulation fails cleanly after the private key has
  * been dropped via OSSL_PKEY_PARAM_ENCODED_PUBLIC_KEY.
  *
- * Regression test for GHSA-g63q-c378-wphj: dropping the private key via the
- * encoded-public-key param left comp_privkey[] dangling into the freed buffer,
- * which KEM decaps then read. Post-fix, decaps must fail rather than read freed
- * memory (heap-use-after-free under AddressSanitizer on a vulnerable build).
+ * Regression test for GHSA-g63q-c378-wphj (canonical reference for this fix):
+ * dropping the private key via the encoded-public-key param left comp_privkey[]
+ * dangling into the freed buffer, which KEM decaps then read. Post-fix, decaps
+ * must fail rather than read freed memory (heap-use-after-free under
+ * AddressSanitizer on a vulnerable build).
  *
  * Uses only public OpenSSL API and self-selects KEMs (signatures cannot
  * encapsulate), so it is safe to call for every keymgmt algorithm.
@@ -683,8 +684,7 @@ int main(int argc, char **argv) {
             test = test || test_pubkey_only_hybrid_get_params(
                                libctx, algs->algorithm_names);
         }
-        /* KEMs only (function skips signatures): regression for
-         * GHSA-g63q-c378-wphj. */
+        /* KEMs only (function skips signatures) */
         test = test || test_decaps_after_set_encoded_public_key(
                            libctx, algs->algorithm_names);
         if (test) {

--- a/test/oqs_test_evp_pkey_params.c
+++ b/test/oqs_test_evp_pkey_params.c
@@ -489,18 +489,13 @@ err:
 /** \brief Tests that KEM decapsulation fails cleanly after the private key has
  * been dropped via OSSL_PKEY_PARAM_ENCODED_PUBLIC_KEY.
  *
- * Regression test for GHSA-g63q-c378-wphj (a variant of GHSA-mqwg-cg22-g8r8):
- * oqsx_set_params() frees oqsxkey->privkey when the caller sets the encoded
- * public key, but used to leave the comp_privkey[] slots pointing into the
- * freed buffer. The KEM decapsulation path only checked comp_privkey[keyslot]
- * (still non-NULL) and fed the dangling pointer to the cryptographic core,
- * causing a use-after-free. After the fix, decapsulation must fail because the
- * private key is gone rather than read freed memory.
+ * Regression test for GHSA-g63q-c378-wphj: dropping the private key via the
+ * encoded-public-key param left comp_privkey[] dangling into the freed buffer,
+ * which KEM decaps then read. Post-fix, decaps must fail rather than read freed
+ * memory (heap-use-after-free under AddressSanitizer on a vulnerable build).
  *
- * The trigger uses only public OpenSSL API. The function self-selects KEM
- * algorithms (signatures do not support encapsulation) so it can be called for
- * every keymgmt algorithm. Run under AddressSanitizer to surface the UAF on a
- * vulnerable build.
+ * Uses only public OpenSSL API and self-selects KEMs (signatures cannot
+ * encapsulate), so it is safe to call for every keymgmt algorithm.
  *
  * \param libctx Top-level OpenSSL context.
  * \param algname Algorithm name.
@@ -554,8 +549,7 @@ static int test_decaps_after_set_encoded_public_key(OSSL_LIB_CTX *libctx,
         goto err;
     }
 
-    /* Read back the encoded public key so it can be fed straight back in at the
-     * exact size the provider expects. */
+    /* Read the encoded public key back to feed it in at the expected size. */
     encpub_len = EVP_PKEY_get1_encoded_public_key(key, &encpub);
     if (encpub_len == 0 || encpub == NULL) {
         fprintf(stderr,
@@ -574,9 +568,8 @@ static int test_decaps_after_set_encoded_public_key(OSSL_LIB_CTX *libctx,
         goto err;
     }
 
-    /* Decapsulation must now fail cleanly rather than read freed memory. On a
-     * vulnerable build this reads comp_privkey[] pointing into the freed
-     * private key (heap-use-after-free under ASan). */
+    /* Must fail cleanly now; a vulnerable build reads the freed privkey here.
+     */
     decctx = EVP_PKEY_CTX_new_from_pkey(libctx, key, OQSPROV_PROPQ);
     if (!decctx || EVP_PKEY_decapsulate_init(decctx, NULL) != 1) {
         goto err;


### PR DESCRIPTION
## Summary

`oqsx_set_params()` frees `oqsxkey->privkey` when a caller sets
`OSSL_PKEY_PARAM_ENCODED_PUBLIC_KEY`, but left the `comp_privkey[]` slots
pointing into the freed buffer (they alias into `privkey`). The KEM
decapsulation path only checked `comp_privkey[keyslot]` (still non-NULL) and
fed the dangling pointer into the cryptographic core as the secret key — a
use-after-free reachable entirely through the public OpenSSL API:

```c
EVP_PKEY_set1_encoded_public_key(pkey, pub, publen); /* frees privkey */
EVP_PKEY_decapsulate_init(ctx, NULL);
EVP_PKEY_decapsulate(ctx, out, &outlen, in, inlen);  /* reads freed privkey */
```

This is a write/use-side variant of GHSA-mqwg-cg22-g8r8. That fix (commit
`bbb20fb`) added the missing `privkey != NULL` guard to
`oqsx_get_hybrid_params()` only, and did not propagate it to the KEM decaps
consumers. Severity is higher here because the freed bytes flow directly into
`OQS_KEM_decaps()` / the classical key-exchange rather than being merely read
back via `EVP_PKEY_get_params`.

## Threat model fit

- **Boundary:** provider dispatch (keymgmt `set_params` → KEM decapsulate),
  within the documented OpenSSL/provider API contract — no ABI violation by the
  caller is required.
- **Why it's an oqsprovider defect:** the dangling state is created and consumed
  entirely in oqsprovider's own key-lifecycle and dispatch code; `liboqs` and
  `libcrypto` are called correctly with a pointer oqsprovider should no longer
  hand them.
- **Affected entry points:** `oqs_qs_kem_decaps_keyslot` (`oqs_kem.c`) and
  `oqs_evp_kem_decaps_keyslot` (`oqs_hyb_kem.c`); root cause in
  `oqsx_set_params` (`oqs_kmgmt.c`). Affects both pure-PQ and hybrid KEMs.

## Fix

- `oqs_kmgmt.c`: after freeing `privkey`, clear every `comp_privkey[i]` slot, and
  release `privkey` with `OPENSSL_secure_clear_free` to match its secure-heap
  allocation (it was allocated via `OPENSSL_secure_zalloc`/`_malloc` but freed
  with the non-secure `OPENSSL_clear_free` — an allocator mismatch the ASan
  trace below also confirms).
- `oqs_kem.c` / `oqs_hyb_kem.c`: add a `privkey != NULL` guard to the QS and
  hybrid decapsulation keyslot helpers as defense in depth (the hybrid helper
  previously had no NULL check on the private key at all).

## Regression test

Adds `test_decaps_after_set_encoded_public_key` to
`test/oqs_test_evp_pkey_params.c` (already part of the CI `oqs_evp_pkey_params`
job). It generates a KEM keypair, captures a valid ciphertext, drops the private
key via `EVP_PKEY_set1_encoded_public_key`, and then decapsulates. The helper
self-selects KEM algorithms (signatures are skipped), covering both pure-PQ and
hybrid KEMs.

## Verification (fail-before / pass-after)

**Functional (system OpenSSL 3.0.2):** on the pre-fix build the new test fails —
decapsulation *succeeds without a private key* for both pure-PQ (`efrodo640aes`)
and hybrid (`x25519_efrodo640aes`) KEMs; after the fix it fails cleanly and the
test passes. `oqs_kems` and `oqs_endecode` suites still pass.

**AddressSanitizer (OpenSSL 3.5.0 + liboqs + provider, all `-fsanitize=address`,
mirroring the CI "Security checks" job):**

- Pre-fix:
  ```
  ERROR: AddressSanitizer: heap-use-after-free ... READ of size 2
    #0 OQS_KEM_efrodokem_640_aes_decaps ekem.c:192
    #2 oqs_qs_kem_decaps_keyslot oqs_kem.c:195
    #3 oqs_qs_kem_decaps        oqs_kem.c:207
  freed by thread T0 here:
    #2 CRYPTO_clear_free crypto/mem.c:362
    #3 oqsx_set_params  oqs_kmgmt.c:571
  previously allocated by thread T0 here:
    #3 CRYPTO_secure_zalloc crypto/mem_sec.c:191
  ```
- Post-fix: all algorithms pass, no ASan report.

## Credit

Reported by **John Bradley (@CrunchyJohnHaven)** as GHSA-g63q-c378-wphj, a
follow-up to GHSA-mqwg-cg22-g8r8.

## AI disclosure

Per `CONTRIBUTING.md`: the original report and this fix + regression test were
prepared with the assistance of generative AI (Claude, Anthropic) and reviewed
and verified by the committer against the ASan build above. The fix commit
carries a `Co-Authored-By:` trailer accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
